### PR TITLE
Adding C++ compiler options to gpr files

### DIFF
--- a/env/activate
+++ b/env/activate
@@ -148,6 +148,16 @@ for path in "${paths[@]}"; do
   #
   eval `alr -n printenv | grep PATH`
 
+  # Set up the LD_LIBRARY_PATH so that it also includes the libraries that come
+  # with the alr native compiler.
+  eval `alr -n printenv | grep GNAT_NATIVE_ALIRE_PREFIX`
+  if [ -n "$GNAT_NATIVE_ALIRE_PREFIX" ]; then
+      # Check if $GNAT_NATIVE_ALIRE_PREFIX/lib64 is already in LD_LIBRARY_PATH
+      if [[ ":$LD_LIBRARY_PATH:" != *":$GNAT_NATIVE_ALIRE_PREFIX/lib64:"* ]]; then
+          export LD_LIBRARY_PATH="$GNAT_NATIVE_ALIRE_PREFIX/lib64:$LD_LIBRARY_PATH"
+      fi
+  fi
+
   # Activate the local python configuration:
   . $ADAMANT_DIR/env/set_python_path.sh $path
 

--- a/redo/targets/gpr/a_bareboard_base.gpr
+++ b/redo/targets/gpr/a_bareboard_base.gpr
@@ -21,6 +21,10 @@ abstract project a_bareboard_base extends all "a_adamant.gpr" is
          -- debug flags
          ("-g");
 
+      for Switches ("C++") use a_adamant.Compiler'Switches ("C++") &
+         -- debug flags
+         ("-g");
+
       for Switches ("Asm_Cpp") use a_adamant.Compiler'Switches ("Asm_Cpp") &
          -- debug flags
          ("-g");

--- a/redo/targets/gpr/a_bareboard_debug.gpr
+++ b/redo/targets/gpr/a_bareboard_debug.gpr
@@ -12,11 +12,15 @@ abstract project a_bareboard_debug extends all "a_bareboard_base.gpr" is
          -- -gnata - assertions are enabled
          ("-gnato", "-gnata") &
          -- Turn on ALL validity checking, not just that which is specified in the Ada Reference Manual.
-         -- This combined with Initialize_Scalars, below, greatly aids in discovering uninitializated 
+         -- This combined with Initialize_Scalars, below, greatly aids in discovering uninitializated
          -- variable bugs.
          ("-gnatVa");
 
       for Switches ("C") use a_bareboard_base.Compiler'Switches ("C") &
+         -- optimization
+         ("-O0");
+
+      for Switches ("C++") use a_bareboard_base.Compiler'Switches ("C++") &
          -- optimization
          ("-O0");
 

--- a/redo/targets/gpr/a_bareboard_development.gpr
+++ b/redo/targets/gpr/a_bareboard_development.gpr
@@ -4,13 +4,13 @@ abstract project a_bareboard_development extends all "a_bareboard_production.gpr
    -- for targets Debug and under
    package Compiler is
       -- Add preprocessor definitions and configuration pragma switches:
-      for Switches ("Ada") use a_bareboard_production.Compiler'Switches ("Ada") & 
+      for Switches ("Ada") use a_bareboard_production.Compiler'Switches ("Ada") &
          -- Turn on assertions and numeric overflow checking:
          -- -gnato - enable numeric overflow checking
          -- -gnata - assertions are enabled
          ("-gnato", "-gnata") &
          -- Turn on ALL validity checking, not just that which is specified in the Ada Reference Manual.
-         -- This combined with Initialize_Scalars, below, greatly aids in discovering uninitializated 
+         -- This combined with Initialize_Scalars, below, greatly aids in discovering uninitializated
          -- variable bugs.
          ("-gnatVa");
    end Compiler;

--- a/redo/targets/gpr/a_linux_debug_base.gpr
+++ b/redo/targets/gpr/a_linux_debug_base.gpr
@@ -6,7 +6,7 @@ abstract project a_linux_debug_base extends all "a_adamant.gpr" is
       -- Add preprocessor definitions and configuration pragma switches:
       for Switches ("Ada") use a_adamant.Compiler'Switches ("Ada") &
          -- optimization
-         ("-O0") & 
+         ("-O0") &
          -- debug flags
          ("-g") &
          -- dynamic stack checking
@@ -16,7 +16,7 @@ abstract project a_linux_debug_base extends all "a_adamant.gpr" is
          -- -gnata - assertions are enabled
          ("-gnato", "-gnata") &
          -- Turn on ALL validity checking, not just that which is specified in the Ada Reference Manual.
-         -- This combined with Initialize_Scalars, below, greatly aids in discovering uninitializated 
+         -- This combined with Initialize_Scalars, below, greatly aids in discovering uninitializated
          -- variable bugs.
          ("-gnatVa") &
          -- Define Initialize_Scalars pragma to allow better detection of unitizialized variable bugs.
@@ -24,13 +24,13 @@ abstract project a_linux_debug_base extends all "a_adamant.gpr" is
 
       for Switches ("C") use a_adamant.Compiler'Switches ("C") &
          -- optimization
-         ("-O0") & 
+         ("-O0") &
          -- debug flags
          ("-g");
 
       for Switches ("Asm_Cpp") use a_adamant.Compiler'Switches ("Asm_Cpp") &
          -- optimization
-         ("-O0") & 
+         ("-O0") &
          -- debug flags
          ("-g");
    end Compiler;


### PR DESCRIPTION
C++ compiler options are now consistent with C compiler options in the Adamant provided gpr file. This PR also includes:

- some white space fixes to gpr file
- modifying `$LD_LIBRARY_PATH` path in `activate` script to fix GLIBC linking issue that sometimes occurred when compiling C++