### PR TITLE
Fix for linking to unbuilt C/C++ objects

### DIFF
--- a/redo/targets/gpr/a_adamant.gpr
+++ b/redo/targets/gpr/a_adamant.gpr
@@ -4,6 +4,7 @@ abstract project a_adamant is
    -- Adamant build system and GPRBuild.
    ADAMANT_DIR := external("ADAMANT_DIR", "");
    SOURCE_DIRS := external_as_list("SOURCE_DIRS", ",");
+   EXCLUDED_SOURCE_FILES := external_as_list("EXCLUDED_SOURCE_FILES", ",");
    OBJECT_DIR := external("OBJECT_DIR", "");
    EXEC_DIR := external("EXEC_DIR", "");
    CHECK_STYLE := external("CHECK_STYLE", "False");

--- a/redo/targets/gpr/linux_analyze.gpr
+++ b/redo/targets/gpr/linux_analyze.gpr
@@ -7,6 +7,7 @@ project linux_analyze extends all "a_linux_debug_base.gpr" is
    -- to GPRBuild.
    -----------------------------------------------
    for Source_Dirs use a_adamant.SOURCE_DIRS;
+   for Excluded_Source_Files use a_adamant.EXCLUDED_SOURCE_FILES;
    for Object_Dir use a_adamant.OBJECT_DIR;
    for Exec_Dir use a_adamant.EXEC_DIR;
 

--- a/redo/targets/gpr/linux_coverage.gpr
+++ b/redo/targets/gpr/linux_coverage.gpr
@@ -10,6 +10,7 @@ project linux_coverage extends all "a_linux_debug_base.gpr" is
    -- to GPRBuild.
    -----------------------------------------------
    for Source_Dirs use a_adamant.SOURCE_DIRS;
+   for Excluded_Source_Files use a_adamant.EXCLUDED_SOURCE_FILES;
    for Object_Dir use a_adamant.OBJECT_DIR;
    for Exec_Dir use a_adamant.EXEC_DIR;
 

--- a/redo/targets/gpr/linux_debug.gpr
+++ b/redo/targets/gpr/linux_debug.gpr
@@ -7,6 +7,7 @@ project linux_debug extends all "a_linux_debug_base.gpr" is
    -- to GPRBuild.
    -----------------------------------------------
    for Source_Dirs use a_adamant.SOURCE_DIRS;
+   for Excluded_Source_Files use a_adamant.EXCLUDED_SOURCE_FILES;
    for Object_Dir use a_adamant.OBJECT_DIR;
    for Exec_Dir use a_adamant.EXEC_DIR;
 

--- a/redo/targets/gpr/linux_test.gpr
+++ b/redo/targets/gpr/linux_test.gpr
@@ -10,6 +10,7 @@ project linux_test extends all "a_linux_debug_base.gpr" is
    -- to GPRBuild.
    -----------------------------------------------
    for Source_Dirs use a_adamant.SOURCE_DIRS;
+   for Excluded_Source_Files use a_adamant.EXCLUDED_SOURCE_FILES;
    for Object_Dir use a_adamant.OBJECT_DIR;
    for Exec_Dir use a_adamant.EXEC_DIR;
 


### PR DESCRIPTION
Linking to C/C++ would fail when only a portion of the C/C++ source files in a directory are dependencies of the currently compiling binary. Only some of the files would be compiled into objects, but GPRBuild (by default) tries to link to all C/C++ objects found in a directory in the Source_Dirs. To work around this, at link time, we now pass a list of files to exclude from the build, which includes C/C++ files that exist in the Source_Dirs, but are not dependencies of the currently compiling binary.