### PR TITLE
Assembly support for .S suffix

### DIFF
--- a/redo/database/create.py
+++ b/redo/database/create.py
@@ -228,7 +228,7 @@ def _is_ada_source_file(filename):
 # Determine if a filename is c/c++ or asm source file by its extension.
 def _is_c_source_file(filename):
     _, ext = os.path.splitext(filename)
-    return ext in [".c", ".cpp", ".h", ".hpp", ".s"]
+    return ext in [".c", ".cpp", ".h", ".hpp", ".S", ".s"]
 
 
 # Determine if a filename is python source file by its extension.
@@ -348,7 +348,7 @@ def create(build_path):
     ada_source_regex = re.compile(r".*\.ad[sb]$")
     do_file_regex = re.compile(r".*\.do$")
     yaml_file_regex = re.compile(r".*\.yaml$")
-    c_source_regex = re.compile(r".*\.(h|hpp|c|cpp|s)$")
+    c_source_regex = re.compile(r".*\.(h|hpp|c|cpp|S|s)$")
 
     # Search first for model files, and create the model database. This
     # may be needed by generators, so we need to build it first.

--- a/redo/rules/build_object.py
+++ b/redo/rules/build_object.py
@@ -235,7 +235,7 @@ def _build_all_c_dependencies(
         all_deps = []
         for source_file in source_files:
             # Get dependencies for this source file. Ignore assembly files.
-            if not source_file.endswith(".s"):
+            if not source_file.endswith(".S") and not source_file.endswith(".s"):
                 all_deps.extend(get_c_source_dependencies(source_file, build_target_instance, c_source_db))
         return list(set(all_deps))
 
@@ -352,7 +352,7 @@ def _get_object_sources(object_file):
         source_to_compile_extension = None
         for source_file in source_files:
             _, source_to_compile_extension = os.path.splitext(source_file)
-            if source_to_compile_extension in [".c", ".cpp", ".s"]:
+            if source_to_compile_extension in [".c", ".cpp", ".S", ".s"]:
                 source_to_compile = source_file
                 break
 
@@ -560,7 +560,7 @@ def _compile_c_object(redo_1, redo_2, redo_3, source_files, db):
     source_to_compile_extension = None
     for source_file in source_files:
         _, source_to_compile_extension = os.path.splitext(source_file)
-        if source_to_compile_extension in [".c", ".cpp", ".s"]:
+        if source_to_compile_extension in [".c", ".cpp", ".S", ".s"]:
             source_to_compile = source_file
             break
 


### PR DESCRIPTION
Previously only `.s` was supported. Now `.S` is also recognized as assembly and can be compiled.