### PR TITLE
`not_null` option in component init and discriminant parameters

### DIFF
--- a/doc/example_architecture/discriminated_component/discriminated_component.component.yaml
+++ b/doc/example_architecture/discriminated_component/discriminated_component.component.yaml
@@ -11,6 +11,8 @@ discriminant:
     - name: packets_Per_Tick
       # Required - parameter type
       type: Natural
+      # Optional - puts "not null" in front of the type. Defaults to false, and only should be used for access types
+      not_null: false
       # Optional - parameter description
       description: The number of packets to send every time the Tick_T_Recv_Sync connector is invoked.
     - name: enabled_At_Startup

--- a/doc/example_architecture/initialized_component/initialized_component.component.yaml
+++ b/doc/example_architecture/initialized_component/initialized_component.component.yaml
@@ -11,6 +11,8 @@ init:
     - name: Packets_Per_Tick
       # Required - parameter type
       type: Natural
+      # Optional - puts "not null" in front of the type. Defaults to false, and only should be used for access types
+      not_null: false
       # Optional - parameter description
       description: The number of packets to send every time the Tick_T_Recv_Sync connector is invoked.
     - name: Enabled_At_Startup

--- a/gen/models/submodels/discriminant.py
+++ b/gen/models/submodels/discriminant.py
@@ -26,12 +26,16 @@ class discriminant(subprogram):
                     description = self._data["discriminant"]["description"]
                 if "parameters" in self._data["discriminant"]:
                     for par in self._data["discriminant"]["parameters"]:
+                        par_not_null = False
+                        if "not_null" in par:
+                            par_not_null = par["not_null"]
                         parameters.append(
                             parameter(
                                 name=par["name"],
                                 type=par["type"],
                                 value=None,
                                 description=par["description"],
+                                not_null=par_not_null,
                             )
                         )
 

--- a/gen/models/submodels/init.py
+++ b/gen/models/submodels/init.py
@@ -27,6 +27,9 @@ class init(subprogram):
                 par_desc = None
                 if "description" in par:
                     par_desc = par["description"]
+                par_not_null = False
+                if "not_null" in par:
+                    par_not_null = par["not_null"]
                 parameters.append(
                     parameter(
                         name=par["name"],
@@ -34,6 +37,7 @@ class init(subprogram):
                         value=None,
                         default_value=default_value,
                         description=par_desc,
+                        not_null=par_not_null,
                     )
                 )
 

--- a/gen/models/submodels/parameter.py
+++ b/gen/models/submodels/parameter.py
@@ -4,7 +4,7 @@ from models.submodels.variable import variable
 class parameter(variable):
     """This class holds data concerning a parameter."""
     def __init__(
-        self, name, type, description=None, mode="in", value=None, default_value=None
+        self, name, type, description=None, mode="in", value=None, default_value=None, not_null=False
     ):
         self.mode = mode
 
@@ -15,6 +15,7 @@ class parameter(variable):
             description=description,
             value=value,
             default_value=default_value,
+            not_null=not_null,
         )
 
     ################################
@@ -25,6 +26,7 @@ class parameter(variable):
             self.name
             + " : "
             + (self.mode + " " if include_mode else "")
+            + ("not null " if self.not_null else "")
             + self.type
             + (" := " + self.default_value if self.default_value else "")
         )

--- a/gen/models/submodels/variable.py
+++ b/gen/models/submodels/variable.py
@@ -64,7 +64,7 @@ class datatype(object):
 
 class variable(object):
     """Class holding information related to an Ada variable"""
-    def __init__(self, name, type, description=None, value=None, default_value=None):
+    def __init__(self, name, type, description=None, value=None, default_value=None, not_null=False):
         self.name = ada.formatVariable(name)
         self.datatype = datatype(name=type)
         self.description = description
@@ -73,6 +73,7 @@ class variable(object):
         # Default value of variable, usually set by model, and used as default initialization
         # in subprogram definitions:
         self.default_value = ada.formatValue(default_value)
+        self.not_null = not_null
 
     ################################
     # Properties:
@@ -160,6 +161,7 @@ class variable(object):
         return (
             self.name
             + " : "
+            + ("not null " if self.not_null else "")
             + self.type
             + (" := " + str(self.default_value) if str(self.default_value) else "")
         )

--- a/gen/schemas/component.yaml
+++ b/gen/schemas/component.yaml
@@ -100,6 +100,10 @@ mapping:
               type:
                 type: str
                 required: True
+              # Whether the initialization parameter can be set to null.
+              not_null:
+                type: bool
+                required: False
         required: False
     required: False
   # User defined initialization method. This method should allocate any memory on the heap
@@ -132,7 +136,7 @@ mapping:
               default:
                 type: str
                 required: False
-              # Whether a parameter can be set to null.
+              # Whether the parameter can be set to null.
               not_null:
                 type: bool
                 required: False

--- a/gen/schemas/component.yaml
+++ b/gen/schemas/component.yaml
@@ -132,6 +132,10 @@ mapping:
               default:
                 type: str
                 required: False
+              # Whether a parameter can be set to null.
+              not_null:
+                type: bool
+                required: False
         required: False
     required: False
   # If the component services an interrupt, it should be documented here.

--- a/src/components/ccsds_downsampler/ccsds_downsampler.component.yaml
+++ b/src/components/ccsds_downsampler/ccsds_downsampler.component.yaml
@@ -10,6 +10,7 @@ init:
   parameters:
     - name: Downsample_List
       type: Ccsds_Downsampler_Types.Ccsds_Downsample_Packet_List_Access
+      not_null: true
       description: The list of APIDs that are to be downsampled and the initial filter factor associated with those APIDs.
 connectors:
   - description: This connector is the input connector for the packets that are coming in. This is where packets are checked for filtering.

--- a/src/components/ccsds_downsampler/component-ccsds_downsampler-implementation.adb
+++ b/src/components/ccsds_downsampler/component-ccsds_downsampler-implementation.adb
@@ -81,10 +81,9 @@ package body Component.Ccsds_Downsampler.Implementation is
    -- Init Parameters:
    -- Downsample_List : Ccsds_Downsampler_Types.Ccsds_Downsample_Packet_List_Access - The list of APIDs that are to be downsampled and the initial filter factor associated with those APIDs.
    --
-   overriding procedure Init (Self : in out Instance; Downsample_List : in Ccsds_Downsampler_Types.Ccsds_Downsample_Packet_List_Access) is
+   overriding procedure Init (Self : in out Instance; Downsample_List : in not null Ccsds_Downsampler_Types.Ccsds_Downsample_Packet_List_Access) is
    begin
-      -- Make sure that we have an initial list and that its not null
-      pragma Assert (Downsample_List /= null, "Downsampler init list cannot be null.");
+      -- Make sure that we have an non-empty initial list
       pragma Assert (Downsample_List'Length /= 0, "Downsampler init list cannot be empty.");
       -- For each item in the list, add the apid and filter factor to the internal tree
       Self.Apid_Entries.Init (Downsample_List);

--- a/src/components/ccsds_downsampler/component-ccsds_downsampler-implementation.ads
+++ b/src/components/ccsds_downsampler/component-ccsds_downsampler-implementation.ads
@@ -24,7 +24,7 @@ package Component.Ccsds_Downsampler.Implementation is
    -- Init Parameters:
    -- Downsample_List : Ccsds_Downsampler_Types.Ccsds_Downsample_Packet_List_Access - The list of APIDs that are to be downsampled and the initial filter factor associated with those APIDs.
    --
-   overriding procedure Init (Self : in out Instance; Downsample_List : in Ccsds_Downsampler_Types.Ccsds_Downsample_Packet_List_Access);
+   overriding procedure Init (Self : in out Instance; Downsample_List : in not null Ccsds_Downsampler_Types.Ccsds_Downsample_Packet_List_Access);
 
 private
    -- Helper procedure that will take a tree entry and create a data product for the filter factor

--- a/src/components/ccsds_product_extractor/ccsds_product_extractor.component.yaml
+++ b/src/components/ccsds_product_extractor/ccsds_product_extractor.component.yaml
@@ -10,6 +10,7 @@ init:
   parameters:
     - name: Data_Product_Extraction_List
       type: Product_Extractor_Types.Extracted_Product_List_Access
+      not_null: true
       description: The list of data products that will be extracted from packets.
 connectors:
   - description: The connector that will receive the CCSDS space packets and extract data products if necessary

--- a/src/components/ccsds_product_extractor/component-ccsds_product_extractor-implementation.adb
+++ b/src/components/ccsds_product_extractor/component-ccsds_product_extractor-implementation.adb
@@ -27,14 +27,12 @@ package body Component.Ccsds_Product_Extractor.Implementation is
    -- Init Parameters:
    -- Data_Product_Extraction_List : Product_Extractor_Types.Extracted_Product_List_Access - The list of data products that will be extracted from packets.
    --
-   overriding procedure Init (Self : in out Instance; Data_Product_Extraction_List : in Product_Extractor_Types.Extracted_Product_List_Access) is
+   overriding procedure Init (Self : in out Instance; Data_Product_Extraction_List : in not null Product_Extractor_Types.Extracted_Product_List_Access) is
       Add_Status : Boolean;
       Search_Status : Boolean;
       Fetched_Entry : Ccsds_Product_Apid_List;
       Ignore : Positive;
    begin
-      -- First make sure the list is not null
-      pragma Assert (Data_Product_Extraction_List /= null, "Initialization list for the product extractor cannot be null.");
       -- Allocate space for the table:
       Self.Extracted_Products_Tree.Init (Data_Product_Extraction_List'Length);
 

--- a/src/components/ccsds_product_extractor/component-ccsds_product_extractor-implementation.ads
+++ b/src/components/ccsds_product_extractor/component-ccsds_product_extractor-implementation.ads
@@ -20,7 +20,7 @@ package Component.Ccsds_Product_Extractor.Implementation is
    -- Init Parameters:
    -- Data_Product_Extraction_List : Product_Extractor_Types.Extracted_Product_List_Access - The list of data products that will be extracted from packets.
    --
-   overriding procedure Init (Self : in out Instance; Data_Product_Extraction_List : in Product_Extractor_Types.Extracted_Product_List_Access);
+   overriding procedure Init (Self : in out Instance; Data_Product_Extraction_List : in not null Product_Extractor_Types.Extracted_Product_List_Access);
 
    function Less_Than (Left, Right : Ccsds_Product_Apid_List) return Boolean with
       Inline => True;

--- a/src/components/command_sequencer/command_sequencer.component.yaml
+++ b/src/components/command_sequencer/command_sequencer.component.yaml
@@ -30,6 +30,7 @@ init:
       description: The size of the stack allocated for each engine in entries. Each stack entry contains a single running sequence, and additional stack entries can be used for subsequence calls. A value of 5 here would allow a sequence to call subsequences up to 5 levels deep.
     - name: Create_Sequence_Load_Command_Function
       type: Create_Sequence_Load_Command_Access
+      not_null: true
       description: When a sequence loads or spans or calls another sequence, the command sequencer will call this function to formulate the correct sequence load command for the assembly. Since the specifics of sequence loading often varies on a mission by mission basis, this function allows the encoding of that mission specific behavior by the user.
     - name: Packet_Period
       type: Interfaces.Unsigned_16

--- a/src/components/command_sequencer/component-command_sequencer-implementation.adb
+++ b/src/components/command_sequencer/component-command_sequencer-implementation.adb
@@ -48,7 +48,7 @@ package body Component.Command_Sequencer.Implementation is
    -- Timeout_Limit : Natural - The number of ticks to wait before timing out sequencer operations such as waiting on a command response or subsequence load. If a timeout of this type occurs the engine will transition to an error state. A value of zero disables these timeouts.
    -- Instruction_Limit : Positive - The maximum number of sequence instructions we allow the sequence to execute without hitting a pausing action such as sending a command, waiting on telemetry, or waiting for a relative or absolute time. The purpose of this parameter is to prevent a sequence from entering an infinite execution loop which would cause the entire component task to hang indefinitely. You should set the value to some maximum number of instructions that you never expect any of your compiled sequences to hit.
    --
-   overriding procedure Init (Self : in out Instance; Num_Engines : in Seq_Types.Num_Engines_Type; Stack_Size : in Seq_Types.Stack_Depth_Type; Create_Sequence_Load_Command_Function : in Create_Sequence_Load_Command_Access; Packet_Period : in Interfaces.Unsigned_16; Continue_On_Command_Failure : in Boolean; Timeout_Limit : in Natural; Instruction_Limit : in Positive) is
+   overriding procedure Init (Self : in out Instance; Num_Engines : in Seq_Types.Num_Engines_Type; Stack_Size : in Seq_Types.Stack_Depth_Type; Create_Sequence_Load_Command_Function : in not null Create_Sequence_Load_Command_Access; Packet_Period : in Interfaces.Unsigned_16; Continue_On_Command_Failure : in Boolean; Timeout_Limit : in Natural; Instruction_Limit : in Positive) is
    begin
       -- Allocate an array of engines and timeout counters:
       pragma Assert (Num_Engines < 255, "255 means 'any' engine and thus we cannot create a 255th engine.");
@@ -72,7 +72,6 @@ package body Component.Command_Sequencer.Implementation is
       Self.Packet_Period := Packet_Period;
 
       -- Set the create sequence load function:
-      pragma Assert (Create_Sequence_Load_Command_Function /= null);
       Self.Create_Sequence_Load_Command_Function := Create_Sequence_Load_Command_Function;
 
       -- Packet size assertions - make sure that we can fit all the data for the engines/sequence stack slots into

--- a/src/components/command_sequencer/component-command_sequencer-implementation.ads
+++ b/src/components/command_sequencer/component-command_sequencer-implementation.ads
@@ -34,7 +34,7 @@ package Component.Command_Sequencer.Implementation is
    -- Timeout_Limit : Natural - The number of ticks to wait before timing out sequencer operations such as waiting on a command response or subsequence load. If a timeout of this type occurs the engine will transition to an error state. A value of zero disables these timeouts.
    -- Instruction_Limit : Positive - The maximum number of sequence instructions we allow the sequence to execute without hitting a pausing action such as sending a command, waiting on telemetry, or waiting for a relative or absolute time. The purpose of this parameter is to prevent a sequence from entering an infinite execution loop which would cause the entire component task to hang indefinitely. You should set the value to some maximum number of instructions that you never expect any of your compiled sequences to hit.
    --
-   overriding procedure Init (Self : in out Instance; Num_Engines : in Seq_Types.Num_Engines_Type; Stack_Size : in Seq_Types.Stack_Depth_Type; Create_Sequence_Load_Command_Function : in Create_Sequence_Load_Command_Access; Packet_Period : in Interfaces.Unsigned_16; Continue_On_Command_Failure : in Boolean; Timeout_Limit : in Natural; Instruction_Limit : in Positive);
+   overriding procedure Init (Self : in out Instance; Num_Engines : in Seq_Types.Num_Engines_Type; Stack_Size : in Seq_Types.Stack_Depth_Type; Create_Sequence_Load_Command_Function : in not null Create_Sequence_Load_Command_Access; Packet_Period : in Interfaces.Unsigned_16; Continue_On_Command_Failure : in Boolean; Timeout_Limit : in Natural; Instruction_Limit : in Positive);
    not overriding procedure Final (Self : in out Instance);
 
 private

--- a/src/components/cpu_monitor/component-cpu_monitor-implementation.adb
+++ b/src/components/cpu_monitor/component-cpu_monitor-implementation.adb
@@ -24,15 +24,13 @@ package body Component.Cpu_Monitor.Implementation is
    -- packet_Period : Interfaces.Unsigned_16 - The period (in ticks) of how often to send out the cpu execution packet. A value of zero disable sending of the packet.
    --
    overriding procedure Init
-      (Self : in out Instance; Task_List : in Task_Types.Task_Info_List_Access; Interrupt_List : in Interrupt_Types.Interrupt_Id_List_Access; Execution_Periods : in Execution_Periods_Type := (1, 6, 30); Packet_Period : in Interfaces.Unsigned_16 := 1)
+      (Self : in out Instance; Task_List : in not null Task_Types.Task_Info_List_Access; Interrupt_List : in not null Interrupt_Types.Interrupt_Id_List_Access; Execution_Periods : in Execution_Periods_Type := (1, 6, 30); Packet_Period : in Interfaces.Unsigned_16 := 1)
    is
       use Task_Types;
       use Interrupt_Types;
       Period : Natural;
       Current_Up_Time : constant Time := Ada.Real_Time.Clock;
    begin
-      pragma Assert (Task_List /= null, "The task_List cannot be null.");
-      pragma Assert (Interrupt_List /= null, "The interrupt_List cannot be null.");
 
       -- Set component variables:
       Self.Tasks := Task_List;

--- a/src/components/cpu_monitor/component-cpu_monitor-implementation.ads
+++ b/src/components/cpu_monitor/component-cpu_monitor-implementation.ads
@@ -26,7 +26,7 @@ package Component.Cpu_Monitor.Implementation is
    -- execution_Periods : Execution_Periods_Type - The period (in ticks) that specify the duration of time that each CPU measurement is taken over.
    -- packet_Period : Interfaces.Unsigned_16 - The period (in ticks) of how often to send out the cpu execution packet. A value of zero disable sending of the packet.
    --
-   overriding procedure Init (Self : in out Instance; Task_List : in Task_Types.Task_Info_List_Access; Interrupt_List : in Interrupt_Types.Interrupt_Id_List_Access; Execution_Periods : in Execution_Periods_Type := (1, 6, 30); Packet_Period : in Interfaces.Unsigned_16 := 1);
+   overriding procedure Init (Self : in out Instance; Task_List : in not null Task_Types.Task_Info_List_Access; Interrupt_List : in not null Interrupt_Types.Interrupt_Id_List_Access; Execution_Periods : in Execution_Periods_Type := (1, 6, 30); Packet_Period : in Interfaces.Unsigned_16 := 1);
 
 private
 

--- a/src/components/cpu_monitor/cpu_monitor.component.yaml
+++ b/src/components/cpu_monitor/cpu_monitor.component.yaml
@@ -13,9 +13,11 @@ init:
   parameters:
     - name: task_List
       type: Task_Types.Task_Info_List_Access
+      not_null: true
       description: A list of task info records to monitor.
     - name: interrupt_List
       type: Interrupt_Types.Interrupt_Id_List_Access
+      not_null: true
       description: A list of task info records to monitor.
     - name: execution_Periods
       type: Execution_Periods_Type

--- a/src/components/last_chance_manager/component-last_chance_manager-implementation.adb
+++ b/src/components/last_chance_manager/component-last_chance_manager-implementation.adb
@@ -16,10 +16,8 @@ package body Component.Last_Chance_Manager.Implementation is
    -- Exception_Data : Packed_Exception_Occurrence.T_Access - The copy of the exception data that is updated by the last chance handler, presumably in a nonvolatile memory region.
    -- Dump_Exception_Data_At_Startup : Boolean - If True, then the exception data will be dumped in packet at startup.
    --
-   overriding procedure Init (Self : in out Instance; Exception_Data : in Packed_Exception_Occurrence.T_Access; Dump_Exception_Data_At_Startup : in Boolean) is
-      use Packed_Exception_Occurrence;
+   overriding procedure Init (Self : in out Instance; Exception_Data : in not null Packed_Exception_Occurrence.T_Access; Dump_Exception_Data_At_Startup : in Boolean) is
    begin
-      pragma Assert (Exception_Data /= null, "Exception data cannot be null.");
       Self.Exception_Data := Exception_Data;
       Self.Dump_Exception_Data_At_Startup := Dump_Exception_Data_At_Startup;
    end Init;

--- a/src/components/last_chance_manager/component-last_chance_manager-implementation.ads
+++ b/src/components/last_chance_manager/component-last_chance_manager-implementation.ads
@@ -20,7 +20,7 @@ package Component.Last_Chance_Manager.Implementation is
    -- Exception_Data : Packed_Exception_Occurrence.T_Access - The copy of the exception data that is updated by the last chance handler, presumably in a nonvolatile memory region.
    -- Dump_Exception_Data_At_Startup : Boolean - If True, then the exception data will be dumped in packet at startup.
    --
-   overriding procedure Init (Self : in out Instance; Exception_Data : in Packed_Exception_Occurrence.T_Access; Dump_Exception_Data_At_Startup : in Boolean);
+   overriding procedure Init (Self : in out Instance; Exception_Data : in not null Packed_Exception_Occurrence.T_Access; Dump_Exception_Data_At_Startup : in Boolean);
 
 private
 

--- a/src/components/last_chance_manager/last_chance_manager.component.yaml
+++ b/src/components/last_chance_manager/last_chance_manager.component.yaml
@@ -6,6 +6,7 @@ init:
   parameters:
     - name: Exception_Data
       type: Packed_Exception_Occurrence.T_Access
+      not_null: true
       description: The copy of the exception data that is updated by the last chance handler, presumably in a nonvolatile memory region.
     - name: Dump_Exception_Data_At_Startup
       type: Boolean

--- a/src/components/memory_dumper/component-memory_dumper-implementation.adb
+++ b/src/components/memory_dumper/component-memory_dumper-implementation.adb
@@ -16,10 +16,8 @@ package body Component.Memory_Dumper.Implementation is
    -- Init Parameters:
    -- memory_Regions : Memory_Manager_Types.Memory_Region_Array_Access - An access to a list of memory regions.
    --
-   overriding procedure Init (Self : in out Instance; Memory_Regions : in Memory_Manager_Types.Memory_Region_Array_Access) is
-      use Memory_Manager_Types;
+   overriding procedure Init (Self : in out Instance; Memory_Regions : in not null Memory_Manager_Types.Memory_Region_Array_Access) is
    begin
-      pragma Assert (Memory_Regions /= null, "Memory regions list cannot be null");
       Self.Regions := Memory_Regions;
    end Init;
 

--- a/src/components/memory_dumper/component-memory_dumper-implementation.ads
+++ b/src/components/memory_dumper/component-memory_dumper-implementation.ads
@@ -19,7 +19,7 @@ package Component.Memory_Dumper.Implementation is
    -- Init Parameters:
    -- memory_Regions : Memory_Manager_Types.Memory_Region_Array_Access - An access to a list of memory regions.
    --
-   overriding procedure Init (Self : in out Instance; Memory_Regions : in Memory_Manager_Types.Memory_Region_Array_Access);
+   overriding procedure Init (Self : in out Instance; Memory_Regions : in not null Memory_Manager_Types.Memory_Region_Array_Access);
 
 private
 

--- a/src/components/memory_dumper/memory_dumper.component.yaml
+++ b/src/components/memory_dumper/memory_dumper.component.yaml
@@ -7,6 +7,7 @@ init:
   parameters:
     - name: memory_Regions
       type: Memory_Manager_Types.Memory_Region_Array_Access
+      not_null: true
       description: An access to a list of memory regions.
 connectors:
   - description: This is the command receive connector.

--- a/src/components/memory_stuffer/component-memory_stuffer-implementation.adb
+++ b/src/components/memory_stuffer/component-memory_stuffer-implementation.adb
@@ -19,11 +19,10 @@ package body Component.Memory_Stuffer.Implementation is
    -- Memory_Regions : Memory_Manager_Types.Memory_Region_Array_Access - An access to a list of memory regions.
    -- Memory_Region_Protection_List : Memory_Manager_Types.Memory_Protection_Array_Access - An access to a list of the protected/unprotected state of each memory region. The index in this array corresponds to the index of the memory region affected in the previous parameter. If the array is null, then it is assumed that all memory regions are unprotected.
    --
-   overriding procedure Init (Self : in out Instance; Memory_Regions : in Memory_Manager_Types.Memory_Region_Array_Access; Memory_Region_Protection_List : in Memory_Manager_Types.Memory_Protection_Array_Access := null) is
+   overriding procedure Init (Self : in out Instance; Memory_Regions : in not null Memory_Manager_Types.Memory_Region_Array_Access; Memory_Region_Protection_List : in Memory_Manager_Types.Memory_Protection_Array_Access := null) is
       use Memory_Manager_Types;
    begin
       -- Set the regions:
-      pragma Assert (Memory_Regions /= null, "Memory regions list cannot be null");
       Self.Regions := Memory_Regions;
       -- Set the memory region protection list:
       if Memory_Region_Protection_List /= null then

--- a/src/components/memory_stuffer/component-memory_stuffer-implementation.ads
+++ b/src/components/memory_stuffer/component-memory_stuffer-implementation.ads
@@ -22,7 +22,7 @@ package Component.Memory_Stuffer.Implementation is
    -- Memory_Regions : Memory_Manager_Types.Memory_Region_Array_Access - An access to a list of memory regions.
    -- Memory_Region_Protection_List : Memory_Manager_Types.Memory_Protection_Array_Access - An access to a list of the protected/unprotected state of each memory region. The index in this array corresponds to the index of the memory region affected in the previous parameter. If the array is null, then it is assumed that all memory regions are unprotected.
    --
-   overriding procedure Init (Self : in out Instance; Memory_Regions : in Memory_Manager_Types.Memory_Region_Array_Access; Memory_Region_Protection_List : in Memory_Manager_Types.Memory_Protection_Array_Access := null);
+   overriding procedure Init (Self : in out Instance; Memory_Regions : in not null Memory_Manager_Types.Memory_Region_Array_Access; Memory_Region_Protection_List : in Memory_Manager_Types.Memory_Protection_Array_Access := null);
 
 private
 

--- a/src/components/memory_stuffer/memory_stuffer.component.yaml
+++ b/src/components/memory_stuffer/memory_stuffer.component.yaml
@@ -7,6 +7,7 @@ init:
   parameters:
     - name: memory_Regions
       type: Memory_Manager_Types.Memory_Region_Array_Access
+      not_null: true
       description: An access to a list of memory regions.
     - name: memory_Region_Protection_List
       type: Memory_Manager_Types.Memory_Protection_Array_Access

--- a/src/components/memory_stuffer/test/memory_stuffer_tests-implementation.adb
+++ b/src/components/memory_stuffer/test/memory_stuffer_tests-implementation.adb
@@ -75,28 +75,6 @@ package body Memory_Stuffer_Tests.Implementation is
             Assert (False, "Nominal init failed!");
       end Init_Nominal;
 
-      procedure Init_Null_Region is
-      begin
-         T.Component_Instance.Init (null, Protection_List'Access);
-         -- Should never get here:
-         Assert (False, "Null regions did not produce exception!");
-      exception
-         -- Expecting exception to be thrown:
-         when others =>
-            null;
-      end Init_Null_Region;
-
-      procedure Init_Null_Region_2 is
-      begin
-         T.Component_Instance.Init (null, null);
-         -- Should never get here:
-         Assert (False, "Null regions 2 did not produce exception!");
-      exception
-         -- Expecting exception to be thrown:
-         when others =>
-            null;
-      end Init_Null_Region_2;
-
       procedure Init_Nominal_No_Protection is
       begin
          T.Component_Instance.Init (Regions'Access, null);
@@ -139,8 +117,6 @@ package body Memory_Stuffer_Tests.Implementation is
 
       -- Test different start-up scenarios:
       Init_Nominal;
-      Init_Null_Region;
-      Init_Null_Region_2;
       Init_Nominal_No_Protection;
       Init_Size_Mismatch;
       Init_Size_Mismatch_2;

--- a/src/components/parameter_store/component-parameter_store-implementation.adb
+++ b/src/components/parameter_store/component-parameter_store-implementation.adb
@@ -20,10 +20,8 @@ package body Component.Parameter_Store.Implementation is
    -- bytes : Basic_Types.Byte_Array_Access - A pointer to an allocation of bytes to be used for storing the parameter table. The size of this byte array MUST be the exact size of the parameter table to be stored, or updating or fetch the table will be rejected with a length error.
    -- dump_Parameters_On_Change : Boolean - If set to True, the component will dump the current parameter values any time a memory region is received to change the parameter table. If set to False, parameters will only be dumped when requested by command.
    --
-   overriding procedure Init (Self : in out Instance; Bytes : in Basic_Types.Byte_Array_Access; Dump_Parameters_On_Change : in Boolean := False) is
-      use Basic_Types;
+   overriding procedure Init (Self : in out Instance; Bytes : in not null Basic_Types.Byte_Array_Access; Dump_Parameters_On_Change : in Boolean := False) is
    begin
-      pragma Assert (Bytes /= null, "Bytes must not be null!");
       -- The implementation of this component assumes that the parameter store fits cleanly in a maximum sized packet.
       pragma Assert (Bytes.all'Length + Crc_16.Crc_16_Type'Length <= Packet_Types.Packet_Buffer_Type'Length, "The parameter table must not be larger than the maximum size packet!");
       Self.Bytes := Bytes;

--- a/src/components/parameter_store/component-parameter_store-implementation.ads
+++ b/src/components/parameter_store/component-parameter_store-implementation.ads
@@ -21,7 +21,7 @@ package Component.Parameter_Store.Implementation is
    -- bytes : Basic_Types.Byte_Array_Access - A pointer to an allocation of bytes to be used for storing the parameter table. The size of this byte array MUST be the exact size of the parameter table to be stored, or updating or fetch the table will be rejected with a length error.
    -- dump_Parameters_On_Change : Boolean - If set to True, the component will dump the current parameter values any time a memory region is received to change the parameter table. If set to False, parameters will only be dumped when requested by command.
    --
-   overriding procedure Init (Self : in out Instance; Bytes : in Basic_Types.Byte_Array_Access; Dump_Parameters_On_Change : in Boolean := False);
+   overriding procedure Init (Self : in out Instance; Bytes : in not null Basic_Types.Byte_Array_Access; Dump_Parameters_On_Change : in Boolean := False);
 
 private
 

--- a/src/components/parameter_store/parameter_store.component.yaml
+++ b/src/components/parameter_store/parameter_store.component.yaml
@@ -7,6 +7,7 @@ init:
   parameters:
     - name: bytes
       type: Basic_Types.Byte_Array_Access
+      not_null: true
       description: "A pointer to an allocation of bytes to be used for storing the parameter table. The size of this byte array MUST be the exact size of the parameter table to be stored, or updating or fetch the table will be rejected with a length error."
     - name: dump_Parameters_On_Change
       type: Boolean

--- a/src/components/parameters/component-parameters-implementation.adb
+++ b/src/components/parameters/component-parameters-implementation.adb
@@ -21,16 +21,13 @@ package body Component.Parameters.Implementation is
    -- parameter_Entries : Parameters_Component_Types.Parameter_Entry_List_Access - A pointer to an autocoded list of parameter entries. This table tells the parameter manager how the parameters are laid out in memory, so that it knows how to construct parameter types to update downstream components.
    -- dump_Parameters_On_Change : Boolean - If set to True, the component will dump the current parameter values any time a command or memory region is received to alter one or more parameter values. If set to False, parameters will only be dumped when requested by command.
    --
-   overriding procedure Init (Self : in out Instance; Parameter_Table_Entries : in Parameters_Component_Types.Parameter_Table_Entry_List_Access; Dump_Parameters_On_Change : in Boolean := False) is
+   overriding procedure Init (Self : in out Instance; Parameter_Table_Entries : in not null Parameters_Component_Types.Parameter_Table_Entry_List_Access; Dump_Parameters_On_Change : in Boolean := False) is
       use Parameter_Types;
       use Parameters_Component_Types;
       Current_Byte : Natural := 0;
    begin
       -- Initialize internal variables:
       Self.Dump_Parameters_On_Change := Dump_Parameters_On_Change;
-
-      -- Make sure the parameter entries is a valid access type. We can't do anything without this:
-      pragma Assert (Parameter_Table_Entries /= null, "parameter_Table_Entries must not be null!");
       Self.Entries := Parameter_Table_Entries;
 
       --

--- a/src/components/parameters/component-parameters-implementation.ads
+++ b/src/components/parameters/component-parameters-implementation.ads
@@ -21,7 +21,7 @@ package Component.Parameters.Implementation is
    -- parameter_Entries : Parameters_Component_Types.Parameter_Entry_List_Access - A pointer to an autocoded list of parameter entries. This table tells the parameter manager how the parameters are laid out in memory, so that it knows how to construct parameter types to update downstream components.
    -- dump_Parameters_On_Change : Boolean - If set to True, the component will dump the current parameter values any time a command or memory region is received to alter one or more parameter values. If set to False, parameters will only be dumped when requested by command.
    --
-   overriding procedure Init (Self : in out Instance; Parameter_Table_Entries : in Parameters_Component_Types.Parameter_Table_Entry_List_Access; Dump_Parameters_On_Change : in Boolean := False);
+   overriding procedure Init (Self : in out Instance; Parameter_Table_Entries : in not null Parameters_Component_Types.Parameter_Table_Entry_List_Access; Dump_Parameters_On_Change : in Boolean := False);
 
 private
 

--- a/src/components/parameters/parameters.component.yaml
+++ b/src/components/parameters/parameters.component.yaml
@@ -7,6 +7,7 @@ init:
   parameters:
     - name: parameter_Table_Entries
       type: Parameters_Component_Types.Parameter_Table_Entry_List_Access
+      not_null: true
       description: "A pointer to an autocoded list of parameter table entries. This table tells the parameter manager how the parameters are laid out in memory, so that it knows how to construct parameter types to update downstream components."
     - name: dump_Parameters_On_Change
       type: Boolean

--- a/src/components/parameters/test/parameters_tests-implementation.adb
+++ b/src/components/parameters/test/parameters_tests-implementation.adb
@@ -78,16 +78,6 @@ package body Parameters_Tests.Implementation is
             Assert (False, "Nominal init failed!");
       end Init_Nominal;
 
-      procedure Init_Null is
-      begin
-         T.Component_Instance.Init (null, False);
-         Assert (False, "Null init failed!");
-      exception
-         -- Expecting exception to be thrown:
-         when others =>
-            null;
-      end Init_Null;
-
       procedure Init_Nonunique_Ids is
          -- A list of the parameter table entries for use by the component.
          Parameter_Table_Entries : aliased Parameters_Component_Types.Parameter_Table_Entry_List :=
@@ -160,7 +150,6 @@ package body Parameters_Tests.Implementation is
    begin
       -- Test different start-up scenarios:
       Init_Nominal;
-      Init_Null;
       Init_Nonunique_Ids;
       Init_Bad_Component_Id;
       Init_Unconnected_Component_Id;

--- a/src/components/product_copier/component-product_copier-implementation.adb
+++ b/src/components/product_copier/component-product_copier-implementation.adb
@@ -30,7 +30,7 @@ package body Component.Product_Copier.Implementation is
    -- this is expected behavior. Accordingly, not sending error events is the
    -- default.
    --
-   overriding procedure Init (Self : in out Instance; Products_To_Copy : in Product_Mapping_Array_Access; Send_Event_On_Source_Id_Out_Of_Range : in Boolean := True; Send_Event_On_Source_Not_Available : in Boolean := False) is
+   overriding procedure Init (Self : in out Instance; Products_To_Copy : in not null Product_Mapping_Array_Access; Send_Event_On_Source_Id_Out_Of_Range : in Boolean := True; Send_Event_On_Source_Not_Available : in Boolean := False) is
    begin
       -- make sure no two destinations have the same ID, otherwise raise an error
       for I in Products_To_Copy'Range loop
@@ -44,7 +44,6 @@ package body Component.Product_Copier.Implementation is
       -- copy configuration to component record
       Self.Send_Event_On_Source_Id_Out_Of_Range := Send_Event_On_Source_Id_Out_Of_Range;
       Self.Send_Event_On_Source_Not_Available := Send_Event_On_Source_Not_Available;
-      pragma Assert (Products_To_Copy /= null);
       Self.Mappings := Products_To_Copy;
    end Init;
 

--- a/src/components/product_copier/component-product_copier-implementation.ads
+++ b/src/components/product_copier/component-product_copier-implementation.ads
@@ -42,7 +42,7 @@ package Component.Product_Copier.Implementation is
    -- this is expected behavior. Accordingly, not sending error events is the
    -- default.
    --
-   overriding procedure Init (Self : in out Instance; Products_To_Copy : in Product_Mapping_Array_Access; Send_Event_On_Source_Id_Out_Of_Range : in Boolean := True; Send_Event_On_Source_Not_Available : in Boolean := False);
+   overriding procedure Init (Self : in out Instance; Products_To_Copy : in not null Product_Mapping_Array_Access; Send_Event_On_Source_Id_Out_Of_Range : in Boolean := True; Send_Event_On_Source_Not_Available : in Boolean := False);
 
 private
 

--- a/src/components/product_copier/product_copier.component.yaml
+++ b/src/components/product_copier/product_copier.component.yaml
@@ -15,6 +15,7 @@ init:
   parameters:
     - name: Products_To_Copy
       type: Product_Mapping_Array_Access
+      not_null: true
       description: The list of mappings to be copied by this component every tick. Raises an error on Init if the list is null, as well as if two mappings share a destination.
     - name: Send_Event_On_Source_Id_Out_Of_Range
       type: Boolean

--- a/src/components/product_packetizer/component-product_packetizer-implementation.ads
+++ b/src/components/product_packetizer/component-product_packetizer-implementation.ads
@@ -18,7 +18,7 @@ package Component.Product_Packetizer.Implementation is
    -- Discriminant Parameters:
    -- packet_List : Product_Packet_Types.Packet_Description_List_Access_Type - The list of packets to packetize.
    --
-   type Instance (Packet_List : Product_Packet_Types.Packet_Description_List_Access_Type) is new Product_Packetizer.Base_Instance with private;
+   type Instance (Packet_List : not null Product_Packet_Types.Packet_Description_List_Access_Type) is new Product_Packetizer.Base_Instance with private;
 
    --------------------------------------------------
    -- Subprogram for implementation init method:
@@ -37,7 +37,7 @@ private
    -- Discriminant Parameters:
    -- packet_List : Product_Packet_Types.Packet_Description_List_Access_Type - The list of packets to packetize.
    --
-   type Instance (Packet_List : Product_Packet_Types.Packet_Description_List_Access_Type) is new Product_Packetizer.Base_Instance with record
+   type Instance (Packet_List : not null Product_Packet_Types.Packet_Description_List_Access_Type) is new Product_Packetizer.Base_Instance with record
       Count : Positive := 1; -- The count is rolled over manually in adb
       Roll_Over_Value : Roll_Over_Natural := Roll_Over_Natural'Last; -- This will change to a more appropriate value via the init function.
       Commands_Dispatched_Per_Tick : Positive := 3;

--- a/src/components/product_packetizer/product_packetizer.component.yaml
+++ b/src/components/product_packetizer/product_packetizer.component.yaml
@@ -8,6 +8,7 @@ discriminant:
     - name: Packet_List
       type: Product_Packet_Types.Packet_Description_List_Access_Type
       description: The list of packets to packetize.
+      not_null: true
 init:
   description: This initialization function is used to initialize the roll-over value for the packetizer's internal counter. It is calculated as the largest 32-bit multiple of all the provided periods in the packet_List. This ensures that no packets are skipped or sent too often when a rollover occurs. Note, that this only guarantees expected roll-over behavior if the period of the packets are not changed during runtime via command. If this happens, then the user accepts that a rollover may cause unwanted behavior.
   parameters:

--- a/src/components/queue_monitor/component-queue_monitor-implementation.adb
+++ b/src/components/queue_monitor/component-queue_monitor-implementation.adb
@@ -15,9 +15,8 @@ package body Component.Queue_Monitor.Implementation is
    -- queued_Component_List : Component.Component_List_Access - A list of components to monitor.
    -- packet_Period : Interfaces.Unsigned_16 - The period (in ticks) of how often to send out the queue usage packet. A value of zero disable sending of the packet.
    --
-   overriding procedure Init (Self : in out Instance; Queued_Component_List : in Component.Component_List_Access; Packet_Period : in Interfaces.Unsigned_16 := 1) is
+   overriding procedure Init (Self : in out Instance; Queued_Component_List : in not null Component.Component_List_Access; Packet_Period : in Interfaces.Unsigned_16 := 1) is
    begin
-      pragma Assert (Queued_Component_List /= null, "queued_Component_List cannot be null.");
       Self.Queued_Component_List := Queued_Component_List;
 
       -- Set the packet length. Each data point for

--- a/src/components/queue_monitor/component-queue_monitor-implementation.ads
+++ b/src/components/queue_monitor/component-queue_monitor-implementation.ads
@@ -21,7 +21,7 @@ package Component.Queue_Monitor.Implementation is
    -- queued_Component_List : Component.Component_List_Access - A list of components to monitor.
    -- packet_Period : Interfaces.Unsigned_16 - The period (in ticks) of how often to send out the queue usage packet. A value of zero disable sending of the packet.
    --
-   overriding procedure Init (Self : in out Instance; Queued_Component_List : in Component.Component_List_Access; Packet_Period : in Interfaces.Unsigned_16 := 1);
+   overriding procedure Init (Self : in out Instance; Queued_Component_List : in not null Component.Component_List_Access; Packet_Period : in Interfaces.Unsigned_16 := 1);
 
 private
 

--- a/src/components/queue_monitor/queue_monitor.component.yaml
+++ b/src/components/queue_monitor/queue_monitor.component.yaml
@@ -7,6 +7,7 @@ init:
   parameters:
     - name: Queued_Component_List
       type: Component.Component_List_Access
+      not_null: true
       description: A list of components to monitor.
     - name: Packet_Period
       type: Interfaces.Unsigned_16

--- a/src/components/sequence_store/component-sequence_store-implementation.adb
+++ b/src/components/sequence_store/component-sequence_store-implementation.adb
@@ -270,10 +270,9 @@ package body Component.Sequence_Store.Implementation is
    -- Check_Slots_At_Startup : Boolean - If True, then check the validity of the sequences in all slots by computing CRCs over them at startup.
    -- Dump_Slot_Summary_At_Startup : Boolean - If True, then the slot summaries will be dumped at startup.
    --
-   overriding procedure Init (Self : in out Instance; Sequence_Slots : in Sequence_Slot_Array_Access; Check_Slots_At_Startup : in Boolean; Dump_Slot_Summary_At_Startup : in Boolean) is
+   overriding procedure Init (Self : in out Instance; Sequence_Slots : in not null Sequence_Slot_Array_Access; Check_Slots_At_Startup : in Boolean; Dump_Slot_Summary_At_Startup : in Boolean) is
    begin
       -- Make sure the sequence slots exist:
-      pragma Assert (Sequence_Slots /= null, "The slot array must not be null.");
       pragma Assert (Sequence_Slots.all'First = 0, "Slots must be zero indexed. This is so there is no conflict with the ground.");
       pragma Assert (Sequence_Slots.all'Length >= 1, "There must be at least one slot.");
       pragma Assert (Sequence_Slots.all'Last >= 0, "There must be at least one slot.");

--- a/src/components/sequence_store/component-sequence_store-implementation.ads
+++ b/src/components/sequence_store/component-sequence_store-implementation.ads
@@ -27,7 +27,7 @@ package Component.Sequence_Store.Implementation is
    -- Check_Slots_At_Startup : Boolean - If True, then check the validity of the sequences in all slots by computing CRCs over them at startup.
    -- Dump_Slot_Summary_At_Startup : Boolean - If True, then the slot summaries will be dumped at startup.
    --
-   overriding procedure Init (Self : in out Instance; Sequence_Slots : in Sequence_Slot_Array_Access; Check_Slots_At_Startup : in Boolean; Dump_Slot_Summary_At_Startup : in Boolean);
+   overriding procedure Init (Self : in out Instance; Sequence_Slots : in not null Sequence_Slot_Array_Access; Check_Slots_At_Startup : in Boolean; Dump_Slot_Summary_At_Startup : in Boolean);
    not overriding procedure Final (Self : in out Instance);
 
 private

--- a/src/components/sequence_store/sequence_store.component.yaml
+++ b/src/components/sequence_store/sequence_store.component.yaml
@@ -15,6 +15,7 @@ init:
   parameters:
     - name: sequence_Slots
       type: Sequence_Slot_Array_Access
+      not_null: true
       description: "A list of memory regions. Each represents a slot to hold a single sequence of equal or smaller size (including header). This list will be copied into the component at initialization onto a heap allocated memory. The memory regions must not overlap in any way, must be large enough to at least hold a sequence header, and the list must not be empty. These properties will be enforced by the component via assertions when Init is called."
     - name: check_Slots_At_Startup
       type: Boolean

--- a/src/components/sequence_store/test/sequence_store_tests-implementation.adb
+++ b/src/components/sequence_store/test/sequence_store_tests-implementation.adb
@@ -159,18 +159,6 @@ package body Sequence_Store_Tests.Implementation is
             Assert (False, "Nominal init failed!");
       end Init_Nominal;
 
-      procedure Init_Null is
-      begin
-         -- Empty list not ok.
-         Self.Tester.Component_Instance.Init (Sequence_Slots => null, Check_Slots_At_Startup => False, Dump_Slot_Summary_At_Startup => True);
-         -- Should never get here:
-         Assert (False, "Null slots did not produce exception!");
-      exception
-         -- Expecting exception to be thrown:
-         when others =>
-            null;
-      end Init_Null;
-
       procedure Init_None is
       begin
          -- Empty list not ok.
@@ -311,8 +299,6 @@ package body Sequence_Store_Tests.Implementation is
       -- Test different start-up scenarios:
       T.Component_Instance.Final;
       Init_Nominal;
-      T.Component_Instance.Final;
-      Init_Null;
       T.Component_Instance.Final;
       Init_None;
       T.Component_Instance.Final;

--- a/src/components/stack_monitor/component-stack_monitor-implementation.adb
+++ b/src/components/stack_monitor/component-stack_monitor-implementation.adb
@@ -18,11 +18,9 @@ package body Component.Stack_Monitor.Implementation is
    -- task_List : Task_Types.Task_Info_List_Access - A list of task info records to monitor.
    -- packet_Period : Interfaces.Unsigned_16 - The period (in ticks) of how often to calculate value for and send out the packet. A period of zero disables sending of the packet.
    --
-   overriding procedure Init (Self : in out Instance; Task_List : in Task_Types.Task_Info_List_Access; Packet_Period : in Interfaces.Unsigned_16 := 1) is
+   overriding procedure Init (Self : in out Instance; Task_List : in not null Task_Types.Task_Info_List_Access; Packet_Period : in Interfaces.Unsigned_16 := 1) is
       use Task_Types;
    begin
-      pragma Assert (Task_List /= null, "The task_List cannot be null.");
-
       -- Set the type variables.
       Self.Counter.Set_Period_And_Reset_Count (Packet_Period);
       Self.Tasks := Task_List;

--- a/src/components/stack_monitor/component-stack_monitor-implementation.ads
+++ b/src/components/stack_monitor/component-stack_monitor-implementation.ads
@@ -23,7 +23,7 @@ package Component.Stack_Monitor.Implementation is
    -- task_List : Task_Types.Task_Info_List_Access - A list of task info records to monitor.
    -- packet_Period : Interfaces.Unsigned_16 - The period (in ticks) of how often to calculate value for and send out the packet. A period of zero disables sending of the packet.
    --
-   overriding procedure Init (Self : in out Instance; Task_List : in Task_Types.Task_Info_List_Access; Packet_Period : in Interfaces.Unsigned_16 := 1);
+   overriding procedure Init (Self : in out Instance; Task_List : in not null Task_Types.Task_Info_List_Access; Packet_Period : in Interfaces.Unsigned_16 := 1);
    not overriding procedure Final (Self : in out Instance);
 
    -- Create a type that is an array of naturals:

--- a/src/components/stack_monitor/stack_monitor.component.yaml
+++ b/src/components/stack_monitor/stack_monitor.component.yaml
@@ -7,6 +7,7 @@ init:
   parameters:
     - name: task_List
       type: Task_Types.Task_Info_List_Access
+      not_null: true
       description: A list of task info records to monitor.
     - name: packet_Period
       type: Interfaces.Unsigned_16

--- a/src/components/tick_divider/component-tick_divider-implementation.adb
+++ b/src/components/tick_divider/component-tick_divider-implementation.adb
@@ -9,11 +9,9 @@ package body Component.Tick_Divider.Implementation is
    ---------------------------------------
    -- This initialization function is used to set the divider values for the component. An entry of 0 disables that connector from ever being invoked.
    --
-   overriding procedure Init (Self : in out Instance; Dividers : in Divider_Array_Type_Access) is
+   overriding procedure Init (Self : in out Instance; Dividers : in not null Divider_Array_Type_Access) is
       Divider : Natural;
    begin
-      -- Check the dividers to make sure they are of the correct size:
-      pragma Assert (Dividers /= null, "Make sure access type is not null.");
       pragma Assert (Dividers'First = Self.Connector_Tick_T_Send'First, "The length of the dividers array must match the length of the connector array!");
       pragma Assert (Dividers'Last = Self.Connector_Tick_T_Send'Last, "The length of the dividers array must match the length of the connector array!");
       pragma Assert (Dividers'Length = Self.Connector_Tick_T_Send'Length, "The length of the dividers array must match the length of the connector array!");

--- a/src/components/tick_divider/component-tick_divider-implementation.ads
+++ b/src/components/tick_divider/component-tick_divider-implementation.ads
@@ -11,7 +11,7 @@ package Component.Tick_Divider.Implementation is
 
    -- Initialization function to set the divider values for the component
    -- An entry of 0 disables that connector from ever being invoked.
-   overriding procedure Init (Self : in out Instance; Dividers : in Divider_Array_Type_Access);
+   overriding procedure Init (Self : in out Instance; Dividers : in not null Divider_Array_Type_Access);
 
 private
 

--- a/src/components/tick_divider/tick_divider.component.yaml
+++ b/src/components/tick_divider/tick_divider.component.yaml
@@ -13,6 +13,7 @@ init:
   parameters:
     - name: dividers
       type: Divider_Array_Type_Access
+      not_null: true
       description: An access to an array of dividers used to determine the tick rate of each Tick_T_Send connector.
 connectors:
   - description: This connector receives a periodic Tick from an external component.


### PR DESCRIPTION
Note that there might be other places where it would make sense to add `not_null`, likely wherever the `parameter` submodule gets instantiated in a Python file in gen/models.