### PR TITLE
Update data dependencies generator template to apply `_Stale_Limit`

### DIFF
--- a/gen/templates/data_dependencies/name_data_dependencies.adb
+++ b/gen/templates/data_dependencies/name_data_dependencies.adb
@@ -25,6 +25,7 @@ package body {{ name }} is
       -- Copy over IDs into the object:
 {% for dd in data_dependencies %}
       Self.{{ dd.name }}_Id := {{ dd.name }}_Id;
+      Self.{{ dd.name }}_Stale_Limit := {{ dd.name }}_Stale_Limit;
 {% endfor %}
    end Set_Ids_And_Limits;
 


### PR DESCRIPTION
When setting the ID and limits for a data product `_Stale_Limit` did not appear to be set. This presents as the default stale limit being used even when setting `map_data_dependencies: stale_limit_us:` in an assembly, and selecting `time: packet_time` in an extracted product.