### PR TITLE
Custom Parameter Validation within Component

### DIFF
--- a/doc/example_architecture/parameter_component/component-parameter_component-implementation.ads
+++ b/doc/example_architecture/parameter_component/component-parameter_component-implementation.ads
@@ -53,5 +53,16 @@ private
    -- hardware registers, or performing other special functionality that only needs to be performed after parameters have
    -- been updated.
    overriding procedure Update_Parameters_Action (Self : in out Instance);
+   -- This function is called when the parameter operation type is "Validate". The default implementation of this
+   -- subprogram in the implementation package is a function that returns "Valid". However, this function can, and should be
+   -- overridden if something special needs to happen to further validate a parameter. Examples of this might be validation of
+   -- certain parameters beyond individual type ranges, or performing other special functionality that only needs to be
+   -- performed after parameters have been validated. Note that range checking is performed during staging, and does not need
+   -- to be implemented here.
+   overriding function Validate_Parameters (
+      Self : in out Instance;
+      Start_Count : in Packed_U16.U;
+      Hello_World_Value : in Packed_U16.U
+   ) return Parameter_Validation_Status.E is (Parameter_Validation_Status.Valid);
 
 end Component.Parameter_Component.Implementation;

--- a/gen/templates/component/component-name-implementation.ads
+++ b/gen/templates/component/component-name-implementation.ads
@@ -170,6 +170,18 @@ private
    -- hardware registers, or performing other special functionality that only needs to be performed after parameters have
    -- been updated.
    overriding procedure Update_Parameters_Action (Self : in out Instance) is null;
+   -- This function is called when the parameter operation type is "Validate". The default implementation of this
+   -- subprogram in the implementation package is a function that returns "Valid". However, this function can, and should be
+   -- overridden if something special needs to happen to further validate a parameter. Examples of this might be validation of
+   -- certain parameters beyond individual type ranges, or performing other special functionality that only needs to be
+   -- performed after parameters have been validated. Note that range checking is performed during staging, and does not need
+   -- to be implemented here.
+   overriding function Validate_Parameters (
+      Self : in out Instance;
+{% for par in parameters %}
+      {{ par.name }} : in {% if par.type_package %}{{ par.type_package }}.U{% else %}{{ par.type }}{% endif %}{{ ";" if not loop.last }}
+{% endfor %}
+   ) return Parameter_Validation_Status.E is (Parameter_Validation_Status.Valid);
 
 {% endif %}
 {% if data_dependencies %}

--- a/gen/templates/component/component-name.ads
+++ b/gen/templates/component/component-name.ads
@@ -269,6 +269,19 @@ package Component.{{ name }} is
    -- been updated.
    not overriding procedure Update_Parameters_Action (Self : in out Base_Instance) is abstract;
 
+   -- This function is called when the parameter operation type is "Validate". The default implementation of this
+   -- subprogram in the implementation package is a function that returns "Valid". However, this function can, and should be
+   -- overridden if something special needs to happen to further validate a parameter. Examples of this might be validation of
+   -- certain parameters beyond individual type ranges, or performing other special functionality that only needs to be
+   -- performed after parameters have been validated. Note that range checking is performed during staging, and does not need
+   -- to be implemented here.
+   not overriding function Validate_Parameters (
+      Self : in out Base_Instance;
+{% for par in parameters %}
+      {{ par.name }} : in {% if par.type_package %}{{ par.type_package }}.U{% else %}{{ par.type }}{% endif %}{{ ";" if not loop.last }}
+{% endfor %}
+   ) return Parameter_Validation_Status.E is abstract;
+
 {% endif %}
 {% if data_dependencies %}
    -----------------------------------------------

--- a/src/components/limiter/component-limiter-implementation.ads
+++ b/src/components/limiter/component-limiter-implementation.ads
@@ -100,5 +100,15 @@ private
    -- hardware registers, or performing other special functionality that only needs to be performed after parameters have
    -- been updated.
    overriding procedure Update_Parameters_Action (Self : in out Instance);
+   -- This function is called when the parameter operation type is "Validate". The default implementation of this
+   -- subprogram in the implementation package is a function that returns "Valid". However, this function can, and should be
+   -- overridden if something special needs to happen to further validate a parameter. Examples of this might be validation of
+   -- certain parameters beyond individual type ranges, or performing other special functionality that only needs to be
+   -- performed after parameters have been validated. Note that range checking is performed during staging, and does not need
+   -- to be implemented here.
+   overriding function Validate_Parameters (
+      Self : in out Instance;
+      Max_Sends_Per_Tick : in Packed_U16.U
+   ) return Parameter_Validation_Status.E is (Parameter_Validation_Status.Valid);
 
 end Component.Limiter.Implementation;

--- a/src/components/parameters/test/test_component_1/component-test_component_1-implementation.ads
+++ b/src/components/parameters/test/test_component_1/component-test_component_1-implementation.ads
@@ -59,5 +59,16 @@ private
    -- hardware registers, or performing other special functionality that only needs to be performed after parameters have
    -- been updated.
    overriding procedure Update_Parameters_Action (Self : in out Instance) is null;
+   -- This function is called when the parameter operation type is "Validate". The default implementation of this
+   -- subprogram in the implementation package is a function that returns "Valid". However, this function can, and should be
+   -- overridden if something special needs to happen to further validate a parameter. Examples of this might be validation of
+   -- certain parameters beyond individual type ranges, or performing other special functionality that only needs to be
+   -- performed after parameters have been validated. Note that range checking is performed during staging, and does not need
+   -- to be implemented here.
+   overriding function Validate_Parameters (
+      Self : in out Instance;
+      Parameter_U16 : in Packed_U16.U;
+      Parameter_I32 : in Packed_I32.U
+   ) return Parameter_Validation_Status.E is (Parameter_Validation_Status.Valid);
 
 end Component.Test_Component_1.Implementation;

--- a/src/components/parameters/test/test_component_2/component-test_component_2-implementation.ads
+++ b/src/components/parameters/test/test_component_2/component-test_component_2-implementation.ads
@@ -50,5 +50,15 @@ private
    -- hardware registers, or performing other special functionality that only needs to be performed after parameters have
    -- been updated.
    overriding procedure Update_Parameters_Action (Self : in out Instance) is null;
+   -- This function is called when the parameter operation type is "Validate". The default implementation of this
+   -- subprogram in the implementation package is a function that returns "Valid". However, this function can, and should be
+   -- overridden if something special needs to happen to further validate a parameter. Examples of this might be validation of
+   -- certain parameters beyond individual type ranges, or performing other special functionality that only needs to be
+   -- performed after parameters have been validated. Note that range checking is performed during staging, and does not need
+   -- to be implemented here.
+   overriding function Validate_Parameters (
+      Self : in out Instance;
+      The_Tick : in Tick.U
+   ) return Parameter_Validation_Status.E is (Parameter_Validation_Status.Valid);
 
 end Component.Test_Component_2.Implementation;

--- a/src/components/pid_controller/component-pid_controller-implementation.ads
+++ b/src/components/pid_controller/component-pid_controller-implementation.ads
@@ -133,5 +133,20 @@ private
    -- hardware registers, or performing other special functionality that only needs to be performed after parameters have
    -- been updated.
    overriding procedure Update_Parameters_Action (Self : in out Instance) is null;
+   -- This function is called when the parameter operation type is "Validate". The default implementation of this
+   -- subprogram in the implementation package is a function that returns "Valid". However, this function can, and should be
+   -- overridden if something special needs to happen to further validate a parameter. Examples of this might be validation of
+   -- certain parameters beyond individual type ranges, or performing other special functionality that only needs to be
+   -- performed after parameters have been validated. Note that range checking is performed during staging, and does not need
+   -- to be implemented here.
+   overriding function Validate_Parameters (
+      Self : in out Instance;
+      P_Gain : in Packed_F32.U;
+      I_Gain : in Packed_F32.U;
+      D_Gain : in Packed_F32.U;
+      N_Filter : in Packed_F32.U;
+      I_Min_Limit : in Packed_F32.U;
+      I_Max_Limit : in Packed_F32.U
+   ) return Parameter_Validation_Status.E is (Parameter_Validation_Status.Valid);
 
 end Component.Pid_Controller.Implementation;

--- a/src/types/parameter/parameter_enums.enums.yaml
+++ b/src/types/parameter/parameter_enums.enums.yaml
@@ -13,8 +13,11 @@ enums:
       - name: Fetch
         value: 2
         description: Fetch the parameter.
+      - name: Validate
+        value: 3
+        description: Validate the parameter.
   - name: Parameter_Update_Status
-    description: This status enumerations provides information on the success/failure of a parameter operation.
+    description: This status enumeration provides information on the success/failure of a parameter operation.
     literals:
       - name: Success
         value: 0
@@ -38,7 +41,7 @@ enums:
         value: 1
         description: Set the current values of the parameters.
   - name: Parameter_Table_Update_Status
-    description: This status enumerations provides information on the success/failure of a parameter table update.
+    description: This status enumeration provides information on the success/failure of a parameter table update.
     literals:
       - name: Success
         value: 0
@@ -55,3 +58,12 @@ enums:
       - name: Dropped
         value: 4
         description: The operation could not be performed because it was dropped from a full queue.
+  - name: Parameter_Validation_Status
+    description: This status enumeration provides information on the result of validating a set of parameters.
+    literals:
+      - name: Valid
+        value: 0
+        description: Parameters were validated.
+      - name: Invalid
+        value: 1
+        description: Parameters were found to be invalid.

--- a/src/types/parameter/parameter_table_header.record.yaml
+++ b/src/types/parameter/parameter_table_header.record.yaml
@@ -1,5 +1,5 @@
 ---
-description: A packed record which holds parameter table header data. This data is asswill be prepended to the table data upon upload.
+description: A packed record which holds parameter table header data. This data is will be prepended to the table data upon upload.
 preamble: |
   -- Declare the start index at which to begin calculating the CRC. The
   -- start index is dependent on this type, and so is declared here so that


### PR DESCRIPTION
This pull request adds the optionally implementable `Validate_Parameters` which allows a user to leverage custom inter-parameter validation in addition to individual component validation. This is optional, but components which have parameters will still have the default implementation of the action added to their respective generated templates.