### PR TITLE
Using standard Long_Float type for Packed_F64 record instead of IEEE type

### DIFF
--- a/src/types/packed_arrays/packed_f64x3.array.yaml
+++ b/src/types/packed_arrays/packed_f64x3.array.yaml
@@ -1,9 +1,5 @@
 ---
 description: Packed 3 element vector of 64-bit floats.
-with:
-  - Interfaces
-preamble: |
-   subtype Float_64 is Interfaces.IEEE_Float_64;
-type: Float_64
+type: Long_Float
 format: F64
 length: 3


### PR DESCRIPTION
For consistency, since we do not use the IEEE types anywhere else. If we want to transition to the IEEE types in the future, we should make that change wholesale. For now, we are consistently using the standard floating point types.