### PR TITLE
Fixing Latex Spacing in Preambles

### DIFF
--- a/gen/templates/array/name.tex
+++ b/gen/templates/array/name.tex
@@ -3,8 +3,7 @@
 %- endif
 
 %- if preamble 
-\\
-\\
+\vspace{10mm}
 \textit{Preamble (inline Ada definitions):}
 \begin{adacode}
 \VAR{preamble}

--- a/gen/templates/enums/name.tex
+++ b/gen/templates/enums/name.tex
@@ -1,15 +1,14 @@
 %- if description
 \VAR{description|e}
-\\
+\vspace{5mm}
 %- endif
 
 %- if preamble 
-\\
+\vspace{10mm}
 \textit{Preamble (inline Ada definitions):}\\
 \texttt{\VAR{preamble|e}}
-\\
 %- endif
-\\
+\vspace{5mm}
 %- for enum in enums.values()
 \textbf{\texttt{\VAR{enum.name|e}}}:
 %- if enum.description

--- a/gen/templates/memory_map/name.tex
+++ b/gen/templates/memory_map/name.tex
@@ -3,8 +3,7 @@
 %- endif
 
 %- if preamble 
-\\
-\\
+\vspace{10mm}
 \textit{Preamble (inline Ada definitions):}
 \begin{adacode}
 \VAR{preamble}

--- a/gen/templates/record/name.tex
+++ b/gen/templates/record/name.tex
@@ -3,8 +3,7 @@
 %- endif
 
 %- if preamble 
-\\
-\\
+\vspace{10mm}
 \textit{Preamble (inline Ada definitions):}
 \begin{adacode}
 \VAR{preamble}

--- a/gen/templates/register_map/name.tex
+++ b/gen/templates/register_map/name.tex
@@ -3,8 +3,7 @@
 %- endif
 
 %- if preamble 
-\\
-\\
+\vspace{10mm}
 \textit{Preamble (inline Ada definitions):}
 \begin{adacode}
 \VAR{preamble}


### PR DESCRIPTION
Sometimes `\\` is not accepted by the compiler depending on what comes before in a .tex file. Using `vspace` works around this problem.