### PR TITLE
Updating github actions to use root user

### DIFF
--- a/.github/workflows/build_user_guide.yml
+++ b/.github/workflows/build_user_guide.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/lasp/adamant:latest
+      options: --user root
     steps:
       - run: echo "Starting job triggered by a ${{ github.event_name }} event on a ${{ runner.os }} server hosted by GitHub."
       - run: echo "Checking out ${{ github.repository }} on branch ${{ github.ref }}."

--- a/.github/workflows/publish_all.yml
+++ b/.github/workflows/publish_all.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/lasp/adamant:latest
+      options: --user root
     steps:
       - run: echo "Starting job triggered by a ${{ github.event_name }} event on a ${{ runner.os }} server hosted by GitHub."
       - run: echo "Checking out ${{ github.repository }} on branch ${{ github.ref }}."

--- a/.github/workflows/style_all.yml
+++ b/.github/workflows/style_all.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/lasp/adamant:latest
+      options: --user root
     steps:
       - run: echo "Starting job triggered by a ${{ github.event_name }} event on a ${{ runner.os }} server hosted by GitHub."
       - run: echo "Checking out ${{ github.repository }} on branch ${{ github.ref }}."

--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/lasp/adamant:latest
+      options: --user root
     steps:
       - run: echo "Starting job triggered by a ${{ github.event_name }} event on a ${{ runner.os }} server hosted by GitHub."
       - run: echo "Checking out ${{ github.repository }} on branch ${{ github.ref }}."


### PR DESCRIPTION
Since we now set the user to `user` at the end of the Dockerfile, we need to force GitHub to use the root user while running actions.