### PR TITLE
Updates to env.py Files

### DIFF
--- a/doc/architecture_description_document/env.py
+++ b/doc/architecture_description_document/env.py
@@ -6,4 +6,6 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-modify_build_path.add_to_build_path([this_dir, os.path.join(this_dir, ".." + os.sep + "example_architecture")])
+modify_build_path.add_to_build_path(
+    [this_dir, os.path.join(this_dir, ".." + os.sep + "example_architecture")]
+)

--- a/doc/architecture_description_document/env.py
+++ b/doc/architecture_description_document/env.py
@@ -1,8 +1,9 @@
 import os
+from environments import modify_build_path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
 # Overwrite the normal build path mechanism and just use
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + os.path.join(this_dir, ".." + os.sep + "example_architecture")
+modify_build_path.add_to_build_path([this_dir, os.path.join(this_dir, ".." + os.sep + "example_architecture")])

--- a/doc/example_architecture/active_component/test/env.py
+++ b/doc/example_architecture/active_component/test/env.py
@@ -1,4 +1,4 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
@@ -6,4 +6,4 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])

--- a/doc/example_architecture/array_register_set/env.py
+++ b/doc/example_architecture/array_register_set/env.py
@@ -1,8 +1,9 @@
 import os
+from environments import modify_build_path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
 # Overwrite the normal build path mechanism and just use
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir + os.sep + ".."])

--- a/doc/example_architecture/array_representation/env.py
+++ b/doc/example_architecture/array_representation/env.py
@@ -1,8 +1,9 @@
 import os
+from environments import modify_build_path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
 # Overwrite the normal build path mechanism and just use
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])

--- a/doc/example_architecture/background_component/test/env.py
+++ b/doc/example_architecture/background_component/test/env.py
@@ -1,4 +1,4 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
@@ -6,4 +6,4 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])

--- a/doc/example_architecture/command_component/test/env.py
+++ b/doc/example_architecture/command_component/test/env.py
@@ -1,4 +1,4 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
@@ -6,4 +6,4 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])

--- a/doc/example_architecture/data_dependency_component/test/env.py
+++ b/doc/example_architecture/data_dependency_component/test/env.py
@@ -1,4 +1,4 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
@@ -6,4 +6,4 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])

--- a/doc/example_architecture/data_product_component/test/env.py
+++ b/doc/example_architecture/data_product_component/test/env.py
@@ -1,4 +1,4 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
@@ -6,4 +6,4 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])

--- a/doc/example_architecture/doc/env.py
+++ b/doc/example_architecture/doc/env.py
@@ -1,4 +1,4 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
@@ -6,4 +6,4 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])

--- a/doc/example_architecture/enum_assertion/env.py
+++ b/doc/example_architecture/enum_assertion/env.py
@@ -1,8 +1,9 @@
 import os
+from environments import modify_build_path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
 # Overwrite the normal build path mechanism and just use
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])

--- a/doc/example_architecture/enum_m/env.py
+++ b/doc/example_architecture/enum_m/env.py
@@ -1,8 +1,9 @@
 import os
+from environments import modify_build_path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
 # Overwrite the normal build path mechanism and just use
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])

--- a/doc/example_architecture/enum_py/env.py
+++ b/doc/example_architecture/enum_py/env.py
@@ -1,8 +1,9 @@
 import os
+from environments import modify_build_path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
 # Overwrite the normal build path mechanism and just use
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])

--- a/doc/example_architecture/enum_representation/env.py
+++ b/doc/example_architecture/enum_representation/env.py
@@ -1,8 +1,9 @@
 import os
+from environments import modify_build_path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
 # Overwrite the normal build path mechanism and just use
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])

--- a/doc/example_architecture/env.py
+++ b/doc/example_architecture/env.py
@@ -1,3 +1,4 @@
+from environments import modify_build_path
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
@@ -5,4 +6,4 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-# os.environ["BUILD_PATH"] = this_dir
+# modify_build_path.set_build_path(this_dir)

--- a/doc/example_architecture/event_component/test/env.py
+++ b/doc/example_architecture/event_component/test/env.py
@@ -1,4 +1,4 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
@@ -6,4 +6,4 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])

--- a/doc/example_architecture/example_component/doc/env.py
+++ b/doc/example_architecture/example_component/doc/env.py
@@ -1,4 +1,4 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
@@ -6,4 +6,4 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])

--- a/doc/example_architecture/example_component/test/env.py
+++ b/doc/example_architecture/example_component/test/env.py
@@ -1,4 +1,4 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
@@ -6,4 +6,4 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])

--- a/doc/example_architecture/example_component/test2/env.py
+++ b/doc/example_architecture/example_component/test2/env.py
@@ -1,4 +1,4 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
@@ -6,4 +6,4 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])

--- a/doc/example_architecture/example_component/test3/env.py
+++ b/doc/example_architecture/example_component/test3/env.py
@@ -1,4 +1,4 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
@@ -6,4 +6,4 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])

--- a/doc/example_architecture/example_component/test4/env.py
+++ b/doc/example_architecture/example_component/test4/env.py
@@ -1,4 +1,4 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
@@ -6,4 +6,4 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])

--- a/doc/example_architecture/example_component/test5/env.py
+++ b/doc/example_architecture/example_component/test5/env.py
@@ -1,4 +1,4 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
@@ -6,4 +6,4 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])

--- a/doc/example_architecture/example_component/tester/env.py
+++ b/doc/example_architecture/example_component/tester/env.py
@@ -1,9 +1,9 @@
 import os
+from environments import modify_build_path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
 # Overwrite the normal build path mechanism and just use
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-# os.environ["BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])

--- a/doc/example_architecture/fault_component/test/env.py
+++ b/doc/example_architecture/fault_component/test/env.py
@@ -1,4 +1,4 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
@@ -6,4 +6,4 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])

--- a/doc/example_architecture/hello_world/env.py
+++ b/doc/example_architecture/hello_world/env.py
@@ -1,8 +1,9 @@
 import os
+from environments import modify_build_path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
 # Overwrite the normal build path mechanism and just use
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])

--- a/doc/example_architecture/nested_record/env.py
+++ b/doc/example_architecture/nested_record/env.py
@@ -1,8 +1,9 @@
 import os
+from environments import modify_build_path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
 # Overwrite the normal build path mechanism and just use
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.sep + ".."
+modify_build_path.add_to_build_path(this_dir + os.sep + "..")

--- a/doc/example_architecture/oo_package/test/env.py
+++ b/doc/example_architecture/oo_package/test/env.py
@@ -1,4 +1,4 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
@@ -6,4 +6,4 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])

--- a/doc/example_architecture/packet_component/test/env.py
+++ b/doc/example_architecture/packet_component/test/env.py
@@ -1,4 +1,4 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
@@ -6,4 +6,4 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])

--- a/doc/example_architecture/parameter_component/test/env.py
+++ b/doc/example_architecture/parameter_component/test/env.py
@@ -1,4 +1,4 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
@@ -6,4 +6,4 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])

--- a/doc/example_architecture/queued_component/test/env.py
+++ b/doc/example_architecture/queued_component/test/env.py
@@ -1,4 +1,4 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
@@ -6,4 +6,4 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])

--- a/doc/example_architecture/queued_component/test2/env.py
+++ b/doc/example_architecture/queued_component/test2/env.py
@@ -1,4 +1,4 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
@@ -6,4 +6,4 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])

--- a/doc/example_architecture/record_assertion/env.py
+++ b/doc/example_architecture/record_assertion/env.py
@@ -1,8 +1,9 @@
 import os
+from environments import modify_build_path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
 # Overwrite the normal build path mechanism and just use
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])

--- a/doc/example_architecture/record_conversion/env.py
+++ b/doc/example_architecture/record_conversion/env.py
@@ -1,8 +1,9 @@
 import os
+from environments import modify_build_path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
 # Overwrite the normal build path mechanism and just use
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.sep + ".."
+modify_build_path.add_to_build_path(this_dir + os.sep + "..")

--- a/doc/example_architecture/record_m/env.py
+++ b/doc/example_architecture/record_m/env.py
@@ -1,8 +1,9 @@
 import os
+from environments import modify_build_path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
 # Overwrite the normal build path mechanism and just use
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])

--- a/doc/example_architecture/record_py/env.py
+++ b/doc/example_architecture/record_py/env.py
@@ -1,8 +1,9 @@
 import os
+from environments import modify_build_path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
 # Overwrite the normal build path mechanism and just use
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])

--- a/doc/example_architecture/record_register/env.py
+++ b/doc/example_architecture/record_register/env.py
@@ -1,8 +1,9 @@
 import os
+from environments import modify_build_path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
 # Overwrite the normal build path mechanism and just use
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.sep + ".."
+modify_build_path.add_to_build_path(this_dir + os.sep + "..")

--- a/doc/example_architecture/record_register_set/env.py
+++ b/doc/example_architecture/record_register_set/env.py
@@ -1,8 +1,9 @@
 import os
+from environments import modify_build_path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
 # Overwrite the normal build path mechanism and just use
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.sep + ".."
+modify_build_path.add_to_build_path(this_dir + os.sep + "..")

--- a/doc/example_architecture/record_representation/env.py
+++ b/doc/example_architecture/record_representation/env.py
@@ -1,8 +1,9 @@
 import os
+from environments import modify_build_path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
 # Overwrite the normal build path mechanism and just use
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])

--- a/doc/example_architecture/record_serialization/env.py
+++ b/doc/example_architecture/record_serialization/env.py
@@ -1,8 +1,9 @@
 import os
+from environments import modify_build_path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
 # Overwrite the normal build path mechanism and just use
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.sep + ".."
+modify_build_path.add_to_build_path(this_dir + os.sep + "..")

--- a/doc/example_architecture/record_validation/env.py
+++ b/doc/example_architecture/record_validation/env.py
@@ -1,8 +1,9 @@
 import os
+from environments import modify_build_path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
 # Overwrite the normal build path mechanism and just use
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])

--- a/doc/example_architecture/simple_package/test/env.py
+++ b/doc/example_architecture/simple_package/test/env.py
@@ -7,4 +7,6 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # name conflicts we might get from using the regular
 # ".all_path".
 modify_build_path.set_build_path(this_dir + os.pathsep + this_dir + os.sep + "..")
-os.environ["ADAMANT_CONFIGURATION_YAML"] = this_dir + os.sep + "demo_conf" + os.sep + "demo.configuration.yaml"
+os.environ["ADAMANT_CONFIGURATION_YAML"] = (
+    this_dir + os.sep + "demo_conf" + os.sep + "demo.configuration.yaml"
+)

--- a/doc/example_architecture/simple_package/test/env.py
+++ b/doc/example_architecture/simple_package/test/env.py
@@ -1,3 +1,4 @@
+from environments import modify_build_path
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
@@ -5,5 +6,5 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.set_build_path(this_dir + os.pathsep + this_dir + os.sep + "..")
 os.environ["ADAMANT_CONFIGURATION_YAML"] = this_dir + os.sep + "demo_conf" + os.sep + "demo.configuration.yaml"

--- a/doc/example_architecture/simple_package/test_better/env.py
+++ b/doc/example_architecture/simple_package/test_better/env.py
@@ -1,4 +1,4 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
@@ -6,4 +6,4 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])

--- a/doc/example_architecture/simple_package/test_better2/env.py
+++ b/doc/example_architecture/simple_package/test_better2/env.py
@@ -1,4 +1,4 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
@@ -6,4 +6,4 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])

--- a/doc/example_architecture/simple_package/test_better3/env.py
+++ b/doc/example_architecture/simple_package/test_better3/env.py
@@ -1,4 +1,4 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
@@ -6,7 +6,7 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])
 
 # Set the variable to create build artifacts in this directory
 os.environ["CREATE_BUILD_ARTIFACTS"] = "1"

--- a/doc/example_architecture/simple_package/test_better4/env.py
+++ b/doc/example_architecture/simple_package/test_better4/env.py
@@ -1,4 +1,4 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
@@ -6,7 +6,7 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + this_dir + os.sep + ".."
+modify_build_path.add_to_build_path([this_dir, this_dir + os.sep + ".."])
 
 # Set the variable to create build artifacts in this directory
 os.environ["CREATE_BUILD_ARTIFACTS"] = "1"

--- a/doc/example_architecture/spark_package/env.py
+++ b/doc/example_architecture/spark_package/env.py
@@ -1,3 +1,4 @@
+from environments import modify_build_path
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
@@ -5,4 +6,4 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["BUILD_PATH"] = this_dir + os.pathsep + os.path.join(this_dir, "depends")
+modify_build_path.set_build_path(this_dir + os.pathsep + os.path.join(this_dir, "depends"))

--- a/doc/example_architecture/spark_package/env.py
+++ b/doc/example_architecture/spark_package/env.py
@@ -6,4 +6,6 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-modify_build_path.set_build_path(this_dir + os.pathsep + os.path.join(this_dir, "depends"))
+modify_build_path.set_build_path(
+    this_dir + os.pathsep + os.path.join(this_dir, "depends")
+)

--- a/doc/example_architecture/spark_package_no_config/env.py
+++ b/doc/example_architecture/spark_package_no_config/env.py
@@ -1,3 +1,4 @@
+from environments import modify_build_path
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
@@ -5,4 +6,4 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["BUILD_PATH"] = this_dir + os.pathsep + os.path.join(this_dir, "depends")
+modify_build_path.set_build_path(this_dir + os.pathsep + os.path.join(this_dir, "depends"))

--- a/doc/example_architecture/spark_package_no_config/env.py
+++ b/doc/example_architecture/spark_package_no_config/env.py
@@ -6,4 +6,6 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-modify_build_path.set_build_path(this_dir + os.pathsep + os.path.join(this_dir, "depends"))
+modify_build_path.set_build_path(
+    this_dir + os.pathsep + os.path.join(this_dir, "depends")
+)

--- a/doc/user_guide/env.py
+++ b/doc/user_guide/env.py
@@ -6,8 +6,13 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-modify_build_path.add_to_build_path([this_dir,
-    os.path.join(this_dir, ".." + os.sep + "example_architecture"),
-    os.path.join(
-        this_dir, ".." + os.sep + "example_architecture" + os.sep + "example_component"
-    )])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.join(this_dir, ".." + os.sep + "example_architecture"),
+        os.path.join(
+            this_dir,
+            ".." + os.sep + "example_architecture" + os.sep + "example_component",
+        ),
+    ]
+)

--- a/doc/user_guide/env.py
+++ b/doc/user_guide/env.py
@@ -1,16 +1,13 @@
 import os
+from environments import modify_build_path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
 # Overwrite the normal build path mechanism and just use
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["EXTRA_BUILD_PATH"] = (
-    this_dir
-    + os.pathsep
-    + os.path.join(this_dir, ".." + os.sep + "example_architecture")
-    + os.pathsep
-    + os.path.join(
+modify_build_path.add_to_build_path([this_dir,
+    os.path.join(this_dir, ".." + os.sep + "example_architecture"),
+    os.path.join(
         this_dir, ".." + os.sep + "example_architecture" + os.sep + "example_component"
-    )
-)
+    )])

--- a/gen/test/active_no_queue/env.py
+++ b/gen/test/active_no_queue/env.py
@@ -2,5 +2,6 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))])
+modify_build_path.add_to_build_path(
+    [this_dir, os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))]
+)

--- a/gen/test/active_no_queue/env.py
+++ b/gen/test/active_no_queue/env.py
@@ -1,6 +1,6 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))])

--- a/gen/test/active_no_queue/test/env.py
+++ b/gen/test/active_no_queue/test/env.py
@@ -2,6 +2,12 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "..")),
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records")
+        ),
+    ]
+)

--- a/gen/test/active_no_queue/test/env.py
+++ b/gen/test/active_no_queue/test/env.py
@@ -1,7 +1,7 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "..")),
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))])

--- a/gen/test/arrayed/env.py
+++ b/gen/test/arrayed/env.py
@@ -2,5 +2,6 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))])
+modify_build_path.add_to_build_path(
+    [this_dir, os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))]
+)

--- a/gen/test/arrayed/env.py
+++ b/gen/test/arrayed/env.py
@@ -1,6 +1,6 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))])

--- a/gen/test/arrayed/test/env.py
+++ b/gen/test/arrayed/test/env.py
@@ -1,7 +1,7 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))
+modify_build_path.add_to_build_path([this_dir,
+   os.path.realpath(os.path.join(this_dir, "..")),
+   os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))])

--- a/gen/test/arrayed/test/env.py
+++ b/gen/test/arrayed/test/env.py
@@ -2,6 +2,12 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-   os.path.realpath(os.path.join(this_dir, "..")),
-   os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records")
+        ),
+    ]
+)

--- a/gen/test/arrayed_invokee/env.py
+++ b/gen/test/arrayed_invokee/env.py
@@ -2,5 +2,6 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))])
+modify_build_path.add_to_build_path(
+    [this_dir, os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))]
+)

--- a/gen/test/arrayed_invokee/env.py
+++ b/gen/test/arrayed_invokee/env.py
@@ -1,6 +1,6 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))])

--- a/gen/test/arrayed_invokee/test/env.py
+++ b/gen/test/arrayed_invokee/test/env.py
@@ -2,6 +2,12 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "..")),
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records")
+        ),
+    ]
+)

--- a/gen/test/arrayed_invokee/test/env.py
+++ b/gen/test/arrayed_invokee/test/env.py
@@ -1,7 +1,7 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "..")),
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))])

--- a/gen/test/arrayed_priority_queued/env.py
+++ b/gen/test/arrayed_priority_queued/env.py
@@ -2,5 +2,6 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))])
+modify_build_path.add_to_build_path(
+    [this_dir, os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))]
+)

--- a/gen/test/arrayed_priority_queued/env.py
+++ b/gen/test/arrayed_priority_queued/env.py
@@ -1,6 +1,6 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))])

--- a/gen/test/arrayed_priority_queued/test/env.py
+++ b/gen/test/arrayed_priority_queued/test/env.py
@@ -2,6 +2,12 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "..")),
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records")
+        ),
+    ]
+)

--- a/gen/test/arrayed_priority_queued/test/env.py
+++ b/gen/test/arrayed_priority_queued/test/env.py
@@ -1,7 +1,7 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "..")),
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))])

--- a/gen/test/arrays/env.py
+++ b/gen/test/arrays/env.py
@@ -2,5 +2,6 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))])
+modify_build_path.add_to_build_path(
+    [this_dir, os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))]
+)

--- a/gen/test/arrays/env.py
+++ b/gen/test/arrays/env.py
@@ -1,6 +1,6 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))])

--- a/gen/test/arrays/test/env.py
+++ b/gen/test/arrays/test/env.py
@@ -2,6 +2,12 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "..")),
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records")
+        ),
+    ]
+)

--- a/gen/test/arrays/test/env.py
+++ b/gen/test/arrays/test/env.py
@@ -1,7 +1,7 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "..")),
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))])

--- a/gen/test/arrays/test_py/env.py
+++ b/gen/test/arrays/test_py/env.py
@@ -1,17 +1,11 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = (
-        this_dir
-        + os.pathsep
-        + os.path.realpath(os.path.join(this_dir, ".."))
-        + os.pathsep
-        + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "arrays"))
-        + os.pathsep
-        + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "enums"))
-        + os.pathsep
-        + os.path.realpath(
-                os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records")
-        )
-)
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "..")),
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "arrays")),
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "enums")),
+    os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records")
+    )])

--- a/gen/test/arrays/test_py/env.py
+++ b/gen/test/arrays/test_py/env.py
@@ -2,10 +2,18 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "..")),
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "arrays")),
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "enums")),
-    os.path.realpath(
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "arrays")
+        ),
+        os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "enums")
+        ),
+        os.path.realpath(
             os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records")
-    )])
+        ),
+    ]
+)

--- a/gen/test/enums/env.py
+++ b/gen/test/enums/env.py
@@ -2,5 +2,6 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "arrays"))])
+modify_build_path.add_to_build_path(
+    [this_dir, os.path.realpath(os.path.join(this_dir, ".." + os.sep + "arrays"))]
+)

--- a/gen/test/enums/env.py
+++ b/gen/test/enums/env.py
@@ -1,6 +1,6 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + "arrays"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "arrays"))])

--- a/gen/test/enums/test/env.py
+++ b/gen/test/enums/test/env.py
@@ -2,7 +2,15 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "..")),
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "arrays")),
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "arrays")
+        ),
+        os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records")
+        ),
+    ]
+)

--- a/gen/test/enums/test/env.py
+++ b/gen/test/enums/test/env.py
@@ -1,8 +1,8 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-    + os.path.realpath(os.path.join(this_dir, "..")) + os.pathsep \
-    + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "arrays")) + os.pathsep \
-    + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "..")),
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "arrays")),
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))])

--- a/gen/test/enums/test_py/env.py
+++ b/gen/test/enums/test_py/env.py
@@ -1,15 +1,10 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = (
-    this_dir
-    + os.pathsep
-    + os.path.realpath(os.path.join(this_dir, ".."))
-    + os.pathsep
-    + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "arrays"))
-    + os.pathsep
-    + os.path.realpath(
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "..")),
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "arrays")),
+    os.path.realpath(
         os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records")
-    )
-)
+    )])

--- a/gen/test/enums/test_py/env.py
+++ b/gen/test/enums/test_py/env.py
@@ -2,9 +2,15 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "..")),
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "arrays")),
-    os.path.realpath(
-        os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records")
-    )])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "arrays")
+        ),
+        os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records")
+        ),
+    ]
+)

--- a/gen/test/generic_component/env.py
+++ b/gen/test/generic_component/env.py
@@ -2,5 +2,6 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))])
+modify_build_path.add_to_build_path(
+    [this_dir, os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))]
+)

--- a/gen/test/generic_component/env.py
+++ b/gen/test/generic_component/env.py
@@ -1,6 +1,6 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))])

--- a/gen/test/generic_component/test/env.py
+++ b/gen/test/generic_component/test/env.py
@@ -2,6 +2,12 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "..")),
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records")
+        ),
+    ]
+)

--- a/gen/test/generic_component/test/env.py
+++ b/gen/test/generic_component/test/env.py
@@ -1,7 +1,7 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "..")),
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))])

--- a/gen/test/generic_queued/env.py
+++ b/gen/test/generic_queued/env.py
@@ -2,5 +2,6 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))])
+modify_build_path.add_to_build_path(
+    [this_dir, os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))]
+)

--- a/gen/test/generic_queued/env.py
+++ b/gen/test/generic_queued/env.py
@@ -1,6 +1,6 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))])

--- a/gen/test/generic_queued/test/env.py
+++ b/gen/test/generic_queued/test/env.py
@@ -2,6 +2,12 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "..")),
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records")
+        ),
+    ]
+)

--- a/gen/test/generic_queued/test/env.py
+++ b/gen/test/generic_queued/test/env.py
@@ -1,7 +1,7 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "..")),
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))])

--- a/gen/test/get_return/env.py
+++ b/gen/test/get_return/env.py
@@ -2,5 +2,6 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))])
+modify_build_path.add_to_build_path(
+    [this_dir, os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))]
+)

--- a/gen/test/get_return/env.py
+++ b/gen/test/get_return/env.py
@@ -1,6 +1,6 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))])

--- a/gen/test/get_return/test/env.py
+++ b/gen/test/get_return/test/env.py
@@ -2,6 +2,12 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "..")),
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records")
+        ),
+    ]
+)

--- a/gen/test/get_return/test/env.py
+++ b/gen/test/get_return/test/env.py
@@ -1,7 +1,7 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "..")),
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))])

--- a/gen/test/priority_queued/env.py
+++ b/gen/test/priority_queued/env.py
@@ -2,5 +2,6 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))])
+modify_build_path.add_to_build_path(
+    [this_dir, os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))]
+)

--- a/gen/test/priority_queued/env.py
+++ b/gen/test/priority_queued/env.py
@@ -1,6 +1,6 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))])

--- a/gen/test/priority_queued/test/env.py
+++ b/gen/test/priority_queued/test/env.py
@@ -2,6 +2,12 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "..")),
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records")
+        ),
+    ]
+)

--- a/gen/test/priority_queued/test/env.py
+++ b/gen/test/priority_queued/test/env.py
@@ -1,7 +1,7 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "..")),
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))])

--- a/gen/test/provide_modify/env.py
+++ b/gen/test/provide_modify/env.py
@@ -2,5 +2,6 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))])
+modify_build_path.add_to_build_path(
+    [this_dir, os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))]
+)

--- a/gen/test/provide_modify/env.py
+++ b/gen/test/provide_modify/env.py
@@ -1,6 +1,6 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))])

--- a/gen/test/provide_modify/test/env.py
+++ b/gen/test/provide_modify/test/env.py
@@ -2,6 +2,12 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "..")),
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records")
+        ),
+    ]
+)

--- a/gen/test/provide_modify/test/env.py
+++ b/gen/test/provide_modify/test/env.py
@@ -1,7 +1,7 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "..")),
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))])

--- a/gen/test/queued/env.py
+++ b/gen/test/queued/env.py
@@ -2,5 +2,6 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))])
+modify_build_path.add_to_build_path(
+    [this_dir, os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))]
+)

--- a/gen/test/queued/env.py
+++ b/gen/test/queued/env.py
@@ -1,6 +1,6 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))])

--- a/gen/test/queued/test/env.py
+++ b/gen/test/queued/test/env.py
@@ -2,6 +2,12 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "..")),
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records")
+        ),
+    ]
+)

--- a/gen/test/queued/test/env.py
+++ b/gen/test/queued/test/env.py
@@ -1,7 +1,7 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "..")),
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))])

--- a/gen/test/records/env.py
+++ b/gen/test/records/env.py
@@ -2,5 +2,6 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "arrays"))])
+modify_build_path.add_to_build_path(
+    [this_dir, os.path.realpath(os.path.join(this_dir, ".." + os.sep + "arrays"))]
+)

--- a/gen/test/records/env.py
+++ b/gen/test/records/env.py
@@ -1,6 +1,6 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + "arrays"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "arrays"))])

--- a/gen/test/records/test/env.py
+++ b/gen/test/records/test/env.py
@@ -1,15 +1,10 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = (
-    this_dir
-    + os.pathsep
-    + os.path.realpath(os.path.join(this_dir, ".."))
-    + os.pathsep
-    + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "arrays"))
-    + os.pathsep
-    + os.path.realpath(
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "..")),
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "arrays")),
+    os.path.realpath(
         os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records")
-    )
-)
+    )])

--- a/gen/test/records/test/env.py
+++ b/gen/test/records/test/env.py
@@ -2,9 +2,15 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "..")),
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "arrays")),
-    os.path.realpath(
-        os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records")
-    )])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "arrays")
+        ),
+        os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records")
+        ),
+    ]
+)

--- a/gen/test/records/test_py/env.py
+++ b/gen/test/records/test_py/env.py
@@ -1,17 +1,11 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = (
-    this_dir
-    + os.pathsep
-    + os.path.realpath(os.path.join(this_dir, ".."))
-    + os.pathsep
-    + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "arrays"))
-    + os.pathsep
-    + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "enums"))
-    + os.pathsep
-    + os.path.realpath(
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "..")),
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "arrays")),
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "enums")),
+    os.path.realpath(
         os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records")
-    )
-)
+    )])

--- a/gen/test/records/test_py/env.py
+++ b/gen/test/records/test_py/env.py
@@ -2,10 +2,18 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "..")),
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "arrays")),
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "enums")),
-    os.path.realpath(
-        os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records")
-    )])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "arrays")
+        ),
+        os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "enums")
+        ),
+        os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records")
+        ),
+    ]
+)

--- a/gen/test/request_service/env.py
+++ b/gen/test/request_service/env.py
@@ -2,5 +2,6 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))])
+modify_build_path.add_to_build_path(
+    [this_dir, os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))]
+)

--- a/gen/test/request_service/env.py
+++ b/gen/test/request_service/env.py
@@ -1,6 +1,6 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))])

--- a/gen/test/request_service/test/env.py
+++ b/gen/test/request_service/test/env.py
@@ -2,6 +2,12 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "..")),
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records")
+        ),
+    ]
+)

--- a/gen/test/request_service/test/env.py
+++ b/gen/test/request_service/test/env.py
@@ -1,7 +1,7 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "..")),
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))])

--- a/gen/test/simple/env.py
+++ b/gen/test/simple/env.py
@@ -2,5 +2,6 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))])
+modify_build_path.add_to_build_path(
+    [this_dir, os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))]
+)

--- a/gen/test/simple/env.py
+++ b/gen/test/simple/env.py
@@ -1,6 +1,6 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "records"))])

--- a/gen/test/simple/test/env.py
+++ b/gen/test/simple/test/env.py
@@ -2,6 +2,12 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "..")),
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records")
+        ),
+    ]
+)

--- a/gen/test/simple/test/env.py
+++ b/gen/test/simple/test/env.py
@@ -1,7 +1,7 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "..")),
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))])

--- a/redo/environments/modify_build_path.py
+++ b/redo/environments/modify_build_path.py
@@ -1,0 +1,51 @@
+import os
+
+
+def update_env_var(variable_name, paths, overwrite=False):
+    """
+    Update the specified environment variable with given paths.
+
+    Args:
+        variable_name (str): The name of the environment variable.
+        paths (str or list of str): A single path or a list of paths to set or append.
+        overwrite (bool): If True, overwrite the existing variable; otherwise, append.
+    """
+    if isinstance(paths, str):
+        paths = [paths]
+
+    # Current paths from the environment variable
+    current_paths = os.environ.get(variable_name, "").split(os.pathsep)
+
+    if overwrite:
+        # Overwrite mode: Only use new paths
+        all_paths = filter(None, paths)
+    else:
+        # Append mode: Combine current and new paths
+        all_paths = filter(None, current_paths + paths)
+
+    # Ensure paths are unique
+    unique_paths = list(set(all_paths))
+
+    # Set the environment variable with paths joined by os.pathsep
+    os.environ[variable_name] = os.pathsep.join(unique_paths)
+
+
+# Specific functions for each environment variable
+def add_to_build_path(paths):
+    update_env_var("EXTRA_BUILD_PATH", paths)
+
+
+def set_build_path(paths):
+    update_env_var("BUILD_PATH", paths, overwrite=True)
+
+
+def set_build_roots(paths):
+    update_env_var("BUILD_ROOTS", paths, overwrite=True)
+
+
+def add_to_build_roots(paths):
+    update_env_var("EXTRA_BUILD_ROOTS", paths)
+
+
+def remove_from_build_path(paths):
+    update_env_var("REMOVE_BUILD_PATH", paths)

--- a/redo/test/c_compile/ada_src/env.py
+++ b/redo/test/c_compile/ada_src/env.py
@@ -6,4 +6,6 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-modify_build_path.set_build_path(this_dir + os.pathsep + os.path.join(this_dir, ".." + os.sep + "c_src"))
+modify_build_path.set_build_path(
+    this_dir + os.pathsep + os.path.join(this_dir, ".." + os.sep + "c_src")
+)

--- a/redo/test/c_compile/ada_src/env.py
+++ b/redo/test/c_compile/ada_src/env.py
@@ -1,3 +1,4 @@
+from environments import modify_build_path
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
@@ -5,4 +6,4 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["BUILD_PATH"] = this_dir + os.pathsep + os.path.join(this_dir, ".." + os.sep + "c_src")
+modify_build_path.set_build_path(this_dir + os.pathsep + os.path.join(this_dir, ".." + os.sep + "c_src"))

--- a/redo/test/c_compile/c_src/env.py
+++ b/redo/test/c_compile/c_src/env.py
@@ -1,3 +1,4 @@
+from environments import modify_build_path
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
@@ -5,4 +6,4 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["BUILD_PATH"] = this_dir + os.pathsep + os.path.join(this_dir, ".." + os.sep + "ada_src")
+modify_build_path.set_build_path(this_dir + os.pathsep + os.path.join(this_dir, ".." + os.sep + "ada_src"))

--- a/redo/test/c_compile/c_src/env.py
+++ b/redo/test/c_compile/c_src/env.py
@@ -6,4 +6,6 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-modify_build_path.set_build_path(this_dir + os.pathsep + os.path.join(this_dir, ".." + os.sep + "ada_src"))
+modify_build_path.set_build_path(
+    this_dir + os.pathsep + os.path.join(this_dir, ".." + os.sep + "ada_src")
+)

--- a/redo/test/spark_compile/env.py
+++ b/redo/test/spark_compile/env.py
@@ -1,3 +1,4 @@
+from environments import modify_build_path
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
@@ -5,4 +6,4 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-os.environ["BUILD_PATH"] = this_dir + os.pathsep + os.path.join(this_dir, "depends")
+modify_build_path.set_build_path(this_dir + os.pathsep + os.path.join(this_dir, "depends"))

--- a/redo/test/spark_compile/env.py
+++ b/redo/test/spark_compile/env.py
@@ -6,4 +6,6 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 # this directory as the build path. This prevents any
 # name conflicts we might get from using the regular
 # ".all_path".
-modify_build_path.set_build_path(this_dir + os.pathsep + os.path.join(this_dir, "depends"))
+modify_build_path.set_build_path(
+    this_dir + os.pathsep + os.path.join(this_dir, "depends")
+)

--- a/src/components/ccsds_downsampler/gen/doc/env.py
+++ b/src/components/ccsds_downsampler/gen/doc/env.py
@@ -1,3 +1,4 @@
+from environments import modify_build_path
 import runpy
 import os
 
@@ -17,4 +18,4 @@ runpy.run_path(
         + "env.py",
     )
 )
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + os.environ["EXTRA_BUILD_PATH"]
+modify_build_path.add_to_build_path(this_dir)

--- a/src/components/ccsds_downsampler/test/env.py
+++ b/src/components/ccsds_downsampler/test/env.py
@@ -1,7 +1,7 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_assembly"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "..")),
+    os.path.realpath(os.path.join(this_dir, "test_assembly"))])

--- a/src/components/ccsds_downsampler/test/env.py
+++ b/src/components/ccsds_downsampler/test/env.py
@@ -2,6 +2,10 @@ from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "..")),
-    os.path.realpath(os.path.join(this_dir, "test_assembly"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(os.path.join(this_dir, "test_assembly")),
+    ]
+)

--- a/src/components/ccsds_downsampler/test/test_assembly/env.py
+++ b/src/components/ccsds_downsampler/test/test_assembly/env.py
@@ -1,7 +1,7 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "types"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "..")),
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "types"))])

--- a/src/components/ccsds_downsampler/test/test_assembly/env.py
+++ b/src/components/ccsds_downsampler/test/test_assembly/env.py
@@ -2,6 +2,12 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "..")),
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "types"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, ".." + os.sep + "..")),
+        os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "types")
+        ),
+    ]
+)

--- a/src/components/ccsds_product_extractor/gen/doc/env.py
+++ b/src/components/ccsds_product_extractor/gen/doc/env.py
@@ -4,5 +4,18 @@ import os
 
 # load env file in test directory since we will use files in there:
 this_dir = os.path.dirname(os.path.realpath(__file__))
-runpy.run_path(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "test" + os.sep + "test_assembly" + os.sep + "env.py"))
+runpy.run_path(
+    os.path.join(
+        this_dir,
+        ".."
+        + os.sep
+        + ".."
+        + os.sep
+        + "test"
+        + os.sep
+        + "test_assembly"
+        + os.sep
+        + "env.py",
+    )
+)
 modify_build_path.add_to_build_path(this_dir)

--- a/src/components/ccsds_product_extractor/gen/doc/env.py
+++ b/src/components/ccsds_product_extractor/gen/doc/env.py
@@ -1,7 +1,8 @@
+from environments import modify_build_path
 import runpy
 import os
 
 # load env file in test directory since we will use files in there:
 this_dir = os.path.dirname(os.path.realpath(__file__))
 runpy.run_path(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "test" + os.sep + "test_assembly" + os.sep + "env.py"))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + os.environ["EXTRA_BUILD_PATH"]
+modify_build_path.add_to_build_path(this_dir)

--- a/src/components/ccsds_product_extractor/test/env.py
+++ b/src/components/ccsds_product_extractor/test/env.py
@@ -1,7 +1,7 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_assembly"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "..")),
+    os.path.realpath(os.path.join(this_dir, "test_assembly"))])

--- a/src/components/ccsds_product_extractor/test/env.py
+++ b/src/components/ccsds_product_extractor/test/env.py
@@ -2,6 +2,10 @@ from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "..")),
-    os.path.realpath(os.path.join(this_dir, "test_assembly"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(os.path.join(this_dir, "test_assembly")),
+    ]
+)

--- a/src/components/ccsds_product_extractor/test/test_assembly/env.py
+++ b/src/components/ccsds_product_extractor/test/test_assembly/env.py
@@ -1,7 +1,7 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "types"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "..")),
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "types"))])

--- a/src/components/ccsds_product_extractor/test/test_assembly/env.py
+++ b/src/components/ccsds_product_extractor/test/test_assembly/env.py
@@ -2,6 +2,12 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "..")),
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "types"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, ".." + os.sep + "..")),
+        os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "types")
+        ),
+    ]
+)

--- a/src/components/ccsds_router/doc/assembly/env.py
+++ b/src/components/ccsds_router/doc/assembly/env.py
@@ -1,6 +1,6 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))])

--- a/src/components/ccsds_router/doc/assembly/env.py
+++ b/src/components/ccsds_router/doc/assembly/env.py
@@ -2,5 +2,6 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))])
+modify_build_path.add_to_build_path(
+    [this_dir, os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))]
+)

--- a/src/components/ccsds_router/doc/env.py
+++ b/src/components/ccsds_router/doc/env.py
@@ -2,5 +2,6 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "assembly"))])
+modify_build_path.add_to_build_path(
+    [this_dir, os.path.realpath(os.path.join(this_dir, "assembly"))]
+)

--- a/src/components/ccsds_router/doc/env.py
+++ b/src/components/ccsds_router/doc/env.py
@@ -1,6 +1,6 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "assembly"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "assembly"))])

--- a/src/components/ccsds_router/gen/doc/env.py
+++ b/src/components/ccsds_router/gen/doc/env.py
@@ -1,3 +1,4 @@
+from environments import modify_build_path
 import runpy
 import os
 
@@ -17,4 +18,4 @@ runpy.run_path(
         + "env.py",
     )
 )
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + os.environ["EXTRA_BUILD_PATH"]
+modify_build_path.add_to_build_path(this_dir)

--- a/src/components/ccsds_router/test/env.py
+++ b/src/components/ccsds_router/test/env.py
@@ -2,7 +2,11 @@ from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "test_component")),
-    os.path.realpath(os.path.join(this_dir, "..")),
-    os.path.realpath(os.path.join(this_dir, "test_assembly"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "test_component")),
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(os.path.join(this_dir, "test_assembly")),
+    ]
+)

--- a/src/components/ccsds_router/test/env.py
+++ b/src/components/ccsds_router/test/env.py
@@ -1,8 +1,8 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_component")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_assembly"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "test_component")),
+    os.path.realpath(os.path.join(this_dir, "..")),
+    os.path.realpath(os.path.join(this_dir, "test_assembly"))])

--- a/src/components/ccsds_router/test/test_assembly/env.py
+++ b/src/components/ccsds_router/test/test_assembly/env.py
@@ -2,6 +2,10 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "../test_component")),
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "../test_component")),
+        os.path.realpath(os.path.join(this_dir, ".." + os.sep + "..")),
+    ]
+)

--- a/src/components/ccsds_router/test/test_assembly/env.py
+++ b/src/components/ccsds_router/test/test_assembly/env.py
@@ -1,7 +1,7 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "../test_component")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "../test_component")),
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))])

--- a/src/components/ccsds_router/test_unrecognized_apid/env.py
+++ b/src/components/ccsds_router/test_unrecognized_apid/env.py
@@ -2,7 +2,11 @@ from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "test_component")),
-    os.path.realpath(os.path.join(this_dir, "..")),
-    os.path.realpath(os.path.join(this_dir, "test_assembly"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "test_component")),
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(os.path.join(this_dir, "test_assembly")),
+    ]
+)

--- a/src/components/ccsds_router/test_unrecognized_apid/env.py
+++ b/src/components/ccsds_router/test_unrecognized_apid/env.py
@@ -1,8 +1,8 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_component")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_assembly"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "test_component")),
+    os.path.realpath(os.path.join(this_dir, "..")),
+    os.path.realpath(os.path.join(this_dir, "test_assembly"))])

--- a/src/components/ccsds_router/test_unrecognized_apid/test_assembly/env.py
+++ b/src/components/ccsds_router/test_unrecognized_apid/test_assembly/env.py
@@ -2,6 +2,10 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "../test_component")),
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "../test_component")),
+        os.path.realpath(os.path.join(this_dir, ".." + os.sep + "..")),
+    ]
+)

--- a/src/components/ccsds_router/test_unrecognized_apid/test_assembly/env.py
+++ b/src/components/ccsds_router/test_unrecognized_apid/test_assembly/env.py
@@ -1,7 +1,7 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "../test_component")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "../test_component")),
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))])

--- a/src/components/ccsds_subpacket_extractor/doc/assembly/env.py
+++ b/src/components/ccsds_subpacket_extractor/doc/assembly/env.py
@@ -1,6 +1,6 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))])

--- a/src/components/ccsds_subpacket_extractor/doc/assembly/env.py
+++ b/src/components/ccsds_subpacket_extractor/doc/assembly/env.py
@@ -2,5 +2,6 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))])
+modify_build_path.add_to_build_path(
+    [this_dir, os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))]
+)

--- a/src/components/ccsds_subpacket_extractor/doc/env.py
+++ b/src/components/ccsds_subpacket_extractor/doc/env.py
@@ -2,5 +2,6 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "assembly"))])
+modify_build_path.add_to_build_path(
+    [this_dir, os.path.realpath(os.path.join(this_dir, "assembly"))]
+)

--- a/src/components/ccsds_subpacket_extractor/doc/env.py
+++ b/src/components/ccsds_subpacket_extractor/doc/env.py
@@ -1,6 +1,6 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "assembly"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "assembly"))])

--- a/src/components/command_protector/test/env.py
+++ b/src/components/command_protector/test/env.py
@@ -2,7 +2,11 @@ from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "test_component")),
-    os.path.realpath(os.path.join(this_dir, "..")),
-    os.path.realpath(os.path.join(this_dir, "test_assembly"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "test_component")),
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(os.path.join(this_dir, "test_assembly")),
+    ]
+)

--- a/src/components/command_protector/test/env.py
+++ b/src/components/command_protector/test/env.py
@@ -1,8 +1,8 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_component")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_assembly"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "test_component")),
+    os.path.realpath(os.path.join(this_dir, "..")),
+    os.path.realpath(os.path.join(this_dir, "test_assembly"))])

--- a/src/components/command_rejector/test/env.py
+++ b/src/components/command_rejector/test/env.py
@@ -2,7 +2,11 @@ from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "test_component")),
-    os.path.realpath(os.path.join(this_dir, "..")),
-    os.path.realpath(os.path.join(this_dir, "test_assembly"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "test_component")),
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(os.path.join(this_dir, "test_assembly")),
+    ]
+)

--- a/src/components/command_rejector/test/env.py
+++ b/src/components/command_rejector/test/env.py
@@ -1,8 +1,8 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_component")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_assembly"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "test_component")),
+    os.path.realpath(os.path.join(this_dir, "..")),
+    os.path.realpath(os.path.join(this_dir, "test_assembly"))])

--- a/src/components/command_router/doc/assembly/env.py
+++ b/src/components/command_router/doc/assembly/env.py
@@ -2,5 +2,6 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))])
+modify_build_path.add_to_build_path(
+    [this_dir, os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))]
+)

--- a/src/components/command_router/doc/assembly/env.py
+++ b/src/components/command_router/doc/assembly/env.py
@@ -1,6 +1,6 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))])

--- a/src/components/command_router/doc/env.py
+++ b/src/components/command_router/doc/env.py
@@ -2,5 +2,6 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "assembly"))])
+modify_build_path.add_to_build_path(
+    [this_dir, os.path.realpath(os.path.join(this_dir, "assembly"))]
+)

--- a/src/components/command_router/doc/env.py
+++ b/src/components/command_router/doc/env.py
@@ -1,6 +1,6 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "assembly"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "assembly"))])

--- a/src/components/command_sequencer/test/env.py
+++ b/src/components/command_sequencer/test/env.py
@@ -2,7 +2,11 @@ from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "test_component")),
-    os.path.realpath(os.path.join(this_dir, "..")),
-    os.path.realpath(os.path.join(this_dir, "test_assembly"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "test_component")),
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(os.path.join(this_dir, "test_assembly")),
+    ]
+)

--- a/src/components/command_sequencer/test/env.py
+++ b/src/components/command_sequencer/test/env.py
@@ -1,8 +1,8 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_component")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_assembly"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "test_component")),
+    os.path.realpath(os.path.join(this_dir, "..")),
+    os.path.realpath(os.path.join(this_dir, "test_assembly"))])

--- a/src/components/command_sequencer/test/test_assembly/env.py
+++ b/src/components/command_sequencer/test/test_assembly/env.py
@@ -2,6 +2,10 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "../test_component")),
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "../test_component")),
+        os.path.realpath(os.path.join(this_dir, ".." + os.sep + "..")),
+    ]
+)

--- a/src/components/command_sequencer/test/test_assembly/env.py
+++ b/src/components/command_sequencer/test/test_assembly/env.py
@@ -1,7 +1,7 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "../test_component")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "../test_component")),
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))])

--- a/src/components/connector_protector/test/env.py
+++ b/src/components/connector_protector/test/env.py
@@ -2,7 +2,11 @@ from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "test_component")),
-    os.path.realpath(os.path.join(this_dir, "..")),
-    os.path.realpath(os.path.join(this_dir, "test_assembly"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "test_component")),
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(os.path.join(this_dir, "test_assembly")),
+    ]
+)

--- a/src/components/connector_protector/test/env.py
+++ b/src/components/connector_protector/test/env.py
@@ -1,8 +1,8 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_component")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_assembly"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "test_component")),
+    os.path.realpath(os.path.join(this_dir, "..")),
+    os.path.realpath(os.path.join(this_dir, "test_assembly"))])

--- a/src/components/connector_queuer/test/env.py
+++ b/src/components/connector_queuer/test/env.py
@@ -2,7 +2,11 @@ from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "test_component")),
-    os.path.realpath(os.path.join(this_dir, "..")),
-    os.path.realpath(os.path.join(this_dir, "test_assembly"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "test_component")),
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(os.path.join(this_dir, "test_assembly")),
+    ]
+)

--- a/src/components/connector_queuer/test/env.py
+++ b/src/components/connector_queuer/test/env.py
@@ -1,8 +1,8 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_component")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_assembly"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "test_component")),
+    os.path.realpath(os.path.join(this_dir, "..")),
+    os.path.realpath(os.path.join(this_dir, "test_assembly"))])

--- a/src/components/event_text_logger/test/env.py
+++ b/src/components/event_text_logger/test/env.py
@@ -1,8 +1,8 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "event_producer")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "event_assembly"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "event_producer")),
+    os.path.realpath(os.path.join(this_dir, "..")),
+    os.path.realpath(os.path.join(this_dir, "event_assembly"))])

--- a/src/components/event_text_logger/test/env.py
+++ b/src/components/event_text_logger/test/env.py
@@ -2,7 +2,11 @@ from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "event_producer")),
-    os.path.realpath(os.path.join(this_dir, "..")),
-    os.path.realpath(os.path.join(this_dir, "event_assembly"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "event_producer")),
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(os.path.join(this_dir, "event_assembly")),
+    ]
+)

--- a/src/components/event_text_logger/test/event_assembly/env.py
+++ b/src/components/event_text_logger/test/event_assembly/env.py
@@ -1,7 +1,7 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "../event_producer")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))
+modify_build_path.add_to_build_path([this_dir,
+   os.path.realpath(os.path.join(this_dir, "../event_producer")),
+   os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))])

--- a/src/components/event_text_logger/test/event_assembly/env.py
+++ b/src/components/event_text_logger/test/event_assembly/env.py
@@ -2,6 +2,12 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-   os.path.realpath(os.path.join(this_dir, "../event_producer")),
-   os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "../event_producer")),
+        os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "records")
+        ),
+    ]
+)

--- a/src/components/fault_correction/gen/doc/env.py
+++ b/src/components/fault_correction/gen/doc/env.py
@@ -4,5 +4,18 @@ import os
 
 # load env file in test directory since we will use files in there:
 this_dir = os.path.dirname(os.path.realpath(__file__))
-runpy.run_path(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "test" + os.sep + "test_assembly" + os.sep + "env.py"))
+runpy.run_path(
+    os.path.join(
+        this_dir,
+        ".."
+        + os.sep
+        + ".."
+        + os.sep
+        + "test"
+        + os.sep
+        + "test_assembly"
+        + os.sep
+        + "env.py",
+    )
+)
 modify_build_path.add_to_build_path(this_dir)

--- a/src/components/fault_correction/gen/doc/env.py
+++ b/src/components/fault_correction/gen/doc/env.py
@@ -1,7 +1,8 @@
+from environments import modify_build_path
 import runpy
 import os
 
 # load env file in test directory since we will use files in there:
 this_dir = os.path.dirname(os.path.realpath(__file__))
 runpy.run_path(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "test" + os.sep + "test_assembly" + os.sep + "env.py"))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + os.environ["EXTRA_BUILD_PATH"]
+modify_build_path.add_to_build_path(this_dir)

--- a/src/components/fault_correction/test/env.py
+++ b/src/components/fault_correction/test/env.py
@@ -1,8 +1,8 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_component")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_assembly"))
+modify_build_path.add_to_build_path([this_dir,
+   os.path.realpath(os.path.join(this_dir, "test_component")),
+   os.path.realpath(os.path.join(this_dir, "..")),
+   os.path.realpath(os.path.join(this_dir, "test_assembly"))])

--- a/src/components/fault_correction/test/env.py
+++ b/src/components/fault_correction/test/env.py
@@ -2,7 +2,11 @@ from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-   os.path.realpath(os.path.join(this_dir, "test_component")),
-   os.path.realpath(os.path.join(this_dir, "..")),
-   os.path.realpath(os.path.join(this_dir, "test_assembly"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "test_component")),
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(os.path.join(this_dir, "test_assembly")),
+    ]
+)

--- a/src/components/fault_correction/test/test_assembly/env.py
+++ b/src/components/fault_correction/test/test_assembly/env.py
@@ -2,6 +2,10 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "../test_component")),
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "../test_component")),
+        os.path.realpath(os.path.join(this_dir, ".." + os.sep + "..")),
+    ]
+)

--- a/src/components/fault_correction/test/test_assembly/env.py
+++ b/src/components/fault_correction/test/test_assembly/env.py
@@ -1,7 +1,7 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "../test_component")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "../test_component")),
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))])

--- a/src/components/forwarder/test/env.py
+++ b/src/components/forwarder/test/env.py
@@ -1,7 +1,7 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_assembly"))
+modify_build_path.add_to_build_path([this_dir,
+   os.path.realpath(os.path.join(this_dir, "..")),
+   os.path.realpath(os.path.join(this_dir, "test_assembly"))])

--- a/src/components/forwarder/test/env.py
+++ b/src/components/forwarder/test/env.py
@@ -2,6 +2,10 @@ from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-   os.path.realpath(os.path.join(this_dir, "..")),
-   os.path.realpath(os.path.join(this_dir, "test_assembly"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(os.path.join(this_dir, "test_assembly")),
+    ]
+)

--- a/src/components/interrupt_listener/doc/assembly/env.py
+++ b/src/components/interrupt_listener/doc/assembly/env.py
@@ -1,6 +1,6 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))])

--- a/src/components/interrupt_listener/doc/assembly/env.py
+++ b/src/components/interrupt_listener/doc/assembly/env.py
@@ -2,5 +2,6 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))])
+modify_build_path.add_to_build_path(
+    [this_dir, os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))]
+)

--- a/src/components/interrupt_listener/doc/env.py
+++ b/src/components/interrupt_listener/doc/env.py
@@ -2,5 +2,6 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "assembly"))])
+modify_build_path.add_to_build_path(
+    [this_dir, os.path.realpath(os.path.join(this_dir, "assembly"))]
+)

--- a/src/components/interrupt_listener/doc/env.py
+++ b/src/components/interrupt_listener/doc/env.py
@@ -1,6 +1,6 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "assembly"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "assembly"))])

--- a/src/components/interrupt_pender/doc/assembly/env.py
+++ b/src/components/interrupt_pender/doc/assembly/env.py
@@ -1,6 +1,6 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))])

--- a/src/components/interrupt_pender/doc/assembly/env.py
+++ b/src/components/interrupt_pender/doc/assembly/env.py
@@ -2,5 +2,6 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))])
+modify_build_path.add_to_build_path(
+    [this_dir, os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))]
+)

--- a/src/components/interrupt_pender/doc/env.py
+++ b/src/components/interrupt_pender/doc/env.py
@@ -2,5 +2,6 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "assembly"))])
+modify_build_path.add_to_build_path(
+    [this_dir, os.path.realpath(os.path.join(this_dir, "assembly"))]
+)

--- a/src/components/interrupt_pender/doc/env.py
+++ b/src/components/interrupt_pender/doc/env.py
@@ -1,6 +1,6 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "assembly"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "assembly"))])

--- a/src/components/interrupt_servicer/doc/assembly/env.py
+++ b/src/components/interrupt_servicer/doc/assembly/env.py
@@ -1,6 +1,6 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))])

--- a/src/components/interrupt_servicer/doc/assembly/env.py
+++ b/src/components/interrupt_servicer/doc/assembly/env.py
@@ -2,5 +2,6 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))])
+modify_build_path.add_to_build_path(
+    [this_dir, os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))]
+)

--- a/src/components/interrupt_servicer/doc/env.py
+++ b/src/components/interrupt_servicer/doc/env.py
@@ -2,5 +2,6 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "assembly"))])
+modify_build_path.add_to_build_path(
+    [this_dir, os.path.realpath(os.path.join(this_dir, "assembly"))]
+)

--- a/src/components/interrupt_servicer/doc/env.py
+++ b/src/components/interrupt_servicer/doc/env.py
@@ -1,6 +1,6 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "assembly"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "assembly"))])

--- a/src/components/memory_copier/test/env.py
+++ b/src/components/memory_copier/test/env.py
@@ -2,8 +2,12 @@ from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "test_component_1")),
-    os.path.realpath(os.path.join(this_dir, "test_component_2")),
-    os.path.realpath(os.path.join(this_dir, "..")),
-    os.path.realpath(os.path.join(this_dir, "test_assembly"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "test_component_1")),
+        os.path.realpath(os.path.join(this_dir, "test_component_2")),
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(os.path.join(this_dir, "test_assembly")),
+    ]
+)

--- a/src/components/memory_copier/test/env.py
+++ b/src/components/memory_copier/test/env.py
@@ -1,9 +1,9 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_component_1")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_component_2")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_assembly"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "test_component_1")),
+    os.path.realpath(os.path.join(this_dir, "test_component_2")),
+    os.path.realpath(os.path.join(this_dir, "..")),
+    os.path.realpath(os.path.join(this_dir, "test_assembly"))])

--- a/src/components/parameter_store/test/env.py
+++ b/src/components/parameter_store/test/env.py
@@ -2,8 +2,12 @@ from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "test_component_1")),
-    os.path.realpath(os.path.join(this_dir, "test_component_2")),
-    os.path.realpath(os.path.join(this_dir, "..")),
-    os.path.realpath(os.path.join(this_dir, "test_assembly"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "test_component_1")),
+        os.path.realpath(os.path.join(this_dir, "test_component_2")),
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(os.path.join(this_dir, "test_assembly")),
+    ]
+)

--- a/src/components/parameter_store/test/env.py
+++ b/src/components/parameter_store/test/env.py
@@ -1,9 +1,9 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_component_1")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_component_2")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_assembly"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "test_component_1")),
+    os.path.realpath(os.path.join(this_dir, "test_component_2")),
+    os.path.realpath(os.path.join(this_dir, "..")),
+    os.path.realpath(os.path.join(this_dir, "test_assembly"))])

--- a/src/components/parameters/gen/doc/env.py
+++ b/src/components/parameters/gen/doc/env.py
@@ -4,5 +4,18 @@ import os
 
 # load env file in test directory since we will use files in there:
 this_dir = os.path.dirname(os.path.realpath(__file__))
-runpy.run_path(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "test" + os.sep + "test_assembly" + os.sep + "env.py"))
+runpy.run_path(
+    os.path.join(
+        this_dir,
+        ".."
+        + os.sep
+        + ".."
+        + os.sep
+        + "test"
+        + os.sep
+        + "test_assembly"
+        + os.sep
+        + "env.py",
+    )
+)
 modify_build_path.add_to_build_path(this_dir)

--- a/src/components/parameters/gen/doc/env.py
+++ b/src/components/parameters/gen/doc/env.py
@@ -1,7 +1,8 @@
+from environments import modify_build_path
 import runpy
 import os
 
 # load env file in test directory since we will use files in there:
 this_dir = os.path.dirname(os.path.realpath(__file__))
 runpy.run_path(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "test" + os.sep + "test_assembly" + os.sep + "env.py"))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + os.environ["EXTRA_BUILD_PATH"]
+modify_build_path.add_to_build_path(this_dir)

--- a/src/components/parameters/test/env.py
+++ b/src/components/parameters/test/env.py
@@ -2,8 +2,12 @@ from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "test_component_1")),
-    os.path.realpath(os.path.join(this_dir, "test_component_2")),
-    os.path.realpath(os.path.join(this_dir, "..")),
-    os.path.realpath(os.path.join(this_dir, "test_assembly"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "test_component_1")),
+        os.path.realpath(os.path.join(this_dir, "test_component_2")),
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(os.path.join(this_dir, "test_assembly")),
+    ]
+)

--- a/src/components/parameters/test/env.py
+++ b/src/components/parameters/test/env.py
@@ -1,9 +1,9 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_component_1")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_component_2")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_assembly"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "test_component_1")),
+    os.path.realpath(os.path.join(this_dir, "test_component_2")),
+    os.path.realpath(os.path.join(this_dir, "..")),
+    os.path.realpath(os.path.join(this_dir, "test_assembly"))])

--- a/src/components/parameters/test/test_assembly/env.py
+++ b/src/components/parameters/test/test_assembly/env.py
@@ -1,9 +1,9 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "../test_component_1")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "../test_component_2")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "types"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "../test_component_1")),
+    os.path.realpath(os.path.join(this_dir, "../test_component_2")),
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "..")),
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "types"))])

--- a/src/components/parameters/test/test_assembly/env.py
+++ b/src/components/parameters/test/test_assembly/env.py
@@ -2,8 +2,14 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "../test_component_1")),
-    os.path.realpath(os.path.join(this_dir, "../test_component_2")),
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "..")),
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "types"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "../test_component_1")),
+        os.path.realpath(os.path.join(this_dir, "../test_component_2")),
+        os.path.realpath(os.path.join(this_dir, ".." + os.sep + "..")),
+        os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "types")
+        ),
+    ]
+)

--- a/src/components/product_packetizer/gen/doc/env.py
+++ b/src/components/product_packetizer/gen/doc/env.py
@@ -4,5 +4,18 @@ import os
 
 # load env file in test directory since we will use files in there:
 this_dir = os.path.dirname(os.path.realpath(__file__))
-runpy.run_path(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "test" + os.sep + "test_assembly" + os.sep + "env.py"))
+runpy.run_path(
+    os.path.join(
+        this_dir,
+        ".."
+        + os.sep
+        + ".."
+        + os.sep
+        + "test"
+        + os.sep
+        + "test_assembly"
+        + os.sep
+        + "env.py",
+    )
+)
 modify_build_path.add_to_build_path(this_dir)

--- a/src/components/product_packetizer/gen/doc/env.py
+++ b/src/components/product_packetizer/gen/doc/env.py
@@ -1,7 +1,8 @@
+from environments import modify_build_path
 import runpy
 import os
 
 # load env file in test directory since we will use files in there:
 this_dir = os.path.dirname(os.path.realpath(__file__))
 runpy.run_path(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "test" + os.sep + "test_assembly" + os.sep + "env.py"))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + os.environ["EXTRA_BUILD_PATH"]
+modify_build_path.add_to_build_path(this_dir)

--- a/src/components/product_packetizer/test/env.py
+++ b/src/components/product_packetizer/test/env.py
@@ -2,8 +2,12 @@ from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "test_component_1")),
-    os.path.realpath(os.path.join(this_dir, "test_component_2")),
-    os.path.realpath(os.path.join(this_dir, "..")),
-    os.path.realpath(os.path.join(this_dir, "test_assembly"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "test_component_1")),
+        os.path.realpath(os.path.join(this_dir, "test_component_2")),
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(os.path.join(this_dir, "test_assembly")),
+    ]
+)

--- a/src/components/product_packetizer/test/env.py
+++ b/src/components/product_packetizer/test/env.py
@@ -1,9 +1,9 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_component_1")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_component_2")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_assembly"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "test_component_1")),
+    os.path.realpath(os.path.join(this_dir, "test_component_2")),
+    os.path.realpath(os.path.join(this_dir, "..")),
+    os.path.realpath(os.path.join(this_dir, "test_assembly"))])

--- a/src/components/product_packetizer/test/test_assembly/env.py
+++ b/src/components/product_packetizer/test/test_assembly/env.py
@@ -1,8 +1,8 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "../test_component_1")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "../test_component_2")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "../test_component_1")),
+    os.path.realpath(os.path.join(this_dir, "../test_component_2")),
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))])

--- a/src/components/product_packetizer/test/test_assembly/env.py
+++ b/src/components/product_packetizer/test/test_assembly/env.py
@@ -2,7 +2,11 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "../test_component_1")),
-    os.path.realpath(os.path.join(this_dir, "../test_component_2")),
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".."))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "../test_component_1")),
+        os.path.realpath(os.path.join(this_dir, "../test_component_2")),
+        os.path.realpath(os.path.join(this_dir, ".." + os.sep + "..")),
+    ]
+)

--- a/src/components/queue_monitor/test/env.py
+++ b/src/components/queue_monitor/test/env.py
@@ -2,5 +2,6 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "queued_component"))])
+modify_build_path.add_to_build_path(
+    [this_dir, os.path.realpath(os.path.join(this_dir, "queued_component"))]
+)

--- a/src/components/queue_monitor/test/env.py
+++ b/src/components/queue_monitor/test/env.py
@@ -1,6 +1,6 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "queued_component"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "queued_component"))])

--- a/src/components/sequence_store/gen/doc/env.py
+++ b/src/components/sequence_store/gen/doc/env.py
@@ -1,3 +1,4 @@
+from environments import modify_build_path
 import runpy
 import os
 
@@ -17,4 +18,4 @@ runpy.run_path(
         + "env.py",
     )
 )
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + os.environ["EXTRA_BUILD_PATH"]
+modify_build_path.add_to_build_path(this_dir)

--- a/src/components/sequence_store/test/env.py
+++ b/src/components/sequence_store/test/env.py
@@ -2,7 +2,11 @@ from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "test_component")),
-    os.path.realpath(os.path.join(this_dir, "..")),
-    os.path.realpath(os.path.join(this_dir, "test_assembly"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "test_component")),
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(os.path.join(this_dir, "test_assembly")),
+    ]
+)

--- a/src/components/sequence_store/test/env.py
+++ b/src/components/sequence_store/test/env.py
@@ -1,8 +1,8 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_component")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_assembly"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "test_component")),
+    os.path.realpath(os.path.join(this_dir, "..")),
+    os.path.realpath(os.path.join(this_dir, "test_assembly"))])

--- a/src/components/sequence_store/test/test_assembly/env.py
+++ b/src/components/sequence_store/test/test_assembly/env.py
@@ -1,9 +1,9 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "../test_component_1")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "../test_component_2")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "types"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "../test_component_1")),
+    os.path.realpath(os.path.join(this_dir, "../test_component_2")),
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "..")),
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "types"))])

--- a/src/components/sequence_store/test/test_assembly/env.py
+++ b/src/components/sequence_store/test/test_assembly/env.py
@@ -2,8 +2,14 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "../test_component_1")),
-    os.path.realpath(os.path.join(this_dir, "../test_component_2")),
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "..")),
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "types"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "../test_component_1")),
+        os.path.realpath(os.path.join(this_dir, "../test_component_2")),
+        os.path.realpath(os.path.join(this_dir, ".." + os.sep + "..")),
+        os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "types")
+        ),
+    ]
+)

--- a/src/components/task_watchdog/gen/doc/env.py
+++ b/src/components/task_watchdog/gen/doc/env.py
@@ -4,5 +4,18 @@ import os
 
 # load env file in test directory since we will use files in there:
 this_dir = os.path.dirname(os.path.realpath(__file__))
-runpy.run_path(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "test" + os.sep + "test_assembly" + os.sep + "env.py"))
+runpy.run_path(
+    os.path.join(
+        this_dir,
+        ".."
+        + os.sep
+        + ".."
+        + os.sep
+        + "test"
+        + os.sep
+        + "test_assembly"
+        + os.sep
+        + "env.py",
+    )
+)
 modify_build_path.add_to_build_path(this_dir)

--- a/src/components/task_watchdog/gen/doc/env.py
+++ b/src/components/task_watchdog/gen/doc/env.py
@@ -1,7 +1,8 @@
+from environments import modify_build_path
 import runpy
 import os
 
 # load env file in test directory since we will use files in there:
 this_dir = os.path.dirname(os.path.realpath(__file__))
 runpy.run_path(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "test" + os.sep + "test_assembly" + os.sep + "env.py"))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep + os.environ["EXTRA_BUILD_PATH"]
+modify_build_path.add_to_build_path(this_dir)

--- a/src/components/task_watchdog/test/env.py
+++ b/src/components/task_watchdog/test/env.py
@@ -2,8 +2,12 @@ from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-   os.path.realpath(os.path.join(this_dir, "test_component_1")),
-   os.path.realpath(os.path.join(this_dir, "test_component_2")),
-   os.path.realpath(os.path.join(this_dir, "..")),
-   os.path.realpath(os.path.join(this_dir, "test_assembly"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "test_component_1")),
+        os.path.realpath(os.path.join(this_dir, "test_component_2")),
+        os.path.realpath(os.path.join(this_dir, "..")),
+        os.path.realpath(os.path.join(this_dir, "test_assembly")),
+    ]
+)

--- a/src/components/task_watchdog/test/env.py
+++ b/src/components/task_watchdog/test/env.py
@@ -1,9 +1,9 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os.path
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_component_1")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_component_2")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "test_assembly"))
+modify_build_path.add_to_build_path([this_dir,
+   os.path.realpath(os.path.join(this_dir, "test_component_1")),
+   os.path.realpath(os.path.join(this_dir, "test_component_2")),
+   os.path.realpath(os.path.join(this_dir, "..")),
+   os.path.realpath(os.path.join(this_dir, "test_assembly"))])

--- a/src/components/task_watchdog/test/test_assembly/env.py
+++ b/src/components/task_watchdog/test/test_assembly/env.py
@@ -1,9 +1,9 @@
-from environments import test  # noqa: F401
+from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-os.environ["EXTRA_BUILD_PATH"] = this_dir + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "../test_component_1")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, "../test_component_2")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + "..")) + os.pathsep \
-                                 + os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "types"))
+modify_build_path.add_to_build_path([this_dir,
+    os.path.realpath(os.path.join(this_dir, "../test_component_1")),
+    os.path.realpath(os.path.join(this_dir, "../test_component_2")),
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "..")),
+    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "types"))])

--- a/src/components/task_watchdog/test/test_assembly/env.py
+++ b/src/components/task_watchdog/test/test_assembly/env.py
@@ -2,8 +2,14 @@ from environments import test, modify_build_path  # noqa: F401
 import os
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
-modify_build_path.add_to_build_path([this_dir,
-    os.path.realpath(os.path.join(this_dir, "../test_component_1")),
-    os.path.realpath(os.path.join(this_dir, "../test_component_2")),
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + "..")),
-    os.path.realpath(os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "types"))])
+modify_build_path.add_to_build_path(
+    [
+        this_dir,
+        os.path.realpath(os.path.join(this_dir, "../test_component_1")),
+        os.path.realpath(os.path.join(this_dir, "../test_component_2")),
+        os.path.realpath(os.path.join(this_dir, ".." + os.sep + "..")),
+        os.path.realpath(
+            os.path.join(this_dir, ".." + os.sep + ".." + os.sep + "types")
+        ),
+    ]
+)

--- a/src/core/connector/in_connector.ads
+++ b/src/core/connector/in_connector.ads
@@ -12,7 +12,7 @@ package In_Connector is
    type Ptr is access all Instance;
 
    -- This is the subprogram definition for the invokee side of this connector.
-   type Invokee_Hook is access function (A_Component : in out Component.Core_Instance'Class; Input : in T; Index : in Connector_Index_Type; fFull_Queue_Behavior : in Full_Queue_Action) return Connector_Status;
+   type Invokee_Hook is access function (A_Component : in out Component.Core_Instance'Class; Input : in T; Index : in Connector_Index_Type; Full_Queue_Behavior : in Full_Queue_Action) return Connector_Status;
 
    -- Public function to register the component attached
    -- to the receiving end of the connector:

--- a/src/unit_test/string_util/Linux/string_util.adb
+++ b/src/unit_test/string_util/Linux/string_util.adb
@@ -23,8 +23,8 @@ package body String_Util is
       Toreturn : String (1 .. Bytes'Length * 3);
       Cnt : Natural := 0;
    begin
-      for Indx in Bytes'Range loop
-         Toreturn ((Cnt * 3 + 1) .. (Cnt * 3 + 3)) := " " & String_Util.Natural_2_Hex_String (Natural (Bytes (Indx)), 2);
+      for Idx in Bytes'Range loop
+         Toreturn ((Cnt * 3 + 1) .. (Cnt * 3 + 3)) := " " & String_Util.Natural_2_Hex_String (Natural (Bytes (Idx)), 2);
          Cnt := @ + 1;
       end loop;
       return Prefix & Trim_Both (Toreturn) & Postfix;


### PR DESCRIPTION
    Update env.py files to append to EXTRA_BUILD_PATH
    
    All env.py files used to just overwrite EXTRA_BUILD_PATH, but this does not
    allow a user to specify EXTRA_BUILD_PATH from the commandline (or
    activate script) and then have it stick when those env.py files are run.
    This change adds a python module which makes setting these build path
    variables more straight forward, and converts all the env.py files to
    use it. Now EXTRA_BUILD_PATH is appended to instead of overwritten.
    
    The added python module is: redo/environments/modify_build_path.py
 