### PR TITLE
`redo what` tab completion feature

### DIFF
--- a/default.do
+++ b/default.do
@@ -44,6 +44,8 @@ if __name__ == "__main__":
         from rules.build_clear_cache import build_clear_cache as rule_cls
     elif base == "what":
         from rules.build_what import build_what as rule_cls
+    elif base == "what_predefined":
+        from rules.build_what_predefined import build_what_predefined as rule_cls
     elif base == "prove":
         from rules.build_prove import build_prove as rule_cls
     elif base == "analyze":

--- a/env/activate
+++ b/env/activate
@@ -164,6 +164,7 @@ for path in "${paths[@]}"; do
   cd - &> /dev/null
   echo "Done."
 done
+
 echo "Done."
 echo ""
 echo "-- Adamant Configuration --"
@@ -177,5 +178,5 @@ echo ""
 # Signify the environment is set up
 export ADAMANT_ENVIRONMENT_SET="yes"
 
-
+# Adding redo tab completion feature to shell
 . $ADAMANT_DIR/env/redo_completion.sh

--- a/env/activate
+++ b/env/activate
@@ -176,3 +176,6 @@ echo ""
 
 # Signify the environment is set up
 export ADAMANT_ENVIRONMENT_SET="yes"
+
+
+. $ADAMANT_DIR/env/redo_completion.sh

--- a/env/redo_completion.sh
+++ b/env/redo_completion.sh
@@ -2,6 +2,8 @@
 
 
 
+# The function that provides bash completions for the redo command.
+# To see debug messages, set DBG=true.
 __redo_completion () {
     local underscore=$_ # must be very first command
     local special_arg=____redo_completion_special_arg
@@ -16,23 +18,30 @@ __redo_completion () {
     # so we can use this to detect whether this is the user's first tab press
 
 
-    # echo -
-    # echo - start: "first_run=$first_run this_word=$this_word"
+    dbg () {
+        local prevstatus=$?
+        [ "$DBG" = true ] &&  echo - "$@"
+        return $prevstatus
+    }
+
+    dbg
+    dbg "> start: first_run=$first_run this_word=$this_word"
 
 
 
-
+    ##########################################
     # functions used in redo_completion_helper
+    ##########################################
     
     # takes in an argument, likely `what` or `what_predefined`
     redo_cmd_parsed () {
         redo "$1" 2>&1 | tail +2 | sed 's/^redo //' | sed 's/\n/ /' | echo "$(cat -)
-    what" | grep -v "^$"
+what" | grep -v "^$"
         return ${PIPESTATUS[0]} # i.e. status of redo what
     }
 
     # for all these functions:
-    # path arg should not contain a trailing slash
+    # path arg should/will not contain a trailing slash
 
     what_parsed () {
         local path=$1
@@ -44,19 +53,16 @@ __redo_completion () {
         redo_cmd_parsed "$path/what_predefined"
     }
 
-
-
-    # main cache: output of the last time we ran `redo what`
+    # main cache: stores output of previous runs of `redo what`
     words_cache_ok () {
         local path=$1
         [ -f "$path"/build/redo/what_cache.txt ] || return 1
         [ -n "$(cat "$path"/build/redo/what_cache.txt)" ] || return 1
-        # check for file integrity, timestamp, etc?
+        # todo: check for file integrity, timestamp, etc?
         return 0
     }
 
     words_cache_save () {
-        # echo  - ">f do caching enter"
         local path=$1
         local res status
         res="$(what_parsed "$path")"
@@ -65,15 +71,13 @@ __redo_completion () {
         [ "$status" = 0 ] || return 2
         mkdir -p "$path"/build/redo && echo "$res" > "$path"/build/redo/what_cache.txt
         [ "$?" = 0 ] || return 1
-        # echo  - ">f do caching exit"
         return 0
     }
 
-
-
+    # short lived cache of a directories in which we've run `redo what`
     # i.e. can we assume that the cache in this directory is completely up to date?
     dir_first_visit () {
-        local path=$1 filename=./build/redo/what_cache_dirs.txt
+        local path=$1 filename=~/.cache/redo/what_cache_dirs.txt
         [ -f "$filename" ] || return 0
 
         cat "$filename" | grep "^$path\$" >/dev/null && return 1
@@ -82,27 +86,25 @@ __redo_completion () {
 
     dir_cache_save () {
         local path=$1 
-        mkdir -p ./build/redo/ && echo "$path" >> ./build/redo/what_cache_dirs.txt
+        mkdir -p ~/.cache/redo/ 2>/dev/null && echo "$path" >> ~/.cache/redo/what_cache_dirs.txt
     }
 
     # doesn't take a path, since dir cache is always relative to ./
     dir_cache_clean () {
-        local filename=./build/redo/what_cache_dirs.txt
+        local filename=~/.cache/redo/what_cache_dirs.txt
         [ -f "$filename" ] && rm "$filename"
     }
-
-
 
     # shorter-lived cache to avoid having to recurse every new dir completion
     # see usages of `save_last_confirmed_dir` and `try_cached_dir`
     save_last_confirmed_dir () {
         local dir=$1
-        # echo - "saved $dir"
-        mkdir -p ./build/redo/ && echo "$dir" > ./build/redo/what_cache_lastdir.txt
+        dbg "saved $dir"
+        mkdir -p ~/.cache/redo/ && echo "$dir" > ~/.cache/redo/what_cache_lastdir.txt
     }
 
     get_last_confirmed_dir () {
-        local filename=./build/redo/what_cache_lastdir.txt
+        local filename=~/.cache/redo/what_cache_lastdir.txt
         [ -f "$filename" ] || return 1
 
         local dir
@@ -113,15 +115,11 @@ __redo_completion () {
         return 0
     }
 
-
-
     prepend () {
         while read -r line; do
             echo "$1$line"
         done
     }
-
-
 
     # if $1 is formatted dir///other//stuff,
     # split into LEAD_DIR=dir RES=other//stuff
@@ -146,46 +144,115 @@ __redo_completion () {
 
 
 
+    # the following functions are more like subroutines for redo_completion_helper
+    # these assume lots of global state
 
-    # more like subroutines for redo_completion_helper
-
-    synchronous_work () {
-        compgen_arg=$(words_cache_save "$path")
-        RES=$(compgen -W "$compgen_arg" "$arg")
-    }
-
-    async_work () {
-        words_cache_save "$path" >/dev/null
-    }
-
-    # we `prepend_path` every branch, except for when `compgen -d` does it for us
     prepend_path () {
         if [ $path != . ] && [ -n "$RES" ]; then
             RES=$(echo "$RES" | prepend "$path/")
         fi
     }
 
-    # main helper function
+    append_compgen_dirs () {
+        # match against directories in $path
+        local full_arg
+        if [ "$path" = . ]; then
+            full_arg=$arg
+        # elif [ -z "$arg" ]; then
+            # full_arg=$path
+        else
+            full_arg=$path/$arg
+        fi
+
+        dbg full arg: "$full_arg"
+
+        # stupid way of appending lines to variable
+        RES=$(echo "$RES
+$(compgen -d "$full_arg" | grep -v '\bbuild\b' | sed 's/$/\//')" | grep -v '^$')
+    }
+
+    synchronous_work () {
+        compgen_arg=$(words_cache_save "$path")
+        RES=$(compgen -W "$compgen_arg" "$arg")
+        prepend_path
+        append_compgen_dirs
+    }
+
+    async_work () {
+        words_cache_save "$path" >/dev/null
+    }
+
+    should_recurse () {
+        try_trim_leading_dir "$path" "$arg"
+    }
+
+    do_recurse () {
+
+        # these are set by try_trim_leading_dir
+        local dir_prefix=$LEAD_DIR trimmed_arg=$REST
+
+        dbg "arg ($arg) vs trimmed halves ($dir_prefix) ($trimmed_arg)"
+
+        # keep paths as clean as possible to prevent stacking
+        # potential todo: detect if user deliberately typed "." and if so, keep
+        if [ "$path" = . ]; then
+            path=$dir_prefix
+        else
+            path=$path/$dir_prefix
+        fi
+
+        dbg "> recurse: path ($path) arg ($trimmed_arg)"
+
+
+        redo_completion_helper "$path" "$trimmed_arg"
+        local status=$?
+
+        return $status
+    
+    }
+
+
+
+    # the main helper function
     redo_completion_helper () {
         local path=$1 arg=$2
 
-        if pwd | grep '/build$' >/dev/null || ! what_predef_parsed "$path" >/dev/null; then
-            # nothing to do here, `redo what` isn't even available
-        #     echo - dip
-            return 1
-        fi
+        # return value -- must reset at start of function
+        RES=
 
         # clean up $path / $arg -- replace instances of ./ with nothing
         path=$(echo "$path" | sed 's/\b\.\///')
         arg=$(echo "$arg" | sed 's/\b\.\///')
         [ "$arg" = . ] && arg=./ # just bc the user must have typed it in
 
-        # path only gets edited when we recurse, so this is safe
-        save_last_confirmed_dir "$path"
+        dbg "> enter helper: path=($path) arg=($arg)"
 
+        if what_predef_parsed "$path" >/dev/null; then
+            # path only gets edited when we recurse, so this is safe
+            save_last_confirmed_dir "$path"
+        else
+            # TODO: make completion work inside of /build directory
+            # for now just dip
+            dbg '> redo what unavailable'
+            if pwd | grep '/build$' >/dev/null; then
+                dbg '> stuck in build/ so dip'
+                return 0
+            fi
 
-        # return value
-        RES=
+            # `redo what` isn't even available
+            # so just complete dirs
+            append_compgen_dirs
+            dbg new res just dropped "RES ($RES)"
+            # return 1
+
+            if should_recurse; then
+                dbg '> yet recurse'
+                do_recurse
+                return $?
+            fi
+            return 0
+        fi
+
 
         # locals
         local compgen_arg first_run=false
@@ -194,8 +261,6 @@ __redo_completion () {
             dir_cache_save "$path"
         fi
 
-        # echo - "enter: path=($path) arg=($arg) first_run=$first_run"
-    
         # overview:
         # if typed `redo <tab>` or `redo path/<tab>`, run `redo what` synchronously
         # check word cache (fallback to `redo what_predefined`)
@@ -216,18 +281,18 @@ __redo_completion () {
         # if typed `redo <tab>` and cache is outdated, bypass cache
         if [ "$first_run" = true ] && [ -z "$arg" ]; then
             synchronous_work
-            prepend_path
+            append_compgen_dirs
             return 0
         fi
 
 
         if words_cache_ok "$path"; then
             compgen_arg=$(cat "$path"/build/redo/what_cache.txt)
-        #     echo - '> cache ok'
+            dbg '> cache ok'
         else
             # fallback to `redo what_predefined`
             compgen_arg=$(what_predef_parsed "$path")
-        #     echo - '> cache fallback to what_predef'
+            dbg '> cache fallback to what_predef'
         fi
 
         # generate completions
@@ -235,84 +300,51 @@ __redo_completion () {
 
         if [ -n "$RES" ]; then
 
-        #     echo - '> used cache'
-
-            (async_work &)
+            dbg '> used cache'
 
             prepend_path
-            return 0
-        fi
-
-        # echo - '> cache miss'
-
-        # no match, so check for a directory prefix
-        if try_trim_leading_dir "$path" "$arg"; then
-            # found directory, so recurse "into" it
-
-            # these are set by try_trim_leading_dir
-            local dir_prefix=$LEAD_DIR trimmed_arg=$REST
-
-        #     echo - "arg ($arg) vs trimmed halves ($dir_prefix) ($trimmed_arg)"
-
-            # keep paths as clean as possible to prevent stacking
-            # potential todo: detect if user deliberately typed "." and if so, keep
-            if [ "$path" = . ]; then
-                path=$dir_prefix
-            else
-                path=$path/$dir_prefix
-            fi
-
-        #     echo - "> recurse: path ($path) arg ($trimmed_arg)"
-
-
-            redo_completion_helper "$path" "$trimmed_arg"
-            local status=$?
-
-            return $status
-        fi
-
-        # echo - '> no recurse'
-
-        # echo - pre-full arg: "path ($path) arg ($arg)"
-        # match against directories in $path
-        local full_arg
-        if [ "$path" = . ]; then
-            full_arg=$arg
-        elif [ -z "$arg" ]; then
-            full_arg=$path
-        else
-            full_arg=$path/$arg
-        fi
-        RES=$(compgen -d "$full_arg" | grep -v '\bbuild\b' | sed 's/$/\//')
-
-        # echo - full arg: $full_arg
-
-        if [ -n "$RES" ]; then
-        #     echo - '> matched compgen -d'
-            # we have a match, may as well start a bg task in this dir
+            append_compgen_dirs
             (async_work &)
 
-            # don't prepend path, `compgen -d` provides full path names
-            # (since we never `cd` even on recursive calls)
-
             return 0
         fi
 
-        # echo - '> synchronous time'
+        dbg '> cache miss'
+
+        # no match, so check for a directory prefix
+        if should_recurse; then
+            # found directory, so recurse "into" it
+            do_recurse
+            return $?
+        fi
+
+        dbg '> no recurse'
+        dbg pre-full arg: "path ($path) arg ($arg)"
+
+        RES=
+        append_compgen_dirs
+
+        if [ -n "$RES" ]; then
+            # no need to prepend_path
+            (async_work &)
+            return 0
+        fi
 
         # now there's really nothing to match
         # so do synchronous anyway, but only on first run
         # this is useful for i.e. autocompleting build/ in a directory for the first time after making a .component.yaml file
         if [ "$first_run" = true ]; then
+            dbg '> synchronous time'
             synchronous_work
-            prepend_path
             return 0
         fi
+        dbg '> no matches at all'
+        return 0
     }
 
 
 
-    # subroutine for below
+    # subroutine used shortly
     local subdir trimmed_arg
     try_cached_dir () {
         subdir= trimmed_arg=
@@ -321,14 +353,14 @@ __redo_completion () {
             local lastdir=$LAST_DIR
 
             # check if arg starts with dir
-            if echo "$this_word" | grep "^$lastdir" >/dev/null; then
+            if [ "$lastdir" != . ] && echo "$this_word" | grep "^$lastdir/" >/dev/null; then
                 subdir=$lastdir
 
                 # the #*$ bit trims a prefix off the left string
                 trimmed_arg=$(echo "${this_word#*$subdir}" | sed 's/^\///')
                 all_ifs=true
 
-    #             echo - "last confirmed: subdir=$subdir trimmed_arg=$trimmed_arg"
+                dbg "last confirmed: subdir=$subdir trimmed_arg=$trimmed_arg"
             fi
         fi
         [ "$all_ifs" = true ] && return 0 || return 1
@@ -336,8 +368,9 @@ __redo_completion () {
 
 
 
-
+    ######################################
     # end definitions, start running stuff
+    ######################################
 
     # helps us figure out whether re-running `redo what` is a waste
     # if first_run=true then the user might have run commands 
@@ -347,7 +380,15 @@ __redo_completion () {
     fi
 
     local cmdname=$1 this_word=$2 prev_word=$3
+    local starting_dir=.
 
+    # manually detect whether "~" is used
+    # TODO: incompatible with ~otheruser/ syntax
+    local tilde=false
+    if echo "$this_word" | grep '^~' >/dev/null; then
+        tilde=true
+        this_word=$(echo "$this_word" | sed "s#~#$HOME#")
+    fi
 
     # call helper function
 
@@ -355,17 +396,22 @@ __redo_completion () {
     if [ "$first_run" = false ] && try_cached_dir; then
         # this saves a few recursions 
         # see recursion in helper function for when this gets cached
-    #     echo - "> insta-recurse"
+        dbg "> insta-recurse"
         redo_completion_helper "$subdir" "$trimmed_arg"
     else
-        redo_completion_helper . "$this_word"
+        redo_completion_helper "$starting_dir" "$this_word"
     fi
 
     if [ $? = 0 ]; then
-        # if it ends with a slash, it's a path
-        # so if it doesn't end with a slash, we should add a space to it
-        if [ -n "$RES" ] && ! echo "$RES" | grep '/$' >/dev/null; then
-            RES=$(echo "$RES" | sed 's/$/ /')
+        if [ -n "$RES" ]; then
+            # if it ends with a slash, it's a path
+            # so if it doesn't end with a slash, we should add a space to it
+            RES=$(echo "$RES" | sed 's#$# #' | sed 's#/ $#/#')
+
+            # reapply the tilde
+            if [ "$tilde" = true ]; then
+                RES=$(echo "$RES" | sed "s#^$HOME#~#")
+            fi
         fi
 
         # split into bash array based on newline, not any whitespace (precaution)
@@ -377,7 +423,7 @@ __redo_completion () {
         unset oldifs
     fi
 
-    unset -f redo_cmd_parsed what_parsed what_predef_parsed words_cache_ok words_cache_save dir_first_visit dir_cache_save dir_cache_clean save_last_confirmed_dir get_last_confirmed_dir prepend try_trim_leading_dir synchronous_work async_work prepend_path redo_completion_helper try_cached_dir
+    unset -f redo_cmd_parsed what_parsed what_predef_parsed words_cache_ok words_cache_save dir_first_visit dir_cache_save dir_cache_clean save_last_confirmed_dir get_last_confirmed_dir prepend try_trim_leading_dir append_compgen_dirs synchronous_work async_work prepend_path redo_completion_helper try_cached_dir
     
     # must be very last command, see top
     echo $special_arg > /dev/null

--- a/env/redo_completion.sh
+++ b/env/redo_completion.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-
-
 # The function that provides bash completions for the redo command.
 # To see debug messages, set DBG=true.
 __redo_completion () {
@@ -28,11 +26,10 @@ __redo_completion () {
     dbg "> start: first_run=$first_run this_word=$this_word"
 
 
-
     ##########################################
     # functions used in redo_completion_helper
     ##########################################
-    
+
     # takes in an argument, likely `what` or `what_predefined`
     redo_cmd_parsed () {
         redo "$1" 2>&1 | tail +2 | sed 's/^redo //' | sed 's/\n/ /' | echo "$(cat -)
@@ -85,7 +82,7 @@ what" | grep -v "^$"
     }
 
     dir_cache_save () {
-        local path=$1 
+        local path=$1
         mkdir -p ~/.cache/redo/ 2>/dev/null && echo "$path" >> ~/.cache/redo/what_cache_dirs.txt
     }
 
@@ -208,7 +205,7 @@ $(compgen -d "$full_arg" | grep -v '\bbuild\b' | sed 's/$/\//')" | grep -v '^$')
         local status=$?
 
         return $status
-    
+
     }
 
 
@@ -373,7 +370,7 @@ $(compgen -d "$full_arg" | grep -v '\bbuild\b' | sed 's/$/\//')" | grep -v '^$')
     ######################################
 
     # helps us figure out whether re-running `redo what` is a waste
-    # if first_run=true then the user might have run commands 
+    # if first_run=true then the user might have run commands
     # which might change the output of `redo what`
     if [ $first_run = true ]; then
         dir_cache_clean
@@ -394,7 +391,7 @@ $(compgen -d "$full_arg" | grep -v '\bbuild\b' | sed 's/$/\//')" | grep -v '^$')
 
     # helper function sets the RES variable
     if [ "$first_run" = false ] && try_cached_dir; then
-        # this saves a few recursions 
+        # this saves a few recursions
         # see recursion in helper function for when this gets cached
         dbg "> insta-recurse"
         redo_completion_helper "$subdir" "$trimmed_arg"
@@ -424,7 +421,7 @@ $(compgen -d "$full_arg" | grep -v '\bbuild\b' | sed 's/$/\//')" | grep -v '^$')
     fi
 
     unset -f redo_cmd_parsed what_parsed what_predef_parsed words_cache_ok words_cache_save dir_first_visit dir_cache_save dir_cache_clean save_last_confirmed_dir get_last_confirmed_dir prepend try_trim_leading_dir append_compgen_dirs synchronous_work async_work prepend_path redo_completion_helper try_cached_dir
-    
+
     # must be very last command, see top
     echo $special_arg > /dev/null
 }
@@ -432,5 +429,3 @@ $(compgen -d "$full_arg" | grep -v '\bbuild\b' | sed 's/$/\//')" | grep -v '^$')
 # the reason we can't use `complete -o dirnames` is that
 # we need to exclude ./build (and want to exclude hidden dirs)
 complete -o nospace -o nosort -F __redo_completion redo
-
-

--- a/env/redo_completion.sh
+++ b/env/redo_completion.sh
@@ -1,122 +1,390 @@
 #!/bin/bash
 
-# takes in an argument, likely `what` or `what_predefined`
-__redo_cmd_parsed () {
-    redo "$1" 2>&1 | tail +2 | sed 's/^redo //' | sed 's/\n/ /' | echo "$(cat -)
-what" | grep -v "^$"
-    return ${PIPESTATUS[0]} # i.e. status of redo what
-}
 
-__what_parsed () {
-    __redo_cmd_parsed what
-}
-
-__what_predef_parsed () {
-    __redo_cmd_parsed what_predefined
-}
-
-__do_caching () {
-    local res status
-    res="$(__what_parsed)"
-    status=$?
-    echo $res
-    [ "$status" = 0 ] || return 2
-    mkdir -p ./build/redo && echo "$res" > ./build/redo/whatcache.txt
-    [ "$?" = 0 ] || return 1
-    return 0
-}
-
-
-__cache_ok () {
-    [ -f ./build/redo/whatcache.txt ] || return 1
-    [ -n "$(cat ./build/redo/whatcache.txt)" ] || return 1
-    # check for file integrity, timestamp, etc?
-    return 0
-}
 
 __redo_completion () {
+    local underscore=$_ # must be very first command
+    local special_arg=____redo_completion_special_arg
+    local first_run=false
+    [ "$underscore" != "$special_arg" ] && first_run=true
+
+
     # $_ is set to the argument of the last executed command
-    # on the first run, it will depend on what the user just ran
+    # so on the first run, it will depend on what the user just ran
     # the second run onwards, it will be set to $special_arg
     # this function runs once after every tab completion,
     # so we can use this to detect whether this is the user's first tab press
 
-    local underscore=$_ # must be very first command
-    local special_arg=____redo_completion_special_arg
 
-    local first_run=false
-    [ "$underscore" != "$special_arg" ] && first_run=true
-
-    local cmdname=$1
-    local this_word=$2
-    local prev_word=$3
-
-    # echo
-    # echo cmdname = $cmdname
-    # echo this_word = $this_word
-    # echo prev_word = $prev_word
-    # echo first_run = $first_run
-
-    local compgen_arg compgen_res
-    local do_synch=false
+    # echo -
+    # echo - start: "first_run=$first_run this_word=$this_word"
 
 
-    # I assume that
-    # if someone types `redo <tab>`,
-    # they probably want an up-to-date list of commands
-    # but if someone types `redo b<tab>` for example,
-    # they probably intended to autocomplete build/
-    # which is likely still available, and useful to provide instantly
 
-    # if cache is unavailable,
-    # or if typed `redo <tab>`
-    # bypass cache
-    if [ "$first_run" = true ] &&
-        [ -z "$this_word" ] &&        # blank first arg
-        [ "$prev_word" = "$cmdname" ] # no previous args
-    then
-        # do synchronous run
-        do_synch=true
-    else
-        if __cache_ok; then
-            compgen_arg=$(cat ./build/redo/whatcache.txt)
+
+    # functions used in redo_completion_helper
+    
+    # takes in an argument, likely `what` or `what_predefined`
+    redo_cmd_parsed () {
+        redo "$1" 2>&1 | tail +2 | sed 's/^redo //' | sed 's/\n/ /' | echo "$(cat -)
+    what" | grep -v "^$"
+        return ${PIPESTATUS[0]} # i.e. status of redo what
+    }
+
+    # for all these functions:
+    # path arg should not contain a trailing slash
+
+    what_parsed () {
+        local path=$1
+        redo_cmd_parsed "$path/what"
+    }
+
+    what_predef_parsed () {
+        local path=$1
+        redo_cmd_parsed "$path/what_predefined"
+    }
+
+
+
+    # main cache: output of the last time we ran `redo what`
+    words_cache_ok () {
+        local path=$1
+        [ -f "$path"/build/redo/what_cache.txt ] || return 1
+        [ -n "$(cat "$path"/build/redo/what_cache.txt)" ] || return 1
+        # check for file integrity, timestamp, etc?
+        return 0
+    }
+
+    words_cache_save () {
+        # echo  - ">f do caching enter"
+        local path=$1
+        local res status
+        res="$(what_parsed "$path")"
+        status=$?
+        echo "$res"
+        [ "$status" = 0 ] || return 2
+        mkdir -p "$path"/build/redo && echo "$res" > "$path"/build/redo/what_cache.txt
+        [ "$?" = 0 ] || return 1
+        # echo  - ">f do caching exit"
+        return 0
+    }
+
+
+
+    # i.e. can we assume that the cache in this directory is completely up to date?
+    dir_first_visit () {
+        local path=$1 filename=./build/redo/what_cache_dirs.txt
+        [ -f "$filename" ] || return 0
+
+        cat "$filename" | grep "^$path\$" >/dev/null && return 1
+        return 0
+    }
+
+    dir_cache_save () {
+        local path=$1 
+        mkdir -p ./build/redo/ && echo "$path" >> ./build/redo/what_cache_dirs.txt
+    }
+
+    # doesn't take a path, since dir cache is always relative to ./
+    dir_cache_clean () {
+        local filename=./build/redo/what_cache_dirs.txt
+        [ -f "$filename" ] && rm "$filename"
+    }
+
+
+
+    # shorter-lived cache to avoid having to recurse every new dir completion
+    # see usages of `save_last_confirmed_dir` and `try_cached_dir`
+    save_last_confirmed_dir () {
+        local dir=$1
+        # echo - "saved $dir"
+        mkdir -p ./build/redo/ && echo "$dir" > ./build/redo/what_cache_lastdir.txt
+    }
+
+    get_last_confirmed_dir () {
+        local filename=./build/redo/what_cache_lastdir.txt
+        [ -f "$filename" ] || return 1
+
+        local dir
+        dir=$(cat "$filename")
+        [ $? = 0 ] || return 1
+
+        LAST_DIR="$dir"
+        return 0
+    }
+
+
+
+    prepend () {
+        while read -r line; do
+            echo "$1$line"
+        done
+    }
+
+
+
+    # if $1 is formatted dir///other//stuff,
+    # split into LEAD_DIR=dir RES=other//stuff
+    # also checks if $1/LEAD_DIR is a directory, not just for syntax
+    try_trim_leading_dir () {
+        local basepath=$1 string=$2
+        local all_ifs=false
+        LEAD_DIR=
+        REST=
+        if echo "$string" | grep '/' >/dev/null; then
+            # lmao, the sed command is replace 1 or more slashes with just 1 slash
+            LEAD_DIR=$(echo "$string" | sed 's/\/\/*/\//' | cut -d '/' -f 1)
+            if [ "$LEAD_DIR" != build ] && [ -d "$basepath/$LEAD_DIR" ]; then
+                all_ifs=true
+                REST=$(echo "$string" | sed 's/\/\/*/\//' | cut -d '/' -f 2-)
+            fi
+        fi
+
+        [ "$all_ifs" = true ] && return 0
+        return 1
+    }
+
+
+
+
+    # more like subroutines for redo_completion_helper
+
+    synchronous_work () {
+        compgen_arg=$(words_cache_save "$path")
+        RES=$(compgen -W "$compgen_arg" "$arg")
+    }
+
+    async_work () {
+        words_cache_save "$path" >/dev/null
+    }
+
+    # we `prepend_path` every branch, except for when `compgen -d` does it for us
+    prepend_path () {
+        if [ $path != . ] && [ -n "$RES" ]; then
+            RES=$(echo "$RES" | prepend "$path/")
+        fi
+    }
+
+    # main helper function
+    redo_completion_helper () {
+        local path=$1 arg=$2
+
+        if pwd | grep '/build$' >/dev/null || ! what_predef_parsed "$path" >/dev/null; then
+            # nothing to do here, `redo what` isn't even available
+        #     echo - dip
+            return 1
+        fi
+
+        # clean up $path / $arg -- replace instances of ./ with nothing
+        path=$(echo "$path" | sed 's/\b\.\///')
+        arg=$(echo "$arg" | sed 's/\b\.\///')
+        [ "$arg" = . ] && arg=./ # just bc the user must have typed it in
+
+        # path only gets edited when we recurse, so this is safe
+        save_last_confirmed_dir "$path"
+
+
+        # return value
+        RES=
+
+        # locals
+        local compgen_arg first_run=false
+        if dir_first_visit "$path"; then
+            first_run=true
+            dir_cache_save "$path"
+        fi
+
+        # echo - "enter: path=($path) arg=($arg) first_run=$first_run"
+    
+        # overview:
+        # if typed `redo <tab>` or `redo path/<tab>`, run `redo what` synchronously
+        # check word cache (fallback to `redo what_predefined`)
+        # -> if match, use the result and update caches in background
+        # if no matches yet, check for redo's path syntax
+        # -> if match, recurse using subdirectory
+        # if still no matches, match against directory names
+        # if *still* no matches, and cache is outdated, synchronously run `redo what`
+        # return regardless of matches
+
+
+        # I assume that if someone types `redo <tab>`,
+        # they probably want an up-to-date list of commands
+        # but if someone types `redo b<tab>` for example,
+        # they probably intended to autocomplete build/
+        # which is likely still available, and useful to provide instantly
+
+        # if typed `redo <tab>` and cache is outdated, bypass cache
+        if [ "$first_run" = true ] && [ -z "$arg" ]; then
+            synchronous_work
+            prepend_path
+            return 0
+        fi
+
+
+        if words_cache_ok "$path"; then
+            compgen_arg=$(cat "$path"/build/redo/what_cache.txt)
+        #     echo - '> cache ok'
         else
             # fallback to `redo what_predefined`
-            compgen_arg=$(__what_predef_parsed)
+            compgen_arg=$(what_predef_parsed "$path")
+        #     echo - '> cache fallback to what_predef'
         fi
 
-        # use cache for responsiveness
-        # but make sure a background task is fetching up-to-date results
+        # generate completions
+        RES=$(compgen -W "$compgen_arg" "$arg")
 
+        if [ -n "$RES" ]; then
 
-        compgen_res=$(compgen -W "$compgen_arg" "$this_word")
+        #     echo - '> used cache'
 
-        # if nothing in cache matches, do synchronous anyway (but only on first run to make it responsive)
-        if [ "$first_run" = true ] && [ -z "$compgen_res" ]; then
-            do_synch=true
-        elif ! ps p "$__redo_what_bg_pid" >/dev/null 2>&1; then
-            # pid is not alive, so start bg process
-            (__do_caching >/dev/null &)
-            __redo_what_bg_pid=$!
+            (async_work &)
+
+            prepend_path
+            return 0
         fi
 
+        # echo - '> cache miss'
+
+        # no match, so check for a directory prefix
+        if try_trim_leading_dir "$path" "$arg"; then
+            # found directory, so recurse "into" it
+
+            # these are set by try_trim_leading_dir
+            local dir_prefix=$LEAD_DIR trimmed_arg=$REST
+
+        #     echo - "arg ($arg) vs trimmed halves ($dir_prefix) ($trimmed_arg)"
+
+            # keep paths as clean as possible to prevent stacking
+            # potential todo: detect if user deliberately typed "." and if so, keep
+            if [ "$path" = . ]; then
+                path=$dir_prefix
+            else
+                path=$path/$dir_prefix
+            fi
+
+        #     echo - "> recurse: path ($path) arg ($trimmed_arg)"
+
+
+            redo_completion_helper "$path" "$trimmed_arg"
+            local status=$?
+
+            return $status
+        fi
+
+        # echo - '> no recurse'
+
+        # echo - pre-full arg: "path ($path) arg ($arg)"
+        # match against directories in $path
+        local full_arg
+        if [ "$path" = . ]; then
+            full_arg=$arg
+        elif [ -z "$arg" ]; then
+            full_arg=$path
+        else
+            full_arg=$path/$arg
+        fi
+        RES=$(compgen -d "$full_arg" | grep -v '\bbuild\b' | sed 's/$/\//')
+
+        # echo - full arg: $full_arg
+
+        if [ -n "$RES" ]; then
+        #     echo - '> matched compgen -d'
+            # we have a match, may as well start a bg task in this dir
+            (async_work &)
+
+            # don't prepend path, `compgen -d` provides full path names
+            # (since we never `cd` even on recursive calls)
+
+            return 0
+        fi
+
+        # echo - '> synchronous time'
+
+        # now there's really nothing to match
+        # so do synchronous anyway, but only on first run
+        # this is useful for i.e. autocompleting build/ in a directory for the first time after making a .component.yaml file
+        if [ "$first_run" = true ]; then
+            synchronous_work
+            prepend_path
+            return 0
+        fi
+    }
+
+
+
+    # subroutine for below
+    local subdir trimmed_arg
+    try_cached_dir () {
+        subdir= trimmed_arg=
+        local all_ifs=false
+        if get_last_confirmed_dir; then
+            local lastdir=$LAST_DIR
+
+            # check if arg starts with dir
+            if echo "$this_word" | grep "^$lastdir" >/dev/null; then
+                subdir=$lastdir
+
+                # the #*$ bit trims a prefix off the left string
+                trimmed_arg=$(echo "${this_word#*$subdir}" | sed 's/^\///')
+                all_ifs=true
+
+    #             echo - "last confirmed: subdir=$subdir trimmed_arg=$trimmed_arg"
+            fi
+        fi
+        [ "$all_ifs" = true ] && return 0 || return 1
+    }
+
+
+
+
+    # end definitions, start running stuff
+
+    # helps us figure out whether re-running `redo what` is a waste
+    # if first_run=true then the user might have run commands 
+    # which might change the output of `redo what`
+    if [ $first_run = true ]; then
+        dir_cache_clean
     fi
 
+    local cmdname=$1 this_word=$2 prev_word=$3
 
 
+    # call helper function
 
-    if [ $do_synch = true ]; then
-        compgen_arg=$(__do_caching)
-        compgen_res=$(compgen -W "$compgen_arg" "$this_word")
+    # helper function sets the RES variable
+    if [ "$first_run" = false ] && try_cached_dir; then
+        # this saves a few recursions 
+        # see recursion in helper function for when this gets cached
+    #     echo - "> insta-recurse"
+        redo_completion_helper "$subdir" "$trimmed_arg"
+    else
+        redo_completion_helper . "$this_word"
     fi
 
+    if [ $? = 0 ]; then
+        # if it ends with a slash, it's a path
+        # so if it doesn't end with a slash, we should add a space to it
+        if [ -n "$RES" ] && ! echo "$RES" | grep '/$' >/dev/null; then
+            RES=$(echo "$RES" | sed 's/$/ /')
+        fi
 
-    # this variable is basically the return value for `complete`
-    COMPREPLY=($compgen_res)
+        # split into bash array based on newline, not any whitespace (precaution)
+        oldifs=$IFS
+        IFS="
+"
+        COMPREPLY=($RES)
+        IFS=$oldifs
+        unset oldifs
+    fi
 
-    # sets $_ -- see top of function
+    unset -f redo_cmd_parsed what_parsed what_predef_parsed words_cache_ok words_cache_save dir_first_visit dir_cache_save dir_cache_clean save_last_confirmed_dir get_last_confirmed_dir prepend try_trim_leading_dir synchronous_work async_work prepend_path redo_completion_helper try_cached_dir
+    
+    # must be very last command, see top
     echo $special_arg > /dev/null
 }
 
-complete -F __redo_completion redo
+# the reason we can't use `complete -o dirnames` is that
+# we need to exclude ./build (and want to exclude hidden dirs)
+complete -o nospace -o nosort -F __redo_completion redo
+
 

--- a/env/redo_completion.sh
+++ b/env/redo_completion.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+# takes in an argument, likely `what` or `what_predefined`
+__redo_cmd_parsed () {
+    redo "$1" 2>&1 | tail +2 | sed 's/^redo //' | sed 's/\n/ /' | echo "$(cat -)
+what" | grep -v "^$"
+    return ${PIPESTATUS[0]} # i.e. status of redo what
+}
+
+__what_parsed () {
+    __redo_cmd_parsed what
+}
+
+__what_predef_parsed () {
+    __redo_cmd_parsed what_predefined
+}
+
+__do_caching () {
+    local res status
+    res="$(__what_parsed)"
+    status=$?
+    echo $res
+    [ "$status" = 0 ] || return 2
+    mkdir -p ./build/redo && echo "$res" > ./build/redo/whatcache.txt
+    [ "$?" = 0 ] || return 1
+    return 0
+}
+
+
+__cache_ok () {
+    [ -f ./build/redo/whatcache.txt ] || return 1
+    [ -n "$(cat ./build/redo/whatcache.txt)" ] || return 1
+    # check for file integrity, timestamp, etc?
+    return 0
+}
+
+__redo_completion () {
+    # $_ is set to the argument of the last executed command
+    # on the first run, it will depend on what the user just ran
+    # the second run onwards, it will be set to $special_arg
+    # this function runs once after every tab completion,
+    # so we can use this to detect whether this is the user's first tab press
+
+    local underscore=$_ # must be very first command
+    local special_arg=____redo_completion_special_arg
+
+    local first_run=false
+    [ "$underscore" != "$special_arg" ] && first_run=true
+
+    local cmdname=$1
+    local this_word=$2
+    local prev_word=$3
+
+    # echo
+    # echo cmdname = $cmdname
+    # echo this_word = $this_word
+    # echo prev_word = $prev_word
+    # echo first_run = $first_run
+
+    local compgen_arg compgen_res
+    local do_synch=false
+
+
+    # I assume that
+    # if someone types `redo <tab>`,
+    # they probably want an up-to-date list of commands
+    # but if someone types `redo b<tab>` for example,
+    # they probably intended to autocomplete build/
+    # which is likely still available, and useful to provide instantly
+
+    # if cache is unavailable,
+    # or if typed `redo <tab>`
+    # bypass cache
+    if [ "$first_run" = true ] &&
+        [ -z "$this_word" ] &&        # blank first arg
+        [ "$prev_word" = "$cmdname" ] # no previous args
+    then
+        # do synchronous run
+        do_synch=true
+    else
+        if __cache_ok; then
+            compgen_arg=$(cat ./build/redo/whatcache.txt)
+        else
+            # fallback to `redo what_predefined`
+            compgen_arg=$(__what_predef_parsed)
+        fi
+
+        # use cache for responsiveness
+        # but make sure a background task is fetching up-to-date results
+
+
+        compgen_res=$(compgen -W "$compgen_arg" "$this_word")
+
+        # if nothing in cache matches, do synchronous anyway (but only on first run to make it responsive)
+        if [ "$first_run" = true ] && [ -z "$compgen_res" ]; then
+            do_synch=true
+        elif ! ps p "$__redo_what_bg_pid" >/dev/null 2>&1; then
+            # pid is not alive, so start bg process
+            (__do_caching >/dev/null &)
+            __redo_what_bg_pid=$!
+        fi
+
+    fi
+
+
+
+
+    if [ $do_synch = true ]; then
+        compgen_arg=$(__do_caching)
+        compgen_res=$(compgen -W "$compgen_arg" "$this_word")
+    fi
+
+
+    # this variable is basically the return value for `complete`
+    COMPREPLY=($compgen_res)
+
+    # sets $_ -- see top of function
+    echo $special_arg > /dev/null
+}
+
+complete -F __redo_completion redo
+

--- a/redo/rules/build_what.py
+++ b/redo/rules/build_what.py
@@ -3,6 +3,7 @@ import os.path
 import sys
 from base_classes.build_rule_base import build_rule_base
 from os import environ
+from rules.build_what_predefined import get_predefined_targets
 
 
 # This build rule lists all the known redo targets that
@@ -26,24 +27,7 @@ class build_what(build_rule_base):
             return sorted(set(lst), key=lambda x: lst.index(x))
 
         # Define the special targets that exist everywhere...
-        redo_targets = [
-            "all",
-            # "path",
-            # "recursive",
-            "clean",
-            "clean_all",
-            "clear_cache",
-            "templates",
-            "publish",
-            "targets",
-            "prove",
-            "analyze",
-            "style",
-            "pretty",
-            "test_all",
-            "coverage_all",
-            "style_all",
-        ]
+        redo_targets = get_predefined_targets()
         directory = os.path.dirname(redo_1)
         with redo_target_database() as db:
             try:

--- a/redo/rules/build_what_predefined.py
+++ b/redo/rules/build_what_predefined.py
@@ -1,0 +1,41 @@
+
+from base_classes.build_rule_base import build_rule_base
+import sys
+
+
+def get_predefined_targets() -> list:
+    '''List of `redo` targets that can be run from anywhere in the repository.'''
+    return [
+        "all",
+        # "path",
+        # "recursive",
+        "clean",
+        "clean_all",
+        "clear_cache",
+        "templates",
+        "publish",
+        "targets",
+        "prove",
+        "analyze",
+        "style",
+        "pretty",
+        "test_all",
+        "coverage_all",
+        "style_all",
+    ]
+
+
+class build_what_predefined(build_rule_base):
+    '''Lists all redo targets which will be available in any subdirectory
+    of the project base folder. See `build_what`.
+    '''
+
+    # no need to access database
+    def build(self, redo_1, redo_2, redo_3):
+        self._build(redo_1, redo_2, redo_3)
+
+    def _build(self, redo_1, redo_2, redo_3):
+        redo_targets = sorted(get_predefined_targets())
+        sys.stderr.write(
+            "redo " + "\nredo ".join(sorted(redo_targets)) + "\n"
+        )


### PR DESCRIPTION
Create the redo command `redo what_predefined`, which displays the commands listed in `redo what` which will always be listed regardless of the subdirectory of the project you're in.