### PR TITLE
COSMOS Plugin Command Template Fixes

### DIFF
--- a/src/components/ccsds_command_depacketizer/gen/templates/assembly/name_ccsds_cosmos_commands.txt
+++ b/src/components/ccsds_command_depacketizer/gen/templates/assembly/name_ccsds_cosmos_commands.txt
@@ -4,7 +4,7 @@ Command {{ name }} {{ command.suite.component.instance_name }}-{{ command.name }
 {# The ccsds command header #}
 {% set header_bit_position = [] %}
 {% for field_name, field in ccsds_primary_header_model.fields.items() %}
-{% if loop.last %}{% set _ = header_bit_position.append(field.start_bit + field.size) %}{% endif %}  Parameter {{ field.name }} {{ field.start_bit }} {{ field.size }} {{ plugin_format_dictionary[field.format.type[0]] }} 0 {{ 2**field.size - 1 }} {% if field.name == 'Packet_Length' %}{% if command.size != None %}{{ (command.type_model.fields|length * (command.size / 8) + 3)|int -}}
+{% if loop.last %}{% set _ = header_bit_position.append(field.start_bit + field.size) %}{% endif %}  Parameter {{ field.name }} {{ field.start_bit }} {{ field.size }} {{ plugin_format_dictionary[field.format.type[0]] }} 0 {{ 2**field.size - 1 }} {% if field.name == 'Packet_Length' %}{% if command.type_model %}{{ ((command.type_model.size / 8) + 3)|int -}}
 {% else %}3{% endif %}{% elif field.name == 'Packet_Type' %}1{% elif field.name == 'Secondary_Header' %}1{% elif field.name == 'Apid' %}8{% elif field.name == 'Sequence_Flag' %}3{% else %}{% if field.default_value == None or not field.default_value.isnumeric() %}0{% else %}{{ field.default_value }}{% endif %}{% endif %} "{{ field.description|replace('\n','->') }}"
 {% if field.is_enum %}
 {% for literals in field.datatype.model.literals %}
@@ -18,12 +18,12 @@ Command {{ name }} {{ command.suite.component.instance_name }}-{{ command.name }
 {% endfor %}{% endif -%}{% endfor %}
   ID_Parameter Adamant_Command_Id 64 16 UINT MIN MAX {{ command.id }} "Adamant command ID"
 {# The command argument definitions. #}
-{% if command.type %}{% if command.type_model %}{% for field in command.type_model.flatten() %}
+{% if command.type %}{% if command.type_model %}{% for name, field in command.type_model.flatten_dict().items() %}
   {% if 'x' in (field.format|string)[2] %}Append_Array_Parameter {% if field.type_model.name %}{{ field.type_model.name }}.{% endif %}{{ field.name }} {{ (field.format|string)[1] }} {{ plugin_format_dictionary[field.format.type[0]] }} {{ (field.format|string)[1]|int * (field.format|string)[3:]|int }} "{{ field.description|replace('\n','->') }}"
-{% else %}Append_Parameter {% if field.type_model.name %}{{ field.type_model.name }}.{% endif %}{{ field.name }} {% if field.format.type %}{{ field.format.type[1:] }}{% endif %}{% if field.type_model.size %}{{ field.type_model.size }}{% endif %}
+{% else %}Append_Parameter {% if field.type_model.name %}{{ field.type_model.name }}.{% endif %}{{ name }} {% if field.format.type %}{{ field.format.type[1:] }}{% endif %}{% if field.type_model.size %}{{ field.type_model.size }}{% endif %}
  {{ plugin_format_dictionary[field.format.type[0]] }} MIN MAX {% if command.default_value %}{{ command.default_value }}{% else %}0{% endif %} "{{ field.description|replace('\n','->') }}"
-{% if field.format and 'E' in (field.format|string)[0] %}{% for literals in field.type_model.literals %}
-    State {{ literals.name }} {{ literals.value }}
+{% if field.format and 'E' in (field.format|string)[0] %}{% for literal in field.type_model.literals %}
+    State {{ literal.name }} {{ literal.value }}
 {% endfor %}{% endif %}{% endif %}
 {% endfor %}{% endif %}{% endif %}
 


### PR DESCRIPTION
This pull request updates the COSMOS plugin command template with improved name and length information for parameters.

Previous parameter name output produced identical parameter names for certain command parameter ranges, causing the compiled plugin to only contain one parameter when there should have been two.

Parameter length output was also incorrect for several commands with multiple appended parameters.

The revised behavior now includes the flattened name in addition to the field attributes when iterating over `type_model.flatten_dict()`. Parameter length is now calculated using `type_model.size`.