### PR TITLE
COSMOS Plugin Telemetry Fix

### DIFF
--- a/src/components/ccsds_packetizer/gen/templates/assembly/name_ccsds_cosmos_telemetry.txt
+++ b/src/components/ccsds_packetizer/gen/templates/assembly/name_ccsds_cosmos_telemetry.txt
@@ -14,6 +14,7 @@ Telemetry {{ name }} {{ packet.name }} Big_Endian "{{ packet.description }}"
   Item {{ field.name }} {{ header_bit_position|last + field.start_bit }} {{ field.size }} {{ plugin_format_dictionary[field.format.type[0]] }} "{{ field.description|replace('\n','->') }}"
 {% endfor %}
 {# The packet definitions. #}
+{% if packet.items %}
 {% for item_name, item in packet.items.items() %}
   {% if 'x' in (item.format|string)[2] %}Append_Array_Item {% if item.type_model.name %}{{ item.type_model.name }}.{% endif %}{{ item.name }} {{ (item.format|string)[1] }} {{ plugin_format_dictionary[item.format.type[0]] }} {{ (item.format|string)[1]|int * (item.format|string)[3:]|int }} "{{ item.description|replace('\n','->') }}"
 {% else %}Append_Item {{ item.entity.full_name }}{% if item.flat_name %}.{{ item.flat_name }}{% endif %} {{ item.size }} {{ plugin_format_dictionary[item.format.type[0]] }} "{{ item.flat_desc|replace('\n','->') }}"
@@ -22,9 +23,9 @@ Telemetry {{ name }} {{ packet.name }} Big_Endian "{{ packet.description }}"
     State {{ literals.name }} {{ literals.value }}
 {% endfor %}{% endif %}{% endif %}
 {% endfor %}
-{% if packet.name|string == 'Events_Packet' %}  Append_Item Subpacket.Data -16 BLOCK "Subpacket data"
+  Append_Item CRC 16 UINT "Packet CRC value"
+{% else %}  Append_Item Subpacket.Data -16 BLOCK "Subpacket data"
   Item CRC -16 16 UINT "Packet CRC value"
-{% else %}  Append_Item CRC 16 UINT "Packet CRC value"
 {% endif %}
 
 {% endfor %}


### PR DESCRIPTION
When generating the telemetry configuration for the COSMOS plugin, block data was only generated if the packet name was Events_Packet. Instead, the generator template now checks the packet item array, and produces the block data item in the correct case, similar to the Hydra template. Note that the CRC item is handled differently when the block data item is present, as the subpacket data has an indeterminate length at plugin compile time.