### PR TITLE
Generate C/C++ bindings with valid style

### DIFF
--- a/redo/rules/build_bindings.py
+++ b/redo/rules/build_bindings.py
@@ -9,6 +9,7 @@ from util import shell
 from util import debug
 from base_classes.build_rule_base import build_rule_base
 from rules.build_object import _build_all_c_dependencies, _get_build_target_instance
+from rules.build_pretty import gnatpp_cmd_prefix
 
 
 def _generate_bindings(redo_1, redo_2, redo_3, source_file, c_source_db):
@@ -55,10 +56,17 @@ def _generate_bindings(redo_1, redo_2, redo_3, source_file, c_source_db):
     filesystem.safe_makedir(template_temp_dir)
     os.chdir(template_temp_dir)
     shell.run_command_suppress_output(compile_cmd)
+
+    # The bindings file does not meet our coding style, so we use
+    # gnatpp to reformat it.
+    temp_output = os.path.join(template_temp_dir, os.path.basename(redo_1))
+    gnatpp_cmd = (
+        gnatpp_cmd_prefix() + " " + temp_output
+    )
+    shell.run_command_suppress_output(gnatpp_cmd)
     os.chdir(cwd)
 
     # Move the temporary binding over to the final location:
-    temp_output = os.path.join(template_temp_dir, os.path.basename(redo_1))
     debug.debug_print("mv " + temp_output + " " + redo_3)
     move(temp_output, redo_3)
     rmtree(template_temp_dir)

--- a/redo/rules/build_pretty.py
+++ b/redo/rules/build_pretty.py
@@ -7,6 +7,13 @@ from util import filesystem
 import sys
 
 
+def gnatpp_cmd_prefix():
+    return "gnatpp -j0 --no-compact --no-alignment --indentation=3 --indent-continuation=2 \
+            --max-line-length=5000 --name-mixed-case --attribute-mixed-case \
+            --keyword-lower-case --enum-mixed-case --type-mixed-case --eol=unix \
+            --comments-unchanged "
+
+
 class build_pretty(build_rule_base):
     def _build(self, redo_1, redo_2, redo_3):
         # Get targets for this directory:
@@ -37,12 +44,7 @@ class build_pretty(build_rule_base):
             # Form gnatpp command:
             filesystem.safe_makedir(out_dir)
             gnatpp_cmd = (
-                "gnatpp -j0 --no-compact --no-alignment --indentation=3 --indent-continuation=2 \
-                        --max-line-length=5000 --name-mixed-case --attribute-mixed-case \
-                        --keyword-lower-case --enum-mixed-case --type-mixed-case --eol=unix \
-                        --comments-unchanged --output-dir "
-                + out_dir
-                + " "
+                gnatpp_cmd_prefix() + " --output-dir " + + out_dir + " "
                 + " ".join(handwritten_source)
             )
             shell.run_command(gnatpp_cmd)

--- a/redo/rules/build_style.py
+++ b/redo/rules/build_style.py
@@ -93,7 +93,8 @@ class build_style(build_rule_base):
         codespell_cwd = directory + os.sep + "*.*"
         codespell_ignore = os.environ["ADAMANT_DIR"] + os.sep + "redo" + os.sep + "codespell" + os.sep + "ignore_list.txt"
         codespell_output = "\" 2>&1 | tee -a " + style_log_file + " 1>&2"
-        codespell_build_dir = "*" + os.sep + "build" + os.sep + "obj,*" + os.sep + "build" + os.sep + "bin"
+        codespell_build_dir = "*" + os.sep + "build" + os.sep + "obj,*" + os.sep + "build" + os.sep \
+            + "bin,*" + os.sep + "build" + os.sep + "*style*"
         codespell_skip = " --skip=\"*" + os.sep + "alire," + codespell_build_dir + ",*.pdf,*.eps,*.svg,*.ali," + style_directory
         codespell_suffix = " -I " + codespell_ignore + codespell_skip + codespell_output
         shell.run_command("codespell "


### PR DESCRIPTION
This commit applies gnatpp to the output of the bindings generator so that the generated code matches the Adamant coding style.