### PR TITLE
Moving discriminant parameters to component base

### DIFF
--- a/gen/models/component.py
+++ b/gen/models/component.py
@@ -472,11 +472,16 @@ class component(base):
                 + (self.includes)
             )
         )
-        self.base_ads_includes = [
-            inc
-            for inc in self.base_ads_includes
-            if inc not in self.do_not_includes and inc != "Component"
-        ]
+        self.base_ads_includes = list(
+            OrderedDict.fromkeys(
+                [
+                    inc
+                    for inc in self.base_ads_includes
+                    if inc not in self.do_not_includes and inc != "Component"
+                ]
+                + (self.discriminant.includes if self.discriminant else [])
+            )
+        )
 
         self.base_adb_includes = list(
             OrderedDict.fromkeys(
@@ -506,8 +511,7 @@ class component(base):
 
         self.template_ads_includes = list(
             OrderedDict.fromkeys(
-                (self.discriminant.includes if self.discriminant else [])
-                + (
+                (
                     self.connectors.invokee().type_includes
                     if self.connectors.invokee().includes
                     else []

--- a/gen/templates/component/component-name-implementation.ads
+++ b/gen/templates/component/component-name-implementation.ads
@@ -18,18 +18,7 @@ generic
 package Component.{{ name }}.Implementation is
 
    -- The component class instance record:
-{% if discriminant.description %}
-{{ printMultiLine(discriminant.description, '   -- ') }}
-{% endif %}
-{% if discriminant.parameters %}
-   --
-{{ printMultiLine("Discriminant Parameters:", '   -- ') }}
-{% for p in discriminant.parameters %}
-{{ printMultiLine(p.name + " : " + p.type + ((" - " + p.description) if (p.description) else ""), '   -- ') }}
-{% endfor %}
-   --
-{% endif %}
-   type Instance{% if discriminant.parameters %} ({{ discriminant.parameter_declaration_string(include_mode=False) }}){% endif %} is new {{ name }}.Base_Instance with private;
+   type Instance is new {{ name }}.Base_Instance with private;
 
 {% if init %}
    --------------------------------------------------
@@ -52,18 +41,7 @@ package Component.{{ name }}.Implementation is
 private
 
    -- The component class instance record:
-{% if discriminant.description %}
-{{ printMultiLine(discriminant.description, '   -- ') }}
-{% endif %}
-{% if discriminant.parameters %}
-   --
-{{ printMultiLine("Discriminant Parameters:", '   -- ') }}
-{% for p in discriminant.parameters %}
-{{ printMultiLine(p.name + " : " + p.type + ((" - " + p.description) if (p.description) else ""), '   -- ') }}
-{% endfor %}
-   --
-{% endif %}
-   type Instance{% if discriminant.parameters %} ({{ discriminant.parameter_declaration_string(include_mode=False) }}){% endif %} is new {{ name }}.Base_Instance with record
+   type Instance is new {{ name }}.Base_Instance with record
       null; -- TODO
    end record;
 

--- a/gen/templates/component/component-name.ads
+++ b/gen/templates/component/component-name.ads
@@ -44,7 +44,18 @@ package Component.{{ name }} is
 {% endif %}
 
    -- Base class instance:
-   type Base_Instance is abstract new Component.Core_Instance with private;
+{% if discriminant.description %}
+{{ printMultiLine(discriminant.description, '   -- ') }}
+{% endif %}
+{% if discriminant.parameters %}
+   --
+{{ printMultiLine("Discriminant Parameters:", '   -- ') }}
+{% for p in discriminant.parameters %}
+{{ printMultiLine(p.name + " : " + p.type + ((" - " + p.description) if (p.description) else ""), '   -- ') }}
+{% endfor %}
+   --
+{% endif %}
+   type Base_Instance{% if discriminant.parameters %} ({{ discriminant.parameter_declaration_string(include_mode=False) }}){% endif %} is abstract new Component.Core_Instance with private;
    type Base_Class_Access is access all Base_Instance'Class;
 
 {% if connectors.requires_queue() %}
@@ -655,7 +666,18 @@ private
    -------------------------------------------
    -- The base class instance record:
    -------------------------------------------
-   type Base_Instance is abstract new Component.Core_Instance with record
+{% if discriminant.description %}
+{{ printMultiLine(discriminant.description, '   -- ') }}
+{% endif %}
+{% if discriminant.parameters %}
+   --
+{{ printMultiLine("Discriminant Parameters:", '   -- ') }}
+{% for p in discriminant.parameters %}
+{{ printMultiLine(p.name + " : " + p.type + ((" - " + p.description) if (p.description) else ""), '   -- ') }}
+{% endfor %}
+   --
+{% endif %}
+   type Base_Instance {% if discriminant.parameters %} ({{ discriminant.parameter_declaration_string(include_mode=False) }}){% endif %} is abstract new Component.Core_Instance with record
 {% if connectors.requires_queue() or connectors.invoker() or connectors.invokee().n_arrayed() or data_products or commands or events or packets or parameters or faults %}
 {% if connectors.requires_queue() %}
       -- Internal asynchronous connector queue:


### PR DESCRIPTION
By moving the discriminant to the base type we ensure that the component model always matches the implementation. When the discriminant is reflected in the implementation, it was up to the user to keep the model in sync with the code, which is far from ideal. This commit fixes that issue.