### PR TITLE
Target-based C/C++ Binding Generation

### DIFF
--- a/doc/user_guide/build_user_guide.do
+++ b/doc/user_guide/build_user_guide.do
@@ -33,7 +33,7 @@ redo-ifchange ../example_architecture/memory_map/all
 redo-ifchange ../example_architecture/register_map/all
 redo-ifchange ../example_architecture/yaml_sloc/all
 redo-ifchange ../example_architecture/c_lib/templates
-cp -f ../example_architecture/c_lib/build/template/c_lib_h.ads ../example_architecture/c_lib/c_lib_h.ads
+cp -f ../example_architecture/c_lib/build/template/Linux/c_lib_h.ads ../example_architecture/c_lib/c_lib_h.ads
 redo-ifchange ../example_architecture/c_lib/all
 $ADAMANT_DIR/gnd/matlab/build_all_matlab_autocode.sh ../example_architecture
 

--- a/doc/user_guide/user_guide.tex
+++ b/doc/user_guide/user_guide.tex
@@ -6045,17 +6045,17 @@ redo  what
 redo all
 redo clean
 redo build/obj/Linux/c_lib.o
-redo build/template/c_lib_h.ads
+redo build/template/Linux/c_lib_h.ads
 \end{minted}
 \vspace{5mm} %5mm vertical space
 
-To build the Ada bindings run:
+Note that binding generation is specific to your build target, since different compilers will often bind to symbols with different naming. To build the Ada bindings run:
 
 \vspace{5mm} %5mm vertical space
 \begin{minted}{text}
 > redo templates
   redo  templates
-  redo    build/template/c_lib_h.ads
+  redo    build/template/Linux/c_lib_h.ads
 \end{minted}
 \vspace{5mm} %5mm vertical space
 
@@ -6070,7 +6070,7 @@ Let's take a look at the C source code: \\
 which provides a simple data structure and function that increments a value up to a limit before rolling over. Let's also look at the generated Ada bindings: \\
 
 \textit{c\_lib\_h.ads}:
-\adacodef{../example_architecture/c_lib/build/template/c_lib_h.ads}
+\adacodef{../example_architecture/c_lib/build/template/Linux/c_lib_h.ads}
 
 As you can see, \textit{c\_lib\_h.ads} includes Ada bindings for the C struct and the call to \texttt{increment}. Below is an example \textit{main.adb} that uses the bindings to call the C library. \\
 

--- a/redo/rules/build_bindings.py
+++ b/redo/rules/build_bindings.py
@@ -22,7 +22,9 @@ def _generate_bindings(redo_1, redo_2, redo_3, source_file, c_source_db):
     build_target_instance, _ = _get_build_target_instance(build_target)
     deps = _build_all_c_dependencies([source_file], c_source_db, build_target_instance=build_target_instance)
     dep_dirs = list(set([os.path.dirname(dep) for dep in deps]))
-    include_str = "-I" + " -I".join(dep_dirs)
+    include_str = ""
+    if dep_dirs:
+        include_str = " -I" + " -I".join(dep_dirs)
 
     # Get the gnatmetric info from the target, ie. arm-eabi-
     prefix, _ = build_target_instance.gnatmetric_info(
@@ -42,7 +44,7 @@ def _generate_bindings(redo_1, redo_2, redo_3, source_file, c_source_db):
         + "-fdump-ada-spec "
         + "-C "
         + source_file
-        + " " + include_str
+        + include_str
     )
 
     # Run the bindings command in templates directory so the file

--- a/redo/rules/build_bindings.py
+++ b/redo/rules/build_bindings.py
@@ -51,7 +51,7 @@ def _generate_bindings(redo_1, redo_2, redo_3, source_file, c_source_db):
     # gets created there:
     cwd = os.getcwd()
     template_temp_dir = redo_arg.get_build_dir(redo_1) \
-            + os.sep + "template" + os.sep + build_target + os.sep + "temp"
+        + os.sep + "template" + os.sep + build_target + os.sep + "temp"
     filesystem.safe_makedir(template_temp_dir)
     os.chdir(template_temp_dir)
     shell.run_command_suppress_output(compile_cmd)

--- a/redo/rules/build_bindings.py
+++ b/redo/rules/build_bindings.py
@@ -11,16 +11,23 @@ from base_classes.build_rule_base import build_rule_base
 from rules.build_object import _build_all_c_dependencies, _get_build_target_instance
 
 
-# This function compiles a c object file from a given
-# source file.
+# This function generates Ada bindings for a given C/C++ source file
 def _generate_bindings(redo_1, redo_2, redo_3, source_file, c_source_db):
 
     # First build all the dependencies for this source file and for the include
     # string for those dependencies:
-    build_target_instance, _ = _get_build_target_instance(target.get_default_target())
+
+    # Get the build target instance:
+    build_target = redo_arg.get_target(redo_2)
+    build_target_instance, _ = _get_build_target_instance(build_target)
     deps = _build_all_c_dependencies([source_file], c_source_db, build_target_instance=build_target_instance)
     dep_dirs = list(set([os.path.dirname(dep) for dep in deps]))
     include_str = "-I" + " -I".join(dep_dirs)
+
+    # Get the gnatmetric info from the target, ie. arm-eabi-
+    prefix, _ = build_target_instance.gnatmetric_info(
+        target=build_target
+    )
 
     # Should we use gcc or g++ for bindings generation
     compiler = "gcc"
@@ -30,7 +37,7 @@ def _generate_bindings(redo_1, redo_2, redo_3, source_file, c_source_db):
     # Generate the compilation command that dumps the bindings, ie:
     #    gcc -c -fdump-ada-spec -C c_lib.h
     compile_cmd = (
-        compiler + " "
+        prefix + compiler + " "
         + "-c "
         + "-fdump-ada-spec "
         + "-C "
@@ -41,7 +48,8 @@ def _generate_bindings(redo_1, redo_2, redo_3, source_file, c_source_db):
     # Run the bindings command in templates directory so the file
     # gets created there:
     cwd = os.getcwd()
-    template_temp_dir = redo_arg.get_build_dir(redo_1) + os.sep + "template" + os.sep + "temp"
+    template_temp_dir = redo_arg.get_build_dir(redo_1) \
+            + os.sep + "template" + os.sep + build_target + os.sep + "temp"
     filesystem.safe_makedir(template_temp_dir)
     os.chdir(template_temp_dir)
     shell.run_command_suppress_output(compile_cmd)
@@ -64,11 +72,11 @@ def _generate_bindings(redo_1, redo_2, redo_3, source_file, c_source_db):
 class build_bindings(build_rule_base):
     def _build(self, redo_1, redo_2, redo_3):
         # Make sure the binding is being built in the correct directory:
-        if not redo_arg.in_build_template_dir(redo_1):
+        if not redo_arg.in_build_template_target_dir(redo_1):
             error.error_abort(
-                "Object file '"
+                "Bindings file '"
                 + redo_1
-                + "' can only be built in a 'build/template' directory."
+                + "' can only be built in a 'build/template/$TARGET' directory."
             )
 
         # If no source files were found, then maybe this object
@@ -128,6 +136,8 @@ class build_bindings(build_rule_base):
             "build"
             + os.sep
             + "template"
+            + os.sep
+            + target.get_default_target()
             + os.sep
             + base
             + "_" + ext[1:]

--- a/redo/util/redo_arg.py
+++ b/redo/util/redo_arg.py
@@ -152,6 +152,7 @@ def in_build_template_dir(redo_arg):
     build_dir, src_dir = _get_2_dirs(redo_arg)
     return build_dir == "build" and src_dir == "template"
 
+
 # Given a filename check if the file is found
 # in a directory like /path/to/build/template/$TARGET
 def in_build_template_target_dir(redo_arg):

--- a/redo/util/redo_arg.py
+++ b/redo/util/redo_arg.py
@@ -152,6 +152,12 @@ def in_build_template_dir(redo_arg):
     build_dir, src_dir = _get_2_dirs(redo_arg)
     return build_dir == "build" and src_dir == "template"
 
+# Given a filename check if the file is found
+# in a directory like /path/to/build/template/$TARGET
+def in_build_template_target_dir(redo_arg):
+    build_dir, obj_dir, target_dir = _get_3_dirs(redo_arg)
+    return build_dir == "build" and obj_dir == "template" and target_dir
+
 
 # Given a filename check if the file is found
 # in a directory like /path/to/build/metric
@@ -212,6 +218,7 @@ def get_target(redo_arg):
         in_build_obj_dir(redo_arg)
         or in_build_bin_dir(redo_arg)
         or in_build_metric_dir(redo_arg)
+        or in_build_template_target_dir(redo_arg)
     )
     return _get_1_dir(redo_arg)
 


### PR DESCRIPTION
Bindings are generated in separate subdirectories of `template/` for C/C++ bindings. Symbols for C++ differ based on compiler, so a single bindings file cannot work for any build target. This allows a user to generate bindings for different targets. The user guide has been updated to reflect this change.