### PR TITLE
Packed Record Field Type Aliases

### DIFF
--- a/gen/templates/array/name.ads
+++ b/gen/templates/array/name.ads
@@ -441,4 +441,20 @@ package {{ name }} is
    package Element_Serialization is new Serializer (Element_Packed);
 {% endif %}
 
+   ----------------------------------------------------
+   -- Named subtypes for array element for convenience:
+   ----------------------------------------------------
+
+{% if element.is_packed_type %}
+   subtype Element_Type_U is {{ element.type_package }}.U;
+{% if endianness in ["either", "big"] %}
+   subtype Element_Type_T is {{ element.type_package }}.T;
+{% endif %}
+{% if endianness in ["either", "little"] %}
+   subtype Element_Type_T_Le is {{ element.type_package }}.T_Le;
+{% endif %}
+{% else %}
+   {% if ("Element_Type") == element.type %}-- {% endif %}subtype Element_Type is {{ element.type }};
+{% endif %}
+
 end {{ name }};

--- a/gen/templates/record/name.ads
+++ b/gen/templates/record/name.ads
@@ -539,4 +539,22 @@ package {{ name }} is
 {% endfor %}
 {% endif %}
 
+   -------------------------------------------------
+   -- Named subtypes for each field for convenience:
+   -------------------------------------------------
+
+{% for field in fields.values() %}
+{% if field.is_packed_type %}
+   subtype {{ field.name }}_Type_U is {{ field.type_package }}.U;
+{% if endianness in ["either", "big"] %}
+   subtype {{ field.name }}_Type_T is {{ field.type_package }}.T;
+{% endif %}
+{% if endianness in ["either", "little"] %}
+   subtype {{ field.name }}_Type_T_Le is {{ field.type_package }}.T_Le;
+{% endif %}
+{% else %}
+   {% if (field.name + "_Type") == field.type %}-- {% endif %}subtype {{ field.name }}_Type is {{ field.type }};
+{% endif %}
+{% endfor %}
+
 end {{ name }};


### PR DESCRIPTION
This change provides convenient type aliases (using subtypes) for packed record fields and packed array elements. In this way, a user does not need to know the type of the field to reference it, they can simply use `<field_name>_Type`. For example, for the Sys_Time record, the autocoder now includes the following autocoded types for convenience:

```
   subtype Seconds_Type is Interfaces.Unsigned_32;
   subtype Subseconds_Type is Interfaces.Unsigned_32;
```