### PR TITLE
Fix compiler flags for Linux targets

### DIFF
--- a/redo/targets/gpr/linux_analyze.gpr
+++ b/redo/targets/gpr/linux_analyze.gpr
@@ -15,6 +15,9 @@ project linux_analyze extends all "a_linux_debug_base.gpr" is
       for Switches ("Ada") use a_linux_debug_base.Compiler'Switches ("Ada") &
          -- add ravenscar restriction
          ("-gnatec=" & a_adamant.ADAMANT_DIR & "/redo/targets/configuration_pragmas/ravenscar.adc");
+      for Switches ("C++") use a_linux_debug_base.Compiler'Switches ("C++");
+      for Switches ("C") use a_linux_debug_base.Compiler'Switches ("C");
+      for Switches ("Asm_Cpp") use a_linux_debug_base.Compiler'Switches ("Asm_Cpp");
    end Compiler;
 
    -- Force analysis into "deep" mode

--- a/redo/targets/gpr/linux_coverage.gpr
+++ b/redo/targets/gpr/linux_coverage.gpr
@@ -23,6 +23,13 @@ project linux_coverage extends all "a_linux_debug_base.gpr" is
       for Switches ("Ada") use a_linux_debug_base.Compiler'Switches ("Ada") &
          -- gcov instrumentation flags
          ("-fprofile-arcs", "-ftest-coverage");
+      for Switches ("C++") use a_linux_debug_base.Compiler'Switches ("C++") &
+         -- gcov instrumentation flags
+         ("-fprofile-arcs", "-ftest-coverage");
+      for Switches ("C") use a_linux_debug_base.Compiler'Switches ("C") &
+         -- gcov instrumentation flags
+         ("-fprofile-arcs", "-ftest-coverage");
+      for Switches ("Asm_Cpp") use a_linux_debug_base.Compiler'Switches ("Asm_Cpp");
    end Compiler;
 
    package Linker is

--- a/redo/targets/gpr/linux_debug.gpr
+++ b/redo/targets/gpr/linux_debug.gpr
@@ -15,6 +15,9 @@ project linux_debug extends all "a_linux_debug_base.gpr" is
       for Switches ("Ada") use a_linux_debug_base.Compiler'Switches ("Ada") &
          -- add ravenscar restriction
          ("-gnatec=" & a_adamant.ADAMANT_DIR & "/redo/targets/configuration_pragmas/ravenscar.adc");
+      for Switches ("C++") use a_linux_debug_base.Compiler'Switches ("C++");
+      for Switches ("C") use a_linux_debug_base.Compiler'Switches ("C");
+      for Switches ("Asm_Cpp") use a_linux_debug_base.Compiler'Switches ("Asm_Cpp");
    end Compiler;
 
 end linux_debug;


### PR DESCRIPTION
The compiler flags were not properly propogated through the abstract gpr files, so some options were getting lost for some languages. This fixes that issue so the compiler flags are passed properly through the abstract gpr files to the linux gpr files.