### PR TITLE
Remove old references to /share

### DIFF
--- a/gnd/bin/socket_event_decoder_to_bin.sh
+++ b/gnd/bin/socket_event_decoder_to_bin.sh
@@ -4,9 +4,8 @@ assembly_events_file=$1
 
 if test -z "$assembly_events_file"
 then
-  echo "usage: socket_event_decoder_to_bin.sh /share/path/to/assembly_events.py"
+  echo "usage: socket_event_decoder_to_bin.sh /path/to/assembly_events.py"
   echo "description: Convert a python script to a standalone executable with no dependencies that can run on any platform. You must provide the assembly events file that this program will be run with in production."
-  echo "NOTE: your path to assembly_events.py must start with /share, not /home. There is an issue when starting from /home."
   exit 1
 fi
 

--- a/redo/util/performance.py
+++ b/redo/util/performance.py
@@ -16,9 +16,9 @@ def optimize_path():
         env_paths = []
         other_paths = []
         for p in sys.path:
-            if not (p.startswith("/share") or p.startswith("/home")):
+            if not p.startswith("/home"):
                 system_paths.append(p)
-            elif "env/python" in p:
+            elif ".py_env" in p:
                 env_paths.append(p)
             else:
                 other_paths.append(p)

--- a/src/components/product_packetizer/gen/generators/product_packets.py
+++ b/src/components/product_packetizer/gen/generators/product_packets.py
@@ -71,10 +71,11 @@ class product_packets_ads(product_packets_gen, generator_base):
 
 class product_packets_html(product_packets_gen, generator_base):
     def __init__(self):
+        from os import environ
         product_packets_gen.__init__(
             self,
             template_filename="name.html",
-            additional_template_dirs=["/share/adamant/gen/templates"],
+            additional_template_dirs=[environ["ADAMANT_DIR"] + os.sep + "gen" + os.sep + "templates"],
         )
 
     def generate(self, input_filename):


### PR DESCRIPTION
This commit removes old references to /share which is the location where code used to be shared between the Adamant virtual development environment and the user's host machine. The location of these bind mounts have since changed.