### PR TITLE
Pydep function update

### DIFF
--- a/redo/util/pydep.py
+++ b/redo/util/pydep.py
@@ -178,21 +178,31 @@ def run_py(source_file):
 # This can also be run from the command line:
 if __name__ == "__main__":
     args = sys.argv[1:]
+    verbose = "--verbose" in args or "-v" in args
+    if "--verbose" in args:
+        args.remove("--verbose")
+    if "-v" in args:
+        args.remove("-v")
+
     if not args:
-        print("usage:\n  pydep.py /path/to/python_file1.py /path/to/python_file2.py ...")
+        print("usage:\n  pydep.py [--verbose or -v] /path/to/python_file1.py /path/to/python_file2.py ...")
         sys.exit(1)
 
     for source_file in args:
-        print(f"\nFinding dependencies for: {source_file}")
         existing_deps, nonexistant_deps = pydep(source_file)
 
-        print("\nExisting dependencies:")
-        for dep in existing_deps:
-            print(dep)
+        if verbose:
+            print(f"\nFinding dependencies for: {source_file}")
+            print("\nExisting dependencies:")
+            for dep in existing_deps:
+                print(dep)
 
-        print("\nNonexistent dependencies:")
-        for dep in nonexistant_deps:
-            print(dep)
+            print("\nNonexistent dependencies:")
+            for dep in nonexistant_deps:
+                print(dep)
 
-        print("\nBuilding nonexistent dependencies:")
+            print("\nBuilding nonexistent dependencies:")
+
         build_py_deps(source_file)
+
+        print("\n".join(existing_deps))

--- a/redo/util/pydep.py
+++ b/redo/util/pydep.py
@@ -35,7 +35,10 @@ def pydep(source_file, path=[]):
                 spec = importlib.util.find_spec(name)
                 # if module (and its origin file) exists, append to the existing_deps
                 if spec is not None:
-                    existing_deps.append(name)
+                    if spec.origin is None or spec.origin == "built-in":
+                        existing_deps.append(f"built-in:{name}")
+                    else:
+                        existing_deps.append(spec.origin)
                 else:
                     nonexistent_deps.append(name)
 
@@ -44,11 +47,14 @@ def pydep(source_file, path=[]):
             if name:  # if name is not None
                 spec = importlib.util.find_spec(name)
                 if spec is not None:
-                    existing_deps.append(name)
+                    if spec.origin is None or spec.origin == "built-in":
+                        existing_deps.append(f"built-in:{name}")
+                    else:
+                        existing_deps.append(spec.origin)
                 else:
                     nonexistent_deps.append(name)
 
-    return existing_deps, nonexistent_deps
+    return list(set(existing_deps)), nonexistent_deps
 
 
 def _build_pydeps(source_file, path=[]):
@@ -188,8 +194,11 @@ if __name__ == "__main__":
         print("usage:\n  pydep.py [--verbose or -v] /path/to/python_file1.py /path/to/python_file2.py ...")
         sys.exit(1)
 
+    all_existing_deps = set()
+
     for source_file in args:
         existing_deps, nonexistant_deps = pydep(source_file)
+        all_existing_deps.update(existing_deps)
 
         if verbose:
             print(f"\nFinding dependencies for: {source_file}")
@@ -205,4 +214,4 @@ if __name__ == "__main__":
 
         build_py_deps(source_file)
 
-        print("\n".join(existing_deps))
+    print("\n".join(sorted(all_existing_deps)))

--- a/redo/util/pydep.py
+++ b/redo/util/pydep.py
@@ -35,7 +35,7 @@ def pydep(source_file, path=[]):
                 spec = importlib.util.find_spec(name)
                 # if module (and its origin file) exists, append to the existing_deps
                 if spec is not None:
-                    if spec.origin is None or spec.origin == "built-in":
+                    if spec.origin is None or "built-in" in spec.origin or "site-packages" in spec.origin:
                         existing_deps.append(f"built-in:{name}")
                     else:
                         existing_deps.append(spec.origin)
@@ -47,7 +47,7 @@ def pydep(source_file, path=[]):
             if name:  # if name is not None
                 spec = importlib.util.find_spec(name)
                 if spec is not None:
-                    if spec.origin is None or spec.origin == "built-in":
+                    if spec.origin is None or "built-in" in spec.origin or "site-packages" in spec.origin:
                         existing_deps.append(f"built-in:{name}")
                     else:
                         existing_deps.append(spec.origin)

--- a/redo/util/pydep.py
+++ b/redo/util/pydep.py
@@ -153,7 +153,7 @@ def build_py_deps(source_file=None, update_path=True):
         redo_3=source_file + ".out",
     )
 
-    # Reset the database, so that this function can be run again, if warrented.
+    # Reset the database, so that this function can be run again, if warranted.
     import database.setup
 
     database.setup.reset()
@@ -169,7 +169,7 @@ def run_py(source_file):
         redo_3=source_file + ".out",
     )
 
-    # Reset the database, so that this function can be run again, if warrented.
+    # Reset the database, so that this function can be run again, if warranted.
     import database.setup
 
     database.setup.reset()
@@ -177,21 +177,22 @@ def run_py(source_file):
 
 # This can also be run from the command line:
 if __name__ == "__main__":
-    args = sys.argv[-2:]
-    if len(args) != 2 or args[-1].endswith("pydep.py"):
-        print("usage:\n  pydep.py /path/to/python_file.py")
-    source_file = args[-1]
+    args = sys.argv[1:]
+    if not args:
+        print("usage:\n  pydep.py /path/to/python_file1.py /path/to/python_file2.py ...")
+        sys.exit(1)
 
-    existing_deps, nonexistant_deps = pydep(source_file)
-    print("Finding dependencies for: " + source_file)
-    print("")
-    print("Existing dependencies: ")
-    for dep in existing_deps:
-        print(dep)
-    print("")
-    print("Nonexistent dependencies: ")
-    for dep in nonexistant_deps:
-        print(dep)
-    print("")
-    print("Building nonexistent dependencies: ")
-    build_py_deps(source_file)
+    for source_file in args:
+        print(f"\nFinding dependencies for: {source_file}")
+        existing_deps, nonexistant_deps = pydep(source_file)
+
+        print("\nExisting dependencies:")
+        for dep in existing_deps:
+            print(dep)
+
+        print("\nNonexistent dependencies:")
+        for dep in nonexistant_deps:
+            print(dep)
+
+        print("\nBuilding nonexistent dependencies:")
+        build_py_deps(source_file)

--- a/redo/util/pydep.py
+++ b/redo/util/pydep.py
@@ -32,6 +32,8 @@ def pydep(source_file, path=[]):
         if isinstance(node, ast.Import):
             for alias in node.names:
                 name = alias.name  # name of the module
+                if name == "openc3.script":
+                    continue
                 spec = importlib.util.find_spec(name)
                 # if module (and its origin file) exists, append to the existing_deps
                 if spec is not None:
@@ -44,6 +46,8 @@ def pydep(source_file, path=[]):
 
         if isinstance(node, ast.ImportFrom):
             name = node.module  # name of the module
+            if name == "openc3.script":
+                continue
             if name:  # if name is not None
                 spec = importlib.util.find_spec(name)
                 if spec is not None:


### PR DESCRIPTION
This pull request adds the following features to the `pydep.py` function:
- Accepts a list of files as arguments
- Adds 'verbose' mode with `-v` or `--verbose` arguments, which will output the previously implemented level of information
- Normal output now outputs the entire path to identified dependencies, without duplicates
- Adds `-i` or `--ignore` argument flags, which will ignore any packages containing an entry in the list of strings following the flag, for example:
```pydep -v sourceFile1.py sourceFile2.py -i ignore1 ignore2```
ignores any packages with names containing the strings "ignore1" or "ignore2"
- Catches exceptions when `ModuleNotFoundError` is thrown