### PR TITLE
Make basic generator robust to caps in filename

### DIFF
--- a/gen/generators/basic.py
+++ b/gen/generators/basic.py
@@ -260,9 +260,9 @@ class basic_generator(object):
 
         # Construct the filename:
         if specific_name:
-            output_filename = self._get_default_output_filename(specific_name)
+            output_filename = self._get_default_output_filename(specific_name.lower())
         else:
-            output_filename = self._get_default_output_filename(model_name)
+            output_filename = self._get_default_output_filename(model_name.lower())
 
         # Return the suggested output filename:
         return dirname + os.sep + build_dir + os.sep + output_filename


### PR DESCRIPTION
This ensures that a model filename with capitalization in it still produces autocoded Ada that is all lower case.