### PR TITLE
Disable the model cache by default

### DIFF
--- a/doc/user_guide/user_guide.tex
+++ b/doc/user_guide/user_guide.tex
@@ -474,7 +474,7 @@ Adamant also provides a set of build commands that can be used in almost any pro
   \item \textbf{\texttt{redo recursive}} - runs \texttt{redo all} from this directory and all below it
   \item \textbf{\texttt{redo clean}} - removes all \textit{build/} directories from this directory and all below it
   \item \textbf{\texttt{redo clean\_all}} - removes all \textit{build/} directories from this entire repository
-  \item \textbf{\texttt{redo clear\_cache}} - remove the model cache that the build system uses to increase performance, see Section \ref{The Model Cache}
+  \item \textbf{\texttt{redo clear\_cache}} - remove the persistent model cache that the build system uses to increase performance, see Section \ref{The Model Cache}
   \item \textbf{\texttt{redo templates}} - finds and builds all autocoded templates (in \textit{build/template/}) that can be built from this directory
   \item \textbf{\texttt{redo test\_all}} - finds and runs all unit tests from this directory an all below it. Note: Add a \textit{.skip\_test} file to a directory to exclude it from being run by \texttt{redo test\_all}.
   \item \textbf{\texttt{redo coverage\_all}} - finds and runs all unit tests from this directory an all below it and generates coverage reports for each. Note: Add a \textit{.skip\_test} or \textit{.skip\_coverage} file to a directory to exclude it from being run by \texttt{redo coverage\_all}.
@@ -534,13 +534,13 @@ For more \texttt{redo} options you can run:
 \end{minted}
 \vspace{5mm} %5mm vertical space
 
-Very rarely, \texttt{redo} can get itself into an unknown state. If things are not behaving correctly you can wipe out the redo database, and force things to rebuild fresh, which often fixes any issues that arise.To be safe, you can also remove the model cache that the build system uses to increase performance. The best procedure to do this is:
+Very rarely, \texttt{redo} can get itself into an unknown state. If things are not behaving correctly you can wipe out the redo database, and force things to rebuild fresh, which often fixes any issues that arise. To be safe, you can also remove the model cache that the build system uses to increase performance. The best procedure to do this is:
 
 \vspace{5mm} %5mm vertical space
 \begin{minted}{text}
 > rm -rf ~/.redo      # remove the redo database
 > redo clean_all      # clean the entire repository
-> redo clear_cache    # remove the model cache
+> redo clear_cache    # remove the model cache if ENABLE_PERSISTENT_MODEL_CACHE is set
 > redo <your_command> # retry the redo command that was not working
 \end{minted}
 \vspace{5mm} %5mm vertical space
@@ -6769,6 +6769,17 @@ The default behavior of the Adamant build system is provided by the \textit{.do}
 Note that adding some build rules, such as compiling for a new programming language, will require more work than the procedure presents above. In that case, it is recommended to understand the \textit{set up} and \textit{database} portions of the build system located in \textit{redo/database}.
 
 \subsubsection{Model Caching} \label{The Model Cache}
+
+\textit{Note: The Adamant persistent model cache is currently disabled by default due to some instability in its behavior. If you want to use this experimental feature you can enable it via:}
+
+\vspace{5mm} %5mm vertical space
+\begin{minted}{text}
+> export ENABLE_PERSISTENT_MODEL_CACHE=1
+\end{minted}
+\vspace{5mm} %5mm vertical space
+
+\textit{but be aware that sometimes the cache may not always be refreshed correctly when dependencies change, and clearing the cache manually might be needed (see below). The description below applies if this feature is enabled.}
+\vspace{5mm} %5mm vertical space
 
 When building a target, the Adamant build system spends a lot of time reading YAML models from the file system, validating them, and then using them to generate outputs. Since most of these models do not change often on disk, the build system caches them in a database in \textit{/temp} to speed up build times. It is important when designing python models to correctly track the dependencies so that cached entries can be refreshed when a YAML model, or a YAML model's dependency, has changed. To do this, ensure that your python model correctly implements the \texttt{get\_dependencies} method, which should return a list of all YAML files that the current YAML file depends on. For example, a \texttt{*.component.yaml} always depends on its IDed entity models: \texttt{*.data\_products.yaml}, \texttt{*.data\_commands.yaml}, etc. \\
 

--- a/redo/database/model_cache_database.py
+++ b/redo/database/model_cache_database.py
@@ -3,6 +3,7 @@ from database.database import DATABASE_MODE
 from time import time as curr_time
 from os import environ, sep
 from util import model_loader
+from database.util import get_database_file
 
 # The purpose of the model cache is to save off YAML file model load
 # data structures after they have been read from a file, validated, and
@@ -13,8 +14,17 @@ from util import model_loader
 
 
 def get_model_cache_filename():
-    cache_file = environ["ADAMANT_TMP_DIR"] + sep + "model_cache.db"
-    return cache_file
+    # Decide whether or not to use a persistent or non-persistent model cache.
+    # A persistent model cache that lasts over calls to redo is faster, but
+    # is not stable and potentially buggy. persistent model cache is disabled
+    # by default.
+    if "ENABLE_PERSISTENT_MODEL_CACHE" in environ:
+        # Model cache is persistent over calls to redo (faster):
+        cache_file = environ["ADAMANT_TMP_DIR"] + sep + "model_cache.db"
+        return cache_file
+    else:
+        # Model cache is recreated for each call to redo (safer):
+        return get_database_file("model_cache")
 
 
 class model_cache_database(database):


### PR DESCRIPTION
This feature, while making builds faster, is unstable and produces a lot of hard to diagnose issues. I am disabling this for now. It can be enabled by setting the environment variable ENABLE_PERSISTANT_MODEL_CACHE to 1 manually. We can revisit this in the future if we want to re-enable.

This change forces Adamant to rebuild a new model cache with each call to redo instead of allowing it to persist over subsequent calls. Within a single redo call, the cache is still used to ensure a yaml file is only ever read from disk once maximum per call.