### PR TITLE
Persistant Model Caching

### DIFF
--- a/default.do
+++ b/default.do
@@ -16,75 +16,77 @@ from util import redo_arg
 # as those built by a generator.
 
 if __name__ == "__main__":
-  assert len(sys.argv) == 4
-  directory, base = redo_arg.split_redo_arg(sys.argv[2])
-  rule_cls = None
-  # Is the file a product of the metric generator:
-  if redo_arg.in_build_metric_dir(sys.argv[2]):
-    from rules.build_metric import build_metric as rule_cls
-  # Is the file a type range yaml file?
-  elif base.endswith(".type_ranges.yaml"):
-    from rules.build_type_ranges_yaml import build_type_ranges_yaml as rule_cls
-  elif base.endswith("_h.ads") or base.endswith("_hpp.ads"):
-    from rules.build_bindings import build_bindings as rule_cls
-  # Is the file a product of a generator?
-  elif redo_arg.in_build_dir(sys.argv[2]):
-    from rules.build_via_generator import build_via_generator as rule_cls
-  # Special redo directives:
-  elif base == "clean":
-    from rules.build_clean import build_clean as rule_cls
-  elif base == "clean_all":
-    from rules.build_clean_all import build_clean_all as rule_cls
-  elif base == "what":
-    from rules.build_what import build_what as rule_cls
-  elif base == "prove":
-    from rules.build_prove import build_prove as rule_cls
-  elif base == "analyze":
-    from rules.build_analyze import build_analyze as rule_cls
-  elif base == "style":
-    from rules.build_style import build_style as rule_cls
-  elif base == "style_all":
-    from rules.build_style_all import build_style_all as rule_cls
-  elif base == "pretty":
-    from rules.build_pretty import build_pretty as rule_cls
-  elif base == "targets":
-    from rules.build_targets import build_targets as rule_cls
-  elif base == "templates":
-    from rules.build_templates import build_templates as rule_cls
-  elif base == "all":
-    from rules.build_all import build_all as rule_cls
-  elif base == "recursive":
-    from rules.build_recursive import build_recursive as rule_cls
-  elif base == "path":
-    from rules.build_path import build_path as rule_cls
-  elif base == "print_path":
-    from rules.build_print_path import build_print_path as rule_cls
-  elif base == "test":
-    from rules.build_test import build_test as rule_cls
-  elif base == "coverage":
-    from rules.build_coverage import build_coverage as rule_cls
-    from util import target as tgt
-    tgt.set_default_coverage_target()
-  elif base == "run":
-    from rules.build_run import build_run as rule_cls
-  elif base == "test_all":
-    from rules.build_test_all import build_test_all as rule_cls
-  elif base == "coverage_all":
-    from rules.build_coverage_all import build_coverage_all as rule_cls
-  elif base == "publish":
-    from rules.build_publish import build_publish as rule_cls
-  elif base == "codepeer_server":
-    from rules.build_codepeer_server import build_codepeer_server as rule_cls
-  elif base == "yaml_sloc":
-    from rules.build_yaml_sloc import build_yaml_sloc as rule_cls
+    assert len(sys.argv) == 4
+    directory, base = redo_arg.split_redo_arg(sys.argv[2])
+    rule_cls = None
+    # Is the file a product of the metric generator:
+    if redo_arg.in_build_metric_dir(sys.argv[2]):
+        from rules.build_metric import build_metric as rule_cls
+    # Is the file a type range yaml file?
+    elif base.endswith(".type_ranges.yaml"):
+        from rules.build_type_ranges_yaml import build_type_ranges_yaml as rule_cls
+    elif base.endswith("_h.ads") or base.endswith("_hpp.ads"):
+        from rules.build_bindings import build_bindings as rule_cls
+    # Is the file a product of a generator?
+    elif redo_arg.in_build_dir(sys.argv[2]):
+        from rules.build_via_generator import build_via_generator as rule_cls
+    # Special redo directives:
+    elif base == "clean":
+        from rules.build_clean import build_clean as rule_cls
+    elif base == "clean_all":
+        from rules.build_clean_all import build_clean_all as rule_cls
+    elif base == "clear_cache":
+        from rules.build_clear_cache import build_clear_cache as rule_cls
+    elif base == "what":
+        from rules.build_what import build_what as rule_cls
+    elif base == "prove":
+        from rules.build_prove import build_prove as rule_cls
+    elif base == "analyze":
+        from rules.build_analyze import build_analyze as rule_cls
+    elif base == "style":
+        from rules.build_style import build_style as rule_cls
+    elif base == "style_all":
+        from rules.build_style_all import build_style_all as rule_cls
+    elif base == "pretty":
+        from rules.build_pretty import build_pretty as rule_cls
+    elif base == "targets":
+        from rules.build_targets import build_targets as rule_cls
+    elif base == "templates":
+        from rules.build_templates import build_templates as rule_cls
+    elif base == "all":
+        from rules.build_all import build_all as rule_cls
+    elif base == "recursive":
+        from rules.build_recursive import build_recursive as rule_cls
+    elif base == "path":
+        from rules.build_path import build_path as rule_cls
+    elif base == "print_path":
+        from rules.build_print_path import build_print_path as rule_cls
+    elif base == "test":
+        from rules.build_test import build_test as rule_cls
+    elif base == "coverage":
+        from rules.build_coverage import build_coverage as rule_cls
+        from util import target as tgt
+        tgt.set_default_coverage_target()
+    elif base == "run":
+        from rules.build_run import build_run as rule_cls
+    elif base == "test_all":
+        from rules.build_test_all import build_test_all as rule_cls
+    elif base == "coverage_all":
+        from rules.build_coverage_all import build_coverage_all as rule_cls
+    elif base == "publish":
+        from rules.build_publish import build_publish as rule_cls
+    elif base == "codepeer_server":
+        from rules.build_codepeer_server import build_codepeer_server as rule_cls
+    elif base == "yaml_sloc":
+        from rules.build_yaml_sloc import build_yaml_sloc as rule_cls
 
-  # Run the rule
-  if rule_cls:
-    rule = rule_cls()
-    rule.build(*sys.argv[1:])
-  else:
-    from util import error
-    error.error_abort("default.do: No rule to build '" + sys.argv[1] + "'.")
+    # Run the rule
+    if rule_cls:
+        rule = rule_cls()
+        rule.build(*sys.argv[1:])
+    else:
+        from util import error
+        error.error_abort("default.do: No rule to build '" + sys.argv[1] + "'.")
 
 # Exit fast:
-performance.exit()
+performance.exit(sys.argv[2])

--- a/default.elf.do
+++ b/default.elf.do
@@ -11,9 +11,9 @@ from rules.build_executable import build_executable
 # This .do file builds .elf (executable binary) files.
 
 if __name__ == "__main__":
-  assert len(sys.argv) == 4
-  rule = build_executable()
-  rule.build(*sys.argv[1:])
+    assert len(sys.argv) == 4
+    rule = build_executable()
+    rule.build(*sys.argv[1:])
 
 # Exit fast:
-performance.exit()
+performance.exit(sys.argv[2])

--- a/default.eps.do
+++ b/default.eps.do
@@ -11,9 +11,9 @@ from rules.build_eps import build_eps
 # This .do file builds .eps (PostScript) files.
 
 if __name__ == "__main__":
-  assert len(sys.argv) == 4
-  rule = build_eps()
-  rule.build(*sys.argv[1:])
+    assert len(sys.argv) == 4
+    rule = build_eps()
+    rule.build(*sys.argv[1:])
 
 # Exit fast:
-performance.exit()
+performance.exit(sys.argv[2])

--- a/default.gpr.do
+++ b/default.gpr.do
@@ -11,9 +11,9 @@ from rules.build_gpr import build_gpr
 # This .do file builds .gpr files.
 
 if __name__ == "__main__":
-  assert len(sys.argv) == 4
-  rule = build_gpr()
-  rule.build(*sys.argv[1:])
+    assert len(sys.argv) == 4
+    rule = build_gpr()
+    rule.build(*sys.argv[1:])
 
 # Exit fast:
-performance.exit()
+performance.exit(sys.argv[2])

--- a/default.o.do
+++ b/default.o.do
@@ -11,9 +11,9 @@ from rules.build_object import build_object
 # This .do file builds .o (object) files.
 
 if __name__ == "__main__":
-  assert len(sys.argv) == 4
-  rule = build_object()
-  rule.build(*sys.argv[1:])
+    assert len(sys.argv) == 4
+    rule = build_object()
+    rule.build(*sys.argv[1:])
 
 # Exit fast:
-performance.exit()
+performance.exit(sys.argv[2])

--- a/default.pdf.do
+++ b/default.pdf.do
@@ -11,9 +11,9 @@ from rules.build_pdf import build_pdf
 # This .do file builds .pdf files.
 
 if __name__ == "__main__":
-  assert len(sys.argv) == 4
-  rule = build_pdf()
-  rule.build(*sys.argv[1:])
+    assert len(sys.argv) == 4
+    rule = build_pdf()
+    rule.build(*sys.argv[1:])
 
 # Exit fast:
-performance.exit()
+performance.exit(sys.argv[2])

--- a/default.png.do
+++ b/default.png.do
@@ -11,9 +11,9 @@ from rules.build_png import build_png
 # This .do file builds .png files.
 
 if __name__ == "__main__":
-  assert len(sys.argv) == 4
-  rule = build_png()
-  rule.build(*sys.argv[1:])
+    assert len(sys.argv) == 4
+    rule = build_png()
+    rule.build(*sys.argv[1:])
 
 # Exit fast:
-performance.exit()
+performance.exit(sys.argv[2])

--- a/default.svg.do
+++ b/default.svg.do
@@ -11,9 +11,9 @@ from rules.build_svg import build_svg
 # This .do file builds .svg (vector graphics) files.
 
 if __name__ == "__main__":
-  assert len(sys.argv) == 4
-  rule = build_svg()
-  rule.build(*sys.argv[1:])
+    assert len(sys.argv) == 4
+    rule = build_svg()
+    rule.build(*sys.argv[1:])
 
 # Exit fast:
-performance.exit()
+performance.exit(sys.argv[2])

--- a/doc/user_guide/user_guide.tex
+++ b/doc/user_guide/user_guide.tex
@@ -445,6 +445,7 @@ redo  what
 redo all
 redo clean
 redo clean_all
+redo clear_cache
 redo templates
 redo publish
 redo targets
@@ -473,6 +474,7 @@ Adamant also provides a set of build commands that can be used in almost any pro
   \item \textbf{\texttt{redo recursive}} - runs \texttt{redo all} from this directory and all below it
   \item \textbf{\texttt{redo clean}} - removes all \textit{build/} directories from this directory and all below it
   \item \textbf{\texttt{redo clean\_all}} - removes all \textit{build/} directories from this entire repository
+  \item \textbf{\texttt{redo clear\_cache}} - remove the model cache that the build system uses to increase performance, see Section \ref{The Model Cache}
   \item \textbf{\texttt{redo templates}} - finds and builds all autocoded templates (in \textit{build/template/}) that can be built from this directory
   \item \textbf{\texttt{redo test\_all}} - finds and runs all unit tests from this directory an all below it. Note: Add a \textit{.skip\_test} file to a directory to exclude it from being run by \texttt{redo test\_all}.
   \item \textbf{\texttt{redo coverage\_all}} - finds and runs all unit tests from this directory an all below it and generates coverage reports for each. Note: Add a \textit{.skip\_test} or \textit{.skip\_coverage} file to a directory to exclude it from being run by \texttt{redo coverage\_all}.
@@ -532,12 +534,13 @@ For more \texttt{redo} options you can run:
 \end{minted}
 \vspace{5mm} %5mm vertical space
 
-Very rarely, \texttt{redo} can get itself into an unknown state. If things are not behaving correctly you can wipe out the redo database, and force things to rebuild fresh, which often fixes any issues that arise. The best procedure to do this is:
+Very rarely, \texttt{redo} can get itself into an unknown state. If things are not behaving correctly you can wipe out the redo database, and force things to rebuild fresh, which often fixes any issues that arise.To be safe, you can also remove the model cache that the build system uses to increase performance. The best procedure to do this is:
 
 \vspace{5mm} %5mm vertical space
 \begin{minted}{text}
 > rm -rf ~/.redo      # remove the redo database
 > redo clean_all      # clean the entire repository
+> redo clear_cache    # remove the model cache
 > redo <your_command> # retry the redo command that was not working
 \end{minted}
 \vspace{5mm} %5mm vertical space
@@ -6713,6 +6716,20 @@ The default behavior of the Adamant build system is provided by the \textit{.do}
 \vspace{5mm} %5mm vertical space
 
 Note that adding some build rules, such as compiling for a new programming language, will require more work than the procedure presents above. In that case, it is recommended to understand the \textit{set up} and \textit{database} portions of the build system located in \textit{redo/database}.
+
+\subsubsection{Model Caching} \label{The Model Cache}
+
+When building a target, the Adamant build system spends a lot of time reading YAML models from the file system, validating them, and then using them to generate outputs. Since most of these models do not change often on disk, the build system caches them in a database in \textit{/temp} to speed up build times. It is important when designing python models to correctly track the dependencies so that cached entries can be refreshed when a YAML model, or a YAML model's dependency, has changed. To do this, ensure that your python model correctly implements the \texttt{get\_dependencies} method, which should return a list of all YAML files that the current YAML file depends on. For example, a \texttt{*.component.yaml} always depends on its IDed entity models: \texttt{*.data\_products.yaml}, \texttt{*.data\_commands.yaml}, etc. \\
+
+If you suspect that the cache is messed up, or you want to ensure a completely clean build, you can clear the cache by running:
+
+\vspace{5mm} %5mm vertical space
+\begin{minted}{text}
+> redo clear_cache
+\end{minted}
+\vspace{5mm} %5mm vertical space
+
+which will remove the entire cache database from the system. It will be recreated next time you build a new target.
 
 \subsection{The Generator System} \label{Adding Generators}
 

--- a/gen/models/base.py
+++ b/gen/models/base.py
@@ -95,10 +95,66 @@ class base(renderable_object, metaclass=abc.ABCMeta):
     #################################################
 
     def load_from_cache(cls, filename):
+        def is_model_cached_this_session(filename):
+            with model_cache_database() as db:
+                # Get the time when we last cached the model from this file:
+                cached_sesion_id = db.get_model_session_id(filename)
+                if cached_sesion_id is not None and cached_sesion_id == os.environ["ADAMANT_SESSION_ID"]:
+                    return True
+            return False
+
+        def is_cached_model_up_to_date(filename):
+            # See if the model is stored in the database  cache stored on disk:
+            with model_cache_database() as db:
+                # Get the time when we last cached the model from this file:
+                cache_time_stamp = db.get_model_time_stamp(filename)
+                if cache_time_stamp is None:
+                    return False
+
+                # If the cache time is newer than the file modification time
+                # then we can safely use the cached model:
+                file_time_stamp = os.path.getmtime(filename)
+                if cache_time_stamp >= file_time_stamp:
+                    return True
+
+        def do_load_from_cache(filename):
+            with model_cache_database() as db:
+                return db.get_model(filename)  # This can return None
+
+        def mark_model_cached_this_session(filename):
+            with model_cache_database(mode=DATABASE_MODE.READ_WRITE) as db:
+                db.mark_cached_model_up_to_date_for_session(filename)
+
+        # If the model was cached this redo session, then we know it is safe to use
+        # directly from cache without any additional checking. Dependencies do not
+        # need to be checked, since this would have been done earlier in this session,
+        # ie. milliseconds ago.
+        if is_model_cached_this_session(filename):
+            return do_load_from_cache(filename)
+
+        # If the model was written from a previous session, then we need to check its
+        # write timestamp against the file timestamp to determine if the cached entry is
+        # still valid:
         model = None
-        # See if the model is stored in the database  cache stored on disk:
-        with model_cache_database() as db:
-            model = db.get_model(filename)  # This can return None
+        if is_cached_model_up_to_date(filename):
+            model = do_load_from_cache(filename)
+
+        # We have a model we can use from cache. It was written in a previous
+        # session. This is only safe to use if none of the model dependencies
+        # have not changed on disk either.
+        if model is not None:
+            for dep_model_filename in model.get_dependencies():
+                if not is_cached_model_up_to_date(dep_model_filename):
+                    # One of the dependencies models has recently changed on disk,
+                    # so we need to reload this model from scratch. We cannot safely
+                    # use the cached version.
+                    return None
+
+        # This cached model has been fully validated for this session. So if we use it again
+        # during the session, we can short circuit the full validation and return from
+        # is_model_cached_this_session()
+        mark_model_cached_this_session(filename)
+
         return model
 
     def save_to_cache(self):
@@ -125,6 +181,8 @@ class base(renderable_object, metaclass=abc.ABCMeta):
                 self.filename = os.path.basename(filename)
                 self.full_filename = full_filename
                 self.do_save_to_cache = True
+                # import sys
+                # sys.stderr.write("lcache " + self.filename + "\n")
             else:
                 # Create from scratch:
                 self = super(base, cls).__new__(cls)
@@ -132,6 +190,8 @@ class base(renderable_object, metaclass=abc.ABCMeta):
                 self.filename = os.path.basename(filename)
                 self.full_filename = full_filename
                 self.do_save_to_cache = True
+                # import sys
+                # sys.stderr.write("lfile " + self.filename + "\n")
         else:
             # Create from scratch. This is usually only called when
             # reconstructing the object from cache.

--- a/redo/database/_setup.py
+++ b/redo/database/_setup.py
@@ -274,9 +274,8 @@ def _setup(redo_1, redo_2, redo_3, sandbox=False):
     # the build path. Let's create these now. In fact,
     # we may need some of them in order to calculate
     # the build path, below:
-    import database.create
-
-    database.create.create_pre_build_path()
+    from database.create import create_pre_build_path
+    create_pre_build_path()
 
     # Form the build path:
     # The total path consists of:
@@ -384,7 +383,8 @@ def _setup(redo_1, redo_2, redo_3, sandbox=False):
         )
 
     # Create the database:
-    database.create.create(path)
+    from database.create import create
+    create(path)
 
 
 # Remove temporary directory if it exists.

--- a/redo/database/database.py
+++ b/redo/database/database.py
@@ -52,10 +52,8 @@ def _get_flock(filename):
     return FileLock(_get_flock_filename(filename), timeout=10)
 
 
-# Private helper functions for opening/creating an unqlite database:
-def _create(filename):
-    # Create a database from a fresh file every time. If the user
-    # does not want this they can call open_rw instead.
+# Private helper functions for deleting/opening/creating an unqlite database:
+def _destroy(filename):
     try:
         os.remove(filename)
     except OSError:
@@ -64,6 +62,12 @@ def _create(filename):
         os.remove(_get_flock_filename(filename))
     except OSError:
         pass
+
+
+def _create(filename):
+    # Create a database from a fresh file every time. If the user
+    # does not want this they can call open_rw instead.
+    _destroy(filename)
     lock = _get_flock(filename)
     db = None
     try:
@@ -141,6 +145,11 @@ class database(object):
             self.db.close()
         except BaseException:
             pass
+
+    # Completely remote the database from the filesystem.
+    def destroy(self):
+        self.close()
+        _destroy(self.filename)
 
     # Close the database.
     def __del__(self):

--- a/redo/rules/build_clear_cache.py
+++ b/redo/rules/build_clear_cache.py
@@ -1,0 +1,31 @@
+import os.path
+from os import environ
+from base_classes.build_rule_base import build_rule_base
+from database.model_cache_database import model_cache_database
+
+
+# This build rule remove the model cache from the filesystem
+# so it will need to be recreated from scratch for the next build.
+# This can be useful if an output is not generating correctly, and
+# a dependency is missing to the yaml file being modified.
+class build_clear_cache(build_rule_base):
+    # We override build here for performance. With redo clear_cache there is no
+    # need to load the source code and models from then entire project, so
+    # we just need to build path to include the directory pointed to by
+    # redo_1. So set that in the environment for speed, then call the
+    # normal implementation of build.
+    def build(self, redo_1, redo_2, redo_3):
+        directory = os.path.dirname(os.path.abspath(redo_1))
+        environ["BUILD_PATH"] = directory + os.pathsep + directory + os.sep + ".."
+        super(build_clear_cache, self).build(redo_1, redo_2, redo_3)
+
+    def _build(self, redo_1, redo_2, redo_3):
+        with model_cache_database() as db:
+            fname = db.filename
+            db.destroy()
+            import sys
+            sys.stderr.write("Removed " + fname + "\n")
+
+    # No need to provide these for "redo clear_cache"
+    # def input_file_regex(self): pass
+    # def output_filename(self, input_filename): pass

--- a/redo/rules/build_what.py
+++ b/redo/rules/build_what.py
@@ -32,6 +32,7 @@ class build_what(build_rule_base):
             # "recursive",
             "clean",
             "clean_all",
+            "clear_cache",
             "templates",
             "publish",
             "targets",

--- a/redo/util/filesystem.py
+++ b/redo/util/filesystem.py
@@ -34,9 +34,9 @@ def safe_symlink(filename, link_filename, overwrite=False):
 
 
 # This generator is a modified version of os.walk, except that it
-# ignores "build" directories (by default) and hidden directories
+# ignores "build" and "alire" directories (by default) and hidden directories
 # as it recurses. This improves performance of a recursive search.
-def recurse_through_repo(directory, ignore=["build"]):
+def recurse_through_repo(directory, ignore=["build", "alire"]):
     # Walk recursively through the repository, ignoring hidden directories and build directories:
     for root, dirnames, filenames in os.walk(directory):
         # Don't traverse into hidden directories:

--- a/redo/util/redo_arg.py
+++ b/redo/util/redo_arg.py
@@ -182,6 +182,7 @@ def get_src_dir(redo_arg):
         dir_path, dir_name = _get_1_dir_path(dir_path)
         if dir_name == "build":
             to_return = os.path.dirname(dir_path)
+            break
     if to_return:
         return to_return
     else:


### PR DESCRIPTION
This change introduces a model cache that is persistent across calls to `redo`. This allows the build system to run faster when it does not need to reread and revalidate YAML models that have not changed on disk. It also introduces a new command `redo clear_cache` that clears this cache for true clean building.