### PR TITLE
Tweak capitalization on bindings generation

### DIFF
--- a/redo/database/c_source_database.py
+++ b/redo/database/c_source_database.py
@@ -161,7 +161,7 @@ class c_source_database(database):
                 else:
                     root_dir = os.path.dirname(source)
                 basename, ext = os.path.splitext(source)
-                basename = os.path.basename(basename).lower()
+                basename = os.path.basename(basename)
                 objects.append(
                     os.path.join(
                         root_dir,

--- a/redo/rules/build_bindings.py
+++ b/redo/rules/build_bindings.py
@@ -153,7 +153,7 @@ class build_bindings(build_rule_base):
             + os.sep
             + target.get_default_target()
             + os.sep
-            + base
+            + base.lower()
             + "_" + ext[1:]
             + ".ads",
         )


### PR DESCRIPTION
This fixes an issue where bindings compilation works on a case-insensitive system like Mac, but fails on Linux.