### PR TITLE
Fix consistency issue with enum modeling

### DIFF
--- a/gen/models/record.py
+++ b/gen/models/record.py
@@ -537,6 +537,7 @@ class record(packed_type):
             if (
                 not f.type_ranges_loaded
                 and not f.is_packed_type
+                and not f.is_modeled_enum
                 and not f.format.length
                 and not f.skip_validation
             ):
@@ -548,6 +549,7 @@ class record(packed_type):
                 # OK this must be an enumeration instead:
                 except AttributeError:
                     f.literals = type_range.literals
+                    f.is_enum = True
                 f.type_ranges_loaded = True
 
     def is_always_valid(self):

--- a/gen/models/submodels/variable.py
+++ b/gen/models/submodels/variable.py
@@ -15,6 +15,7 @@ class datatype(object):
         self.is_atomic_type = False
         self.is_register_type = False
         self.is_enum = False
+        self.is_modeled_enum = False
         # set to true when range_min/range_max or literals is set.
         # we don't do this preemptively since it takes a lot of time
         # to set these, and they are rarely needed.
@@ -41,7 +42,14 @@ class datatype(object):
                 if self.model:
                     self.package = sp[0]
                     self.model = self.model.get_enum_by_name(sp[1])
+                    self.is_modeled_enum = True
                     self.is_enum = True
+                    # Save literals at this level so it mirrors how we save off
+                    # literals for type ranges of bare Ada enum types. In this case
+                    # we have a "modeled" enum, but we still want to reflect the
+                    # literals at the datatype level so modeled enums and bare
+                    # Ada enums can be treated uniformly by users of the datatype.
+                    self.literals = self.model.literals
             elif self.name.endswith(".Volatile_T") or self.name.endswith(
                 ".Volatile_T_Le"
             ):
@@ -119,8 +127,16 @@ class variable(object):
         return self.datatype.is_atomic_type
 
     @property
+    def is_modeled_enum(self):
+        return self.datatype.is_modeled_enum
+
+    @property
     def is_enum(self):
         return self.datatype.is_enum
+
+    @is_enum.setter
+    def is_enum(self, value):
+        self.datatype.is_enum = value
 
     @property
     def range_min(self):

--- a/src/components/ccsds_command_depacketizer/gen/generators/ccsds_commands.py
+++ b/src/components/ccsds_command_depacketizer/gen/generators/ccsds_commands.py
@@ -21,6 +21,7 @@ class assembly_ccsds_commands_xml(assembly_hydra_generator, generator_base):
         a = self.model_cls(input_filename)
         if "Ccsds_Command_Depacketizer" in a.component_types_dict:
             a.additional_types.append("Ccsds_Command_Secondary_Header.T")
+        a.load_command_type_ranges()
         assembly_gen.create_type_field_strings(a)
         print(a.render(self.template, template_path=self.template_dir))
 
@@ -37,5 +38,6 @@ class assembly_cosmos_commands_txt(assembly_cosmos_plugin_generator_base, genera
         a = self.model_cls(input_filename)
         a.ccsds_primary_header_model = model_loader.try_load_model_by_name("Ccsds_Primary_Header")
         a.ccsds_command_secondary_header = model_loader.try_load_model_by_name("Ccsds_Command_Secondary_Header")
+        a.load_command_type_ranges()
         assembly_gen.create_type_field_strings(a)
         print(a.render(self.template, template_path=self.template_dir))

--- a/src/components/ccsds_command_depacketizer/gen/templates/assembly/name_ccsds_cosmos_commands.txt
+++ b/src/components/ccsds_command_depacketizer/gen/templates/assembly/name_ccsds_cosmos_commands.txt
@@ -7,14 +7,14 @@ Command {{ name }} {{ command.suite.component.instance_name }}-{{ command.name }
 {% if loop.last %}{% set _ = header_bit_position.append(field.start_bit + field.size) %}{% endif %}  Parameter {{ field.name }} {{ field.start_bit }} {{ field.size }} {{ plugin_format_dictionary[field.format.type[0]] }} 0 {{ 2**field.size - 1 }} {% if field.name == 'Packet_Length' %}{% if command.type_model %}{{ ((command.type_model.size / 8) + 3)|int -}}
 {% else %}3{% endif %}{% elif field.name == 'Packet_Type' %}1{% elif field.name == 'Secondary_Header' %}1{% elif field.name == 'Apid' %}8{% elif field.name == 'Sequence_Flag' %}3{% else %}{% if field.default_value == None or not field.default_value.isnumeric() %}0{% else %}{{ field.default_value }}{% endif %}{% endif %} "{{ field.description|replace('\n','->') }}"
 {% if field.is_enum %}
-{% for literals in field.datatype.model.literals %}
-    State {{ literals.name }} {{ literals.value }}
+{% for literal in field.literals %}
+    State {{ literal.name }} {{ literal.value }}
 {% endfor %}{% endif -%}{% endfor %}
 {% for field_name, field in ccsds_command_secondary_header.fields.items() %}
   Parameter {{ field.name }} {{ header_bit_position|last + field.start_bit }} {{ field.size }} {{ plugin_format_dictionary[field.format.type[0]] }} 0 {{ 2**field.size - 1 }} {% if field.default_value != number %}0{% else %}{{ field.default_value }}{% endif %} "{{ field.description|replace('\n','->') }}"
 {% if field.is_enum %}
-{% for literals in field.datatype.model.literals %}
-    State {{ literals.name }} {{ literals.value }}
+{% for literal in field.literals %}
+    State {{ literal.name }} {{ literal.value }}
 {% endfor %}{% endif -%}{% endfor %}
   ID_Parameter Adamant_Command_Id 64 16 UINT MIN MAX {{ command.id }} "Adamant command ID"
 {# The command argument definitions. #}
@@ -22,7 +22,7 @@ Command {{ name }} {{ command.suite.component.instance_name }}-{{ command.name }
   {% if 'x' in (field.format|string)[2] %}Append_Array_Parameter {% if field.type_model.name %}{{ field.type_model.name }}.{% endif %}{{ field.name }} {{ (field.format|string)[1] }} {{ plugin_format_dictionary[field.format.type[0]] }} {{ (field.format|string)[1]|int * (field.format|string)[3:]|int }} "{{ field.description|replace('\n','->') }}"
 {% else %}Append_Parameter {% if field.type_model.name %}{{ field.type_model.name }}.{% endif %}{{ name }} {% if field.format.type %}{{ field.format.type[1:] }}{% endif %}{% if field.type_model.size %}{{ field.type_model.size }}{% endif %}
  {{ plugin_format_dictionary[field.format.type[0]] }} MIN MAX {% if command.default_value %}{{ command.default_value }}{% else %}0{% endif %} "{{ field.description|replace('\n','->') }}"
-{% if field.format and 'E' in (field.format|string)[0] %}{% for literal in field.type_model.literals %}
+{% if field.is_enum %}{% for literal in field.literals %}
     State {{ literal.name }} {{ literal.value }}
 {% endfor %}{% endif %}{% endif %}
 {% endfor %}{% endif %}{% endif %}

--- a/src/components/ccsds_packetizer/gen/generators/ccsds_xml.py
+++ b/src/components/ccsds_packetizer/gen/generators/ccsds_xml.py
@@ -33,6 +33,7 @@ class ccsds_packets_xml(assembly_hydra_generator, generator_base):
                 "Ccsds_Space_Packet"
             )
 
+        a.load_packet_type_ranges()
         a.type_format_dictionary = genassem.type_format_dictionary
         genassem.create_type_print_strings(a)
         genassem.create_type_field_strings(a)
@@ -51,5 +52,6 @@ class assembly_cosmos_telemetry_txt(assembly_cosmos_plugin_generator_base, gener
         a = self.model_cls(input_filename)
         a.ccsds_primary_header_model = model_loader.try_load_model_by_name("Ccsds_Primary_Header")
         a.sys_time_record_model = model_loader.try_load_model_by_name("sys_time")
+        a.load_packet_type_ranges()
         genassem.create_type_field_strings(a)
         print(a.render(self.template, template_path=self.template_dir))

--- a/src/components/ccsds_packetizer/gen/templates/assembly/name_ccsds_cosmos_telemetry.txt
+++ b/src/components/ccsds_packetizer/gen/templates/assembly/name_ccsds_cosmos_telemetry.txt
@@ -7,8 +7,8 @@ Telemetry {{ name }} {{ packet.name }} Big_Endian "{{ packet.description }}"
 {% if loop.last %}{% set _ = header_bit_position.append(field.start_bit + field.size) %}{% endif %}{% if field.name == 'Apid' %}  Id_Item {{ field.name }} {{ field.start_bit }} {{ field.size }} {{ plugin_format_dictionary[field.format.type[0]] }} {{ packet.id }} "{{ field.description|replace('\n','->') }}"
 {% else %}  Item {{ field.name }} {{ field.start_bit }} {{ field.size }} {{ plugin_format_dictionary[field.format.type[0]] }} "{{ field.description|replace('\n','->') }}"
 {% endif %}{% if field.is_enum %}
-{% for literals in field.datatype.model.literals %}
-    State {{ literals.name }} {{ literals.value }}
+{% for literal in field.literals %}
+    State {{ literal.name }} {{ literal.value }}
 {% endfor %}{% endif -%}{% endfor %}
 {% for field_name, field in sys_time_record_model.fields.items() %}
   Item {{ field.name }} {{ header_bit_position|last + field.start_bit }} {{ field.size }} {{ plugin_format_dictionary[field.format.type[0]] }} "{{ field.description|replace('\n','->') }}"
@@ -19,8 +19,8 @@ Telemetry {{ name }} {{ packet.name }} Big_Endian "{{ packet.description }}"
   {% if 'x' in (item.format|string)[2] %}Append_Array_Item {% if item.type_model.name %}{{ item.type_model.name }}.{% endif %}{{ item.name }} {{ (item.format|string)[1] }} {{ plugin_format_dictionary[item.format.type[0]] }} {{ (item.format|string)[1]|int * (item.format|string)[3:]|int }} "{{ item.description|replace('\n','->') }}"
 {% else %}Append_Item {{ item.entity.full_name }}{% if item.flat_name %}.{{ item.flat_name }}{% endif %} {{ item.size }} {{ plugin_format_dictionary[item.format.type[0]] }} "{{ item.flat_desc|replace('\n','->') }}"
 {% if item.is_enum %}
-{% for literals in item.datatype.model.literals %}
-    State {{ literals.name }} {{ literals.value }}
+{% for literal in item.literals %}
+    State {{ literal.name }} {{ literal.value }}
 {% endfor %}{% endif %}{% endif %}
 {% endfor %}
   Append_Item CRC 16 UINT "Packet CRC value"


### PR DESCRIPTION
The adamant modeling system can retrieve information about enum types for packed record/arrays either because a field is modeled using the adamant enum modeling features, or because type ranges have been loaded which can extract bare Ada enum information from hand written types. The way this enum information gets loaded into the packed record models was not uniform between these two methods and thus necessitated special handlig for each case, particularily in generator templates that need to output enum information.

This fix makes handling enums uniform, regardless of where the information is sourced. Checking .is_enum on a packed record or array field should tell the caller if the type of the field is an enum, and the literals can now always be accessed via .literals.