### PR TITLE
Assembly Compilation Support

### DIFF
--- a/redo/database/create.py
+++ b/redo/database/create.py
@@ -225,10 +225,10 @@ def _is_ada_source_file(filename):
     return ext in [".adb", ".ads"]
 
 
-# Determine if a filename is c/c++ source file by its extension.
+# Determine if a filename is c/c++ or asm source file by its extension.
 def _is_c_source_file(filename):
     _, ext = os.path.splitext(filename)
-    return ext in [".c", ".cpp", ".h", ".hpp"]
+    return ext in [".c", ".cpp", ".h", ".hpp", ".s"]
 
 
 # Determine if a filename is python source file by its extension.
@@ -348,7 +348,7 @@ def create(build_path):
     ada_source_regex = re.compile(r".*\.ad[sb]$")
     do_file_regex = re.compile(r".*\.do$")
     yaml_file_regex = re.compile(r".*\.yaml$")
-    c_source_regex = re.compile(r".*\.[ch]p?p?$")
+    c_source_regex = re.compile(r".*\.(h|hpp|c|cpp|s)$")
 
     # Search first for model files, and create the model database. This
     # may be needed by generators, so we need to build it first.


### PR DESCRIPTION
This supports the compilation of assembly files (asm) within the Adamant build system. There are no dependencies tracked between Ada and assembly or C/C++ and assembly. So, for now, you must compile assembly "manually" prior to linking by writing a custom `redo` file, or by other means. Assembly must use the file extension `.s`.