### PR TITLE
Remove unnecessary `pragma Ada_2022`s

### DIFF
--- a/gen/templates/array/name-validation.adb
+++ b/gen/templates/array/name-validation.adb
@@ -3,7 +3,6 @@
 --
 -- Generated from {{ filename }} on {{ time }}.
 --------------------------------------------------------------------------------
-pragma Ada_2022;
 
 {% if unpacked_types %}
 -- Standard includes:

--- a/gen/templates/array/name.adb
+++ b/gen/templates/array/name.adb
@@ -3,7 +3,6 @@
 --
 -- Generated from {{ filename }} on {{ time }}.
 --------------------------------------------------------------------------------
-pragma Ada_2022;
 
 package body {{ name }} is
 

--- a/gen/templates/array/name.ads
+++ b/gen/templates/array/name.ads
@@ -3,7 +3,6 @@
 --
 -- Generated from {{ filename }} on {{ time }}.
 --------------------------------------------------------------------------------
-pragma Ada_2022;
 
 -- Standard Includes:
 with System;

--- a/gen/templates/record/name-validation.adb
+++ b/gen/templates/record/name-validation.adb
@@ -3,7 +3,6 @@
 --
 -- Generated from {{ filename }} on {{ time }}.
 --------------------------------------------------------------------------------
-pragma Ada_2022;
 
 {% if unpacked_types %}
 with Byte_Array_Util;

--- a/gen/templates/record/name.adb
+++ b/gen/templates/record/name.adb
@@ -3,7 +3,6 @@
 --
 -- Generated from {{ filename }} on {{ time }}.
 --------------------------------------------------------------------------------
-pragma Ada_2022;
 
 package body {{ name }} is
 

--- a/gen/templates/record/name.ads
+++ b/gen/templates/record/name.ads
@@ -3,7 +3,6 @@
 --
 -- Generated from {{ filename }} on {{ time }}.
 --------------------------------------------------------------------------------
-pragma Ada_2022;
 
 -- Standard Includes:
 with Basic_Types;

--- a/gen/test/arrays/test/test.adb
+++ b/gen/test/arrays/test/test.adb
@@ -1,4 +1,3 @@
-pragma Ada_2022;
 with Ada.Text_IO; use Ada.Text_IO;
 with Simple_Array.Representation;
 with Complex_Array.Representation;

--- a/gen/test/records/test/test.adb
+++ b/gen/test/records/test/test.adb
@@ -1,4 +1,3 @@
-pragma Ada_2022;
 with Ada.Text_IO; use Ada.Text_IO;
 with Aa.Representation;
 with Aa.Validation;


### PR DESCRIPTION
Since Ada 2022 is supported throughout all of Adamant, these local pragmas are no longer necessary.