### PR TITLE
Add interpacket gap capability to Serial Interface

### DIFF
--- a/src/components/ccsds_serial_interface/ccsds_serial_interface.component.yaml
+++ b/src/components/ccsds_serial_interface/ccsds_serial_interface.component.yaml
@@ -5,6 +5,13 @@ execution: active
 subtasks:
   - name: Listener
     description: This internal task is used to listen on the serial port for incoming packets.
+init:
+  description: Init to provide gap between packets if necessary
+  parameters:
+    - name: Interpacket_Gap_Ms
+      type: Natural
+      default: "0"
+      description: Amount of time in milliseconds to wait in between transmission of each CCSDS packet. Some UART protocols rely on a gap to differentiate between packets, and this can be used to enforce that.
 connectors:
   - description: On this connector the Socket Interface Component receives data and sends it out of the socket.
     type: Ccsds_Space_Packet.T

--- a/src/components/ccsds_serial_interface/component-ccsds_serial_interface-implementation.adb
+++ b/src/components/ccsds_serial_interface/component-ccsds_serial_interface-implementation.adb
@@ -8,10 +8,26 @@ with Ccsds_Primary_Header;
 with Interfaces;
 with Ada.Execution_Time;
 with Ada.Real_Time;
+with Sleep;
 -- with Ada.Text_IO; use Ada.Text_IO;
 -- with Basic_Types.Representation;
 
 package body Component.Ccsds_Serial_Interface.Implementation is
+
+   --------------------------------------------------
+   -- Subprogram for implementation init method:
+   --------------------------------------------------
+   -- Init to provide gap between packets if necessary
+   --
+   -- Init Parameters:
+   -- Interpacket_Gap_Ms : Natural - Amount of time in milliseconds to wait in
+   -- between transmission of each CCSDS packet. Some UART protocols rely on a gap to
+   -- differentiate between packets, and this can be used to enforce that.
+   --
+   overriding procedure Init (Self : in out Instance; Interpacket_Gap_Ms : in Natural := 0) is
+   begin
+      Self.Interpacket_Gap_Ms := Interpacket_Gap_Ms;
+   end Init;
 
    ---------------------------------------
    -- Invokee connector primitives:
@@ -55,6 +71,9 @@ package body Component.Ccsds_Serial_Interface.Implementation is
          begin
             Diagnostic_Uart.Put (Sync_Pattern & Bytes (0 .. Num_Bytes_Serialized - 1));
             --Put_Line(Standard_Error, Basic_Types.Representation.Image(sync_Pattern & bytes(0 .. num_Bytes_Serialized - 1)));
+            if Self.Interpacket_Gap_Ms > 0 then
+               Sleep.Sleep_Ms (Self.Interpacket_Gap_Ms);
+            end if;
          end;
       end if;
    end Ccsds_Space_Packet_T_Recv_Async;

--- a/src/components/ccsds_serial_interface/component-ccsds_serial_interface-implementation.ads
+++ b/src/components/ccsds_serial_interface/component-ccsds_serial_interface-implementation.ads
@@ -16,6 +16,18 @@ package Component.Ccsds_Serial_Interface.Implementation is
    -- The component class instance record:
    type Instance is new Ccsds_Serial_Interface.Base_Instance with private;
 
+   --------------------------------------------------
+   -- Subprogram for implementation init method:
+   --------------------------------------------------
+   -- Init to provide gap between packets if necessary
+   --
+   -- Init Parameters:
+   -- Interpacket_Gap_Ms : Natural - Amount of time in milliseconds to wait in
+   -- between transmission of each CCSDS packet. Some UART protocols rely on a gap to
+   -- differentiate between packets, and this can be used to enforce that.
+   --
+   overriding procedure Init (Self : in out Instance; Interpacket_Gap_Ms : in Natural := 0);
+
 private
 
    -- The component class instance record:
@@ -24,6 +36,7 @@ private
       Task_Id_Set : Boolean := False;
       Cpu_Usage : Float;
       Count : Natural := 0;
+      Interpacket_Gap_Ms : Natural := 0;
    end record;
 
    ---------------------------------------


### PR DESCRIPTION
This allows the user to configure a gap (in ms) to be adhered to in between packets transmitted by the Ccsds_Serial_Interface component.