### PR TITLE
Build system performance enhancements

### DIFF
--- a/gen/models/component.py
+++ b/gen/models/component.py
@@ -12,6 +12,7 @@ import models.submodels.ided_suite as ided_suite_module
 from util import ada
 from util import model_loader
 from util import redo_arg
+from util import filesystem
 import os
 from collections import OrderedDict
 
@@ -639,21 +640,23 @@ class component(base):
 
         ut_model_files = []
         self.full_file_dir = os.path.dirname(self.full_filename)
-        for root, dirs, files in os.walk(self.full_file_dir):
+        for root, dirs, files in filesystem.recurse_through_repo(
+            self.full_file_dir,
+            ignore=["build", "ignore", "doc"]
+        ):
             for dirname in dirs:
-                if dirname not in ["build", "doc"]:
-                    for unit_test_model in glob.iglob(
-                        os.path.join(
-                            os.path.join(root, dirname),
-                            "*" + self.name.lower() + ".tests.yaml",
-                        )
-                    ):
-                        # Unit test found, load it:
-                        # sys.stderr.write(unit_test_model + "\n")
-                        t = tests(unit_test_model)
-                        t.set_component(self)
-                        self.unit_tests.append(t)
-                        ut_model_files.append(t.full_filename)
+                for unit_test_model in glob.iglob(
+                    os.path.join(
+                        os.path.join(root, dirname),
+                        "*" + self.name.lower() + ".tests.yaml",
+                    )
+                ):
+                    # Unit test found, load it:
+                    # sys.stderr.write(unit_test_model + "\n")
+                    t = tests(unit_test_model)
+                    t.set_component(self)
+                    self.unit_tests.append(t)
+                    ut_model_files.append(t.full_filename)
         return ut_model_files
 
     def set_component_instance_data(

--- a/redo/rules/build_executable.py
+++ b/redo/rules/build_executable.py
@@ -73,19 +73,19 @@ def _build_all_ada_object_dependencies(
         # Read the dependency files for each object we just built and construct
         # a list of dependencies:
         dep_files = list(set([of + ".deps" for of in object_files]))
-        deps = []
+        obj_deps = []
         for dep_file in dep_files:
             with open(dep_file, "r") as f:
-                deps.extend(f.read().split("\n"))
+                obj_deps.extend(f.read().split("\n"))
 
         # Filter out files that are not Ada/C/C++ source files:
-        deps = [d for d in deps if d.endswith('.ads') or d.endswith('.adb') or
-                d.endswith('.c') or d.endswith('.h') or d.endswith('.hpp') or d.endswith('.cpp')]
-        deps = list(set(deps))
+        obj_deps = [d for d in obj_deps if d.endswith('.ads') or d.endswith('.adb') or
+                    d.endswith('.c') or d.endswith('.h') or d.endswith('.hpp') or d.endswith('.cpp')]
+        obj_deps = list(set(obj_deps))
 
         # Only include dependencies that exist in the database:
         dep_objects = []
-        dep_packages = list(set([ada.file_name_to_package_name(dep) for dep in deps]))
+        dep_packages = list(set([ada.file_name_to_package_name(dep) for dep in obj_deps]))
         for package in dep_packages:
             objects_in_db = source_db.get_objects([package], the_target=build_target)
             if not objects_in_db:


### PR DESCRIPTION
For `redo clean` as well as building binaries and executables.

For `redo clean` we now call out to the system to remove files using `rm` and we do this concurrently. This is much faster than using python's `rmtree`.

For building, the prebuild logic was making duplicate calls out to `redo-ifchange` during the prebuild phase. A refactor was able to eliminate these duplicate calls, improving build times.