### PR TITLE
Add Epsilon Based Assertions for Packed Types

### DIFF
--- a/gen/generators/packed_types.py
+++ b/gen/generators/packed_types.py
@@ -27,6 +27,7 @@ array_templates = [
     "array/name-validation.ads",
     "array/name-validation.adb",
     "array/name-assertion.ads",
+    "array/name-assertion.adb",
     "array/name-c.ads",
     "array/name-c.adb",
     "array/name.py",

--- a/gen/models/submodels/field.py
+++ b/gen/models/submodels/field.py
@@ -423,3 +423,11 @@ class field(variable):
                 return True
             else:
                 return False
+
+    @property
+    def has_float(self):
+        if self.is_packed_type:
+            assert self.type_model.has_float is not None
+            return self.type_model.has_float
+        else:
+            return self.format.type.startswith("F")

--- a/gen/models/type.py
+++ b/gen/models/type.py
@@ -23,6 +23,7 @@ class type(packed_type):
         """Load record specific data structures with information from YAML file."""
         # Initialize object members:
         self.element = None
+        self.has_float = False
 
         # Populate the object with the contents of the
         # file data:
@@ -37,6 +38,10 @@ class type(packed_type):
                 "Error encountered loading data for element: " + str(e)
             )
         self.num_fields = 1
+
+        # If this element has a float, then this type has a float:
+        if self.element.has_float:
+            self.has_float = True
 
         # Calculate total size:
         self.size = self.element.size

--- a/gen/templates/array/name-assertion.adb
+++ b/gen/templates/array/name-assertion.adb
@@ -1,0 +1,148 @@
+--------------------------------------------------------------------------------
+-- {{ formatType(model_name) }} {{ formatType(model_type) }} Assertion Body
+--
+-- Generated from {{ filename }} on {{ time }}.
+--------------------------------------------------------------------------------
+
+pragma Warnings (Off, "no entities of ""Basic_Types"" are referenced");
+with Basic_Types; use Basic_Types;
+pragma Warnings (On, "no entities of ""Basic_Types"" are referenced");
+
+package body {{ name }}.Assertion is
+
+{% if has_float %}
+   function Err_Msg (Index : in Natural) return String is
+      Msg_Pre : constant String := "Assertion failed for index ";
+      Msg_Post : constant String := " while comparing {{ name }} below.";
+   begin
+      return Msg_Pre & Natural'Image (Index) & Msg_Post;
+   end Err_Msg;
+
+   pragma Warnings (Off, "redundant conversion, ""Epsilon"" is of type ""Long_Float""");
+   procedure Assert_Eq (T1 : in U; T2 : in U; Epsilon : in Long_Float := 0.0) is
+   begin
+      -- Assert on all indices individually:
+      for Idx in T1'Range loop
+{% if element.is_packed_type %}
+         Element_Assertion.{{ element.type_package }}_U_Assert.Eq (T1 (Idx), T2 (Idx), Epsilon, Err_Msg (Idx));
+{% else %}
+         Element_Assert.Eq (T1 (Idx), T2 (Idx), {{ element.type }} (Epsilon), Err_Msg (Idx));
+{% endif %}
+      end loop;
+   end Assert_Eq;
+
+{% if endianness in ["either", "big"] %}
+   procedure Assert_Eq (T1 : in T; T2 : in T; Epsilon : in Long_Float := 0.0) is
+   begin
+      -- Assert on all indices individually:
+      for Idx in T1'Range loop
+{% if element.is_packed_type %}
+         Element_Assertion.{{ element.type_package }}_Assert.Eq (T1 (Idx), T2 (Idx), Epsilon, Err_Msg (Idx));
+{% else %}
+         Element_Assert.Eq (T1 (Idx), T2 (Idx), {{ element.type }} (Epsilon), Err_Msg (Idx));
+{% endif %}
+      end loop;
+   end Assert_Eq;
+
+{% endif %}
+{% if endianness in ["either", "little"] %}
+   procedure Assert_Eq (T1 : in T_Le; T2 : in T_Le; Epsilon : in Long_Float := 0.0) is
+   begin
+      -- Assert on all indices individually:
+      for Idx in T1'Range loop
+{% if element.is_packed_type %}
+         Element_Assertion.{{ element.type_package }}_Le_Assert.Eq (T1 (Idx), T2 (Idx), Epsilon, Err_Msg (Idx));
+{% else %}
+         Element_Assert.Eq (T1 (Idx), T2 (Idx), {{ element.type }} (Epsilon), Err_Msg (Idx));
+{% endif %}
+      end loop;
+   end Assert_Eq;
+
+{% endif %}
+   pragma Warnings (On, "redundant conversion, ""Epsilon"" is of type ""Long_Float""");
+
+{% if endianness in ["either", "big"] %}
+   package body {{ name }}_Assert is
+      procedure Eq (T1 : in T; T2 : in T; Epsilon : in Long_Float := 0.0; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line) is
+      begin
+         Assert_Eq (T1, T2, Epsilon);
+      exception
+         -- If an assertion was thrown above, then the comparison failed.
+         -- Go ahead and call the assert all function to produce the error message.
+         when others =>
+            {{ name }}_Assert_All.Eq (T1, T2, Message, Filename, Line);
+      end Eq;
+
+      procedure Neq (T1 : in T; T2 : in T; Epsilon : in Long_Float := 0.0; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line) is
+      begin
+         -- Call Eq. If this fails we know that they are not equal.
+         Assert_Eq (T1, T2, Epsilon);
+         -- If we got here without an assertion, then T1 and T2 are equal which is
+         -- a failure. Call the assert all function to produce the error message.
+         {{ name }}_Assert_All.Neq (T1, T2, Message, Filename, Line);
+      exception
+         -- If an assertion was not thrown above, then the comparison succeeded.
+         when others => null;
+      end Neq;
+   end {{ name }}_Assert;
+
+{% endif %}
+{% if endianness in ["either", "little"] %}
+   package body {{ name }}_Le_Assert is
+      procedure Eq (T1 : in T_Le; T2 : in T_Le; Epsilon : in Long_Float := 0.0; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line) is
+      begin
+         Assert_Eq (T1, T2, Epsilon);
+      exception
+         -- If an assertion was thrown above, then the comparison failed.
+         -- Go ahead and call the assert all function to produce the error message.
+         when others =>
+            {{ name }}_Le_Assert_All.Eq (T1, T2, Message, Filename, Line);
+      end Eq;
+
+      procedure Neq (T1 : in T_Le; T2 : in T_Le; Epsilon : in Long_Float := 0.0; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line) is
+      begin
+         -- Call Eq. If this fails we know that they are not equal.
+         Assert_Eq (T1, T2, Epsilon);
+         -- If we got here without an assertion, then T1 and T2 are equal which is
+         -- a failure. Call the assert all function to produce the error message.
+         {{ name }}_Le_Assert_All.Neq (T1, T2, Message, Filename, Line);
+      exception
+         -- If an assertion was not thrown above, then the comparison succeeded.
+         when others => null;
+      end Neq;
+   end {{ name }}_Le_Assert;
+
+{% endif %}
+   package body {{ name }}_U_Assert is
+      procedure Eq (T1 : in U; T2 : in U; Epsilon : in Long_Float := 0.0; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line) is
+      begin
+         Assert_Eq (T1, T2, Epsilon);
+      exception
+         -- If an assertion was thrown above, then the comparison failed.
+         -- Go ahead and call the assert all function to produce the error message.
+         when others =>
+            {{ name }}_U_Assert_All.Eq (T1, T2, Message, Filename, Line);
+      end Eq;
+
+      procedure Neq (T1 : in U; T2 : in U; Epsilon : in Long_Float := 0.0; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line) is
+      begin
+         -- Call Eq. If this fails we know that they are not equal.
+         Assert_Eq (T1, T2, Epsilon);
+         -- If we got here without an assertion, then T1 and T2 are equal which is
+         -- a failure. Call the assert all function to produce the error message.
+         {{ name }}_U_Assert_All.Neq (T1, T2, Message, Filename, Line);
+      exception
+         -- If an assertion was not thrown above, then the comparison succeeded.
+         when others => null;
+      end Neq;
+   end {{ name }}_U_Assert;
+{% else %}
+   package body Dummy is
+      procedure Dumb is
+      begin
+         null;
+      end Dumb;
+   end Dummy;
+
+{% endif %}
+end {{ name }}.Assertion;

--- a/gen/templates/record/name-assertion.adb
+++ b/gen/templates/record/name-assertion.adb
@@ -10,146 +10,102 @@ pragma Warnings (On, "no entities of ""Basic_Types"" are referenced");
 
 package body {{ name }}.Assertion is
 
-{% if variable_length %}
-   procedure Assert_Eq (T1 : in U; T2 : in U) is
+{% if variable_length or has_float %}
+   function Err_Msg (Field_Name : in String) return String is
+      Msg_Pre : constant String := "Assertion failed for field ";
+      Msg_Post : constant String := " while comparing {{ name }} below.";
+   begin
+      return Msg_Pre & Field_Name & Msg_Post;
+   end Err_Msg;
+
+{% if has_float %}
+   pragma Warnings (Off, "redundant conversion, ""Epsilon"" is of type ""Long_Float""");
+{% endif %}
+   procedure Assert_Eq (T1 : in U; T2 : in U{% if has_float %}; Epsilon : in Long_Float := 0.0{% endif %}) is
 {% for include in type_uses %}
       use {{ include }};
 {% endfor %}
    begin
       -- Assert on all fields individually:
 {% for field in fields.values() %}
-{% if field.is_packed_type and field.type_model.variable_length %}
-      {{ field.name }}_Assertion.{{ field.type_package }}_U_Assert.Eq (T1.{{ field.name }}, T2.{{ field.name }}, "Comparing {{ field.name }} failed.");
-{% elif field.variable_length %}
+{% if field.variable_length %}
+{% if field.has_float %}
+      pragma Assert (Epsilon = 0.0, "Floating point comparisons with Epsilon > 0.0 for an array of floats is not yet supported.");
+{% endif %}
       pragma Assert (
          T1.{{ field.name }} (T1.{{ field.name }}'First .. T1.{{ field.name }}'First + Integer (T1.{{ field.variable_length }}) + Integer ({{ field.variable_length_offset }}) - 1) =
          T2.{{ field.name }} (T2.{{ field.name }}'First .. T2.{{ field.name }}'First + Integer (T2.{{ field.variable_length }}) + Integer ({{ field.variable_length_offset }}) - 1),
-         "Comparing {{ field.name }} failed."
+         Err_Msg ("{{ field.name }}")
       );
+{% elif field.is_packed_type %}
+      {{ field.name }}_Assertion.{{ field.type_package }}_U_Assert.Eq (T1.{{ field.name }}, T2.{{ field.name }},{% if field.has_float %} Epsilon,{% endif %} Err_Msg ("{{ field.name }}"));
 {% else %}
-      pragma Assert (T1.{{ field.name }} = T2.{{ field.name }}, "Comparing {{ field.name }} failed.");
+      {{ field.name }}_Assert.Eq (T1.{{ field.name }}, T2.{{ field.name }},{% if field.has_float %} {{ field.type }} (Epsilon),{% endif %} Err_Msg ("{{ field.name }}"));
 {% endif %}
 {% endfor %}
    end Assert_Eq;
 
 {% if endianness in ["either", "big"] %}
-   procedure Assert_Eq (T1 : in T; T2 : in T) is
+   procedure Assert_Eq (T1 : in T; T2 : in T{% if has_float %}; Epsilon : in Long_Float := 0.0{% endif %}) is
 {% for include in type_uses %}
       use {{ include }};
 {% endfor %}
    begin
       -- Assert on all fields individually:
 {% for field in fields.values() %}
-{% if field.is_packed_type and field.type_model.variable_length %}
-      {{ field.name }}_Assertion.{{ field.type_package }}_Assert.Eq (T1.{{ field.name }}, T2.{{ field.name }}, "Comparing {{ field.name }} failed.");
-{% elif field.variable_length %}
+{% if field.variable_length %}
+{% if field.has_float %}
+      pragma Assert (Epsilon = 0.0, "Floating point comparisons with Epsilon > 0.0 for a variable sized array of floats is not yet supported.");
+{% endif %}
       pragma Assert (
          T1.{{ field.name }} (T1.{{ field.name }}'First .. T1.{{ field.name }}'First + Integer (T1.{{ field.variable_length }}) + Integer ({{ field.variable_length_offset }}) - 1) =
          T2.{{ field.name }} (T2.{{ field.name }}'First .. T2.{{ field.name }}'First + Integer (T2.{{ field.variable_length }}) + Integer ({{ field.variable_length_offset }}) - 1),
-         "Comparing {{ field.name }} failed."
+         Err_Msg ("{{ field.name }}")
       );
+{% elif field.is_packed_type %}
+      {{ field.name }}_Assertion.{{ field.type_package }}_Assert.Eq (T1.{{ field.name }}, T2.{{ field.name }},{% if field.has_float %} Epsilon,{% endif %} Err_Msg ("{{ field.name }}"));
 {% else %}
-      pragma Assert (T1.{{ field.name }} = T2.{{ field.name }}, "Comparing {{ field.name }} failed.");
+      {{ field.name }}_Assert.Eq (T1.{{ field.name }}, T2.{{ field.name }},{% if field.has_float %} {{ field.type }} (Epsilon),{% endif %} Err_Msg ("{{ field.name }}"));
 {% endif %}
 {% endfor %}
    end Assert_Eq;
 
 {% endif %}
 {% if endianness in ["either", "little"] %}
-   procedure Assert_Eq (T1 : in T_Le; T2 : in T_Le) is
+   procedure Assert_Eq (T1 : in T_Le; T2 : in T_Le{% if has_float %}; Epsilon : in Long_Float := 0.0{% endif %}) is
 {% for include in type_uses %}
       use {{ include }};
 {% endfor %}
    begin
       -- Assert on all fields individually:
 {% for field in fields.values() %}
-{% if field.is_packed_type and field.type_model.variable_length %}
-      {{ field.name }}_Assertion.{{ field.type_package }}_Le_Assert.Eq (T1.{{ field.name }}, T2.{{ field.name }}, "Comparing {{ field.name }} failed.");
-{% elif field.variable_length %}
+{% if field.variable_length %}
+{% if field.has_float %}
+      pragma Assert (Epsilon = 0.0, "Floating point comparisons with Epsilon > 0.0 for a variable sized array of floats is not yet supported.");
+{% endif %}
       pragma Assert (
          T1.{{ field.name }} (T1.{{ field.name }}'First .. T1.{{ field.name }}'First + Integer (T1.{{ field.variable_length }}) + Integer ({{ field.variable_length_offset }}) - 1) =
          T2.{{ field.name }} (T2.{{ field.name }}'First .. T2.{{ field.name }}'First + Integer (T2.{{ field.variable_length }}) + Integer ({{ field.variable_length_offset }}) - 1),
-         "Comparing {{ field.name }} failed."
+         Err_Msg ("{{ field.name }}")
       );
+{% elif field.is_packed_type %}
+      {{ field.name }}_Assertion.{{ field.type_package }}_Le_Assert.Eq (T1.{{ field.name }}, T2.{{ field.name }},{% if field.has_float %} Epsilon,{% endif %} Err_Msg ("{{ field.name }}"));
 {% else %}
-      pragma Assert (T1.{{ field.name }} = T2.{{ field.name }}, "Comparing {{ field.name }} failed.");
+      {{ field.name }}_Assert.Eq (T1.{{ field.name }}, T2.{{ field.name }},{% if field.has_float %} {{ field.type }} (Epsilon),{% endif %} Err_Msg ("{{ field.name }}"));
 {% endif %}
 {% endfor %}
    end Assert_Eq;
 
 {% endif %}
-   procedure Assert_Neq (T1 : in U; T2 : in U) is
-{% for include in type_uses %}
-      use {{ include }};
-{% endfor %}
-   begin
-      -- Assert on all fields individually:
-{% for field in fields.values() %}
-{% if field.is_packed_type and field.type_model.variable_length %}
-      {{ field.name }}_Assertion.{{ field.type_package }}_U_Assert.Neq (T1.{{ field.name }}, T2.{{ field.name }}, "Comparing {{ field.name }} failed.");
-{% elif field.variable_length %}
-      pragma Assert (
-         T1.{{ field.name }} (T1.{{ field.name }}'First .. T1.{{ field.name }}'First + Integer (T1.{{ field.variable_length }}) + Integer ({{ field.variable_length_offset }}) - 1) /=
-         T2.{{ field.name }} (T2.{{ field.name }}'First .. T2.{{ field.name }}'First + Integer (T2.{{ field.variable_length }}) + Integer ({{ field.variable_length_offset }}) - 1),
-         "Comparing {{ field.name }} failed."
-      );
-{% else %}
-      pragma Assert (T1.{{ field.name }} /= T2.{{ field.name }}, "Comparing {{ field.name }} failed.");
+{% if has_float %}
+   pragma Warnings (On, "redundant conversion, ""Epsilon"" is of type ""Long_Float""");
 {% endif %}
-{% endfor %}
-   end Assert_Neq;
 
-{% if endianness in ["either", "big"] %}
-   procedure Assert_Neq (T1 : in T; T2 : in T) is
-{% for include in type_uses %}
-      use {{ include }};
-{% endfor %}
-   begin
-      -- Assert on all fields individually:
-{% for field in fields.values() %}
-{% if field.is_packed_type and field.type_model.variable_length %}
-      {{ field.name }}_Assertion.{{ field.type_package }}_Assert.Neq (T1.{{ field.name }}, T2.{{ field.name }}, "Comparing {{ field.name }} failed.");
-{% elif field.variable_length %}
-      pragma Assert (
-         T1.{{ field.name }} (T1.{{ field.name }}'First .. T1.{{ field.name }}'First + Integer (T1.{{ field.variable_length }}) + Integer ({{ field.variable_length_offset }}) - 1) /=
-         T2.{{ field.name }} (T2.{{ field.name }}'First .. T2.{{ field.name }}'First + Integer (T2.{{ field.variable_length }}) + Integer ({{ field.variable_length_offset }}) - 1),
-         "Comparing {{ field.name }} failed."
-      );
-{% else %}
-      pragma Assert (T1.{{ field.name }} /= T2.{{ field.name }}, "Comparing {{ field.name }} failed.");
-{% endif %}
-{% endfor %}
-   end Assert_Neq;
-
-{% endif %}
-{% if endianness in ["either", "little"] %}
-   procedure Assert_Neq (T1 : in T_Le; T2 : in T_Le) is
-{% for include in type_uses %}
-      use {{ include }};
-{% endfor %}
-   begin
-      -- Assert on all fields individually:
-{% for field in fields.values() %}
-{% if field.is_packed_type and field.type_model.variable_length %}
-      {{ field.name }}_Assertion.{{ field.type_package }}_Le_Assert.Neq (T1.{{ field.name }}, T2.{{ field.name }}, "Comparing {{ field.name }} failed.");
-{% elif field.variable_length %}
-      pragma Assert (
-         T1.{{ field.name }} (T1.{{ field.name }}'First .. T1.{{ field.name }}'First + Integer (T1.{{ field.variable_length }}) + Integer ({{ field.variable_length_offset }}) - 1) /=
-         T2.{{ field.name }} (T2.{{ field.name }}'First .. T2.{{ field.name }}'First + Integer (T2.{{ field.variable_length }}) + Integer ({{ field.variable_length_offset }}) - 1),
-         "Comparing {{ field.name }} failed."
-      );
-{% else %}
-      pragma Assert (T1.{{ field.name }} /= T2.{{ field.name }}, "Comparing {{ field.name }} failed.");
-{% endif %}
-{% endfor %}
-   end Assert_Neq;
-
-{% endif %}
 {% if endianness in ["either", "big"] %}
    package body {{ name }}_Assert is
-      procedure Eq (T1 : in T; T2 : in T; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line) is
+      procedure Eq (T1 : in T; T2 : in T;{% if has_float %} Epsilon : in Long_Float := 0.0;{% endif %} Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line) is
       begin
-         Assert_Eq (T1, T2);
+         Assert_Eq (T1, T2{% if has_float %}, Epsilon{% endif %});
       exception
          -- If an assertion was thrown above, then the comparison failed.
          -- Go ahead and call the assert all function to produce the error message.
@@ -157,23 +113,25 @@ package body {{ name }}.Assertion is
             {{ name }}_Assert_All.Eq (T1, T2, Message, Filename, Line);
       end Eq;
 
-      procedure Neq (T1 : in T; T2 : in T; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line) is
+      procedure Neq (T1 : in T; T2 : in T;{% if has_float %} Epsilon : in Long_Float := 0.0;{% endif %} Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line) is
       begin
-         Assert_Neq (T1, T2);
+         -- Call Eq. If this fails we know that they are not equal.
+         Assert_Eq (T1, T2{% if has_float %}, Epsilon{% endif %});
+         -- If we got here without an assertion, then T1 and T2 are equal which is
+         -- a failure. Call the assert all function to produce the error message.
+         {{ name }}_Assert_All.Neq (T1, T2, Message, Filename, Line);
       exception
-         -- If an assertion was thrown above, then the comparison failed.
-         -- Go ahead and call the assert all function to produce the error message.
-         when others =>
-            {{ name }}_Assert_All.Neq (T1, T2, Message, Filename, Line);
+         -- If an assertion was not thrown above, then the comparison succeeded.
+         when others => null;
       end Neq;
    end {{ name }}_Assert;
 
 {% endif %}
 {% if endianness in ["either", "little"] %}
    package body {{ name }}_Le_Assert is
-      procedure Eq (T1 : in T_Le; T2 : in T_Le; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line) is
+      procedure Eq (T1 : in T_Le; T2 : in T_Le;{% if has_float %} Epsilon : in Long_Float := 0.0;{% endif %} Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line) is
       begin
-         Assert_Eq (T1, T2);
+         Assert_Eq (T1, T2{% if has_float %}, Epsilon{% endif %});
       exception
          -- If an assertion was thrown above, then the comparison failed.
          -- Go ahead and call the assert all function to produce the error message.
@@ -181,22 +139,24 @@ package body {{ name }}.Assertion is
             {{ name }}_Le_Assert_All.Eq (T1, T2, Message, Filename, Line);
       end Eq;
 
-      procedure Neq (T1 : in T_Le; T2 : in T_Le; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line) is
+      procedure Neq (T1 : in T_Le; T2 : in T_Le;{% if has_float %} Epsilon : in Long_Float := 0.0;{% endif %} Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line) is
       begin
-         Assert_Neq (T1, T2);
+         -- Call Eq. If this fails we know that they are not equal.
+         Assert_Eq (T1, T2{% if has_float %}, Epsilon{% endif %});
+         -- If we got here without an assertion, then T1 and T2 are equal which is
+         -- a failure. Call the assert all function to produce the error message.
+         {{ name }}_Le_Assert_All.Neq (T1, T2, Message, Filename, Line);
       exception
-         -- If an assertion was thrown above, then the comparison failed.
-         -- Go ahead and call the assert all function to produce the error message.
-         when others =>
-            {{ name }}_Le_Assert_All.Neq (T1, T2, Message, Filename, Line);
+         -- If an assertion was not thrown above, then the comparison succeeded.
+         when others => null;
       end Neq;
    end {{ name }}_Le_Assert;
 
 {% endif %}
    package body {{ name }}_U_Assert is
-      procedure Eq (T1 : in U; T2 : in U; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line) is
+      procedure Eq (T1 : in U; T2 : in U;{% if has_float %} Epsilon : in Long_Float := 0.0;{% endif %} Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line) is
       begin
-         Assert_Eq (T1, T2);
+         Assert_Eq (T1, T2{% if has_float %}, Epsilon{% endif %});
       exception
          -- If an assertion was thrown above, then the comparison failed.
          -- Go ahead and call the assert all function to produce the error message.
@@ -204,14 +164,16 @@ package body {{ name }}.Assertion is
             {{ name }}_U_Assert_All.Eq (T1, T2, Message, Filename, Line);
       end Eq;
 
-      procedure Neq (T1 : in U; T2 : in U; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line) is
+      procedure Neq (T1 : in U; T2 : in U;{% if has_float %} Epsilon : in Long_Float := 0.0;{% endif %} Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line) is
       begin
-         Assert_Neq (T1, T2);
+         -- Call Eq. If this fails we know that they are not equal.
+         Assert_Eq (T1, T2{% if has_float %}, Epsilon{% endif %});
+         -- If we got here without an assertion, then T1 and T2 are equal which is
+         -- a failure. Call the assert all function to produce the error message.
+         {{ name }}_U_Assert_All.Neq (T1, T2, Message, Filename, Line);
       exception
-         -- If an assertion was thrown above, then the comparison failed.
-         -- Go ahead and call the assert all function to produce the error message.
-         when others =>
-            {{ name }}_U_Assert_All.Neq (T1, T2, Message, Filename, Line);
+         -- If an assertion was not thrown above, then the comparison succeeded.
+         when others => null;
       end Neq;
    end {{ name }}_U_Assert;
 

--- a/gen/templates/record/name-assertion.ads
+++ b/gen/templates/record/name-assertion.ads
@@ -8,7 +8,7 @@
 -- Standard includes:
 with Smart_Assert;
 with {{ name }}.Representation;
-{% if variable_length %}
+{% if variable_length or has_float %}
 with GNAT.Source_Info;
 {% endif %}
 {% if modeled_type_includes %}
@@ -22,7 +22,7 @@ with {{ include }}.Assertion;
 
 package {{ name }}.Assertion is
 
-{% if variable_length %}
+{% if variable_length or has_float %}
    package Sinfo renames GNAT.Source_Info;
 
    -- Special assertion package for the variable length type. This package
@@ -31,26 +31,31 @@ package {{ name }}.Assertion is
    -- with valid data, as prescribed by that types variable length field, would
    -- only be compared up to that length. Unused data in the buffer is ignored.
    package {{ name }}_U_Assert is
-      procedure Eq (T1 : in U; T2 : in U; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line);
-      procedure Neq (T1 : in U; T2 : in U; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line);
+      procedure Eq (T1 : in U; T2 : in U;{% if has_float %} Epsilon : in Long_Float := 0.0;{% endif %} Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line);
+      procedure Neq (T1 : in U; T2 : in U;{% if has_float %} Epsilon : in Long_Float := 0.0;{% endif %} Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line);
    end {{ name }}_U_Assert;
 
 {% if endianness in ["either", "big"] %}
    package {{ name }}_Assert is
-      procedure Eq (T1 : in T; T2 : in T; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line);
-      procedure Neq (T1 : in T; T2 : in T; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line);
+      procedure Eq (T1 : in T; T2 : in T;{% if has_float %} Epsilon : in Long_Float := 0.0;{% endif %} Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line);
+      procedure Neq (T1 : in T; T2 : in T;{% if has_float %} Epsilon : in Long_Float := 0.0;{% endif %} Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line);
    end {{ name }}_Assert;
 
 {% endif %}
 {% if endianness in ["either", "little"] %}
    package {{ name }}_Le_Assert is
-      procedure Eq (T1 : in T_Le; T2 : in T_Le; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line);
-      procedure Neq (T1 : in T_Le; T2 : in T_Le; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line);
+      procedure Eq (T1 : in T_Le; T2 : in T_Le;{% if has_float %} Epsilon : in Long_Float := 0.0;{% endif %} Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line);
+      procedure Neq (T1 : in T_Le; T2 : in T_Le;{% if has_float %} Epsilon : in Long_Float := 0.0;{% endif %} Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line);
    end {{ name }}_Le_Assert;
 
 {% endif %}
+{% if variable_length %}
    -- This package compares all data in the variable length type, even data
    -- that is "out of bounds", ie. past the variable type's length
+{% else %}
+   -- This package compares data without any Epsilon, using the
+   -- Smart_Assert.Basic package.
+{% endif %}
    package {{ name }}_U_Assert_All is new Smart_Assert.Basic ({{ name }}.U, {{ name }}.Representation.Image);
 {% if endianness in ["either", "big"] %}
    package {{ name }}_Assert_All is new Smart_Assert.Basic ({{ name }}.T, {{ name }}.Representation.Image);
@@ -82,6 +87,8 @@ package {{ name }}.Assertion is
 {% elif field.is_enum %}
    package {{ field.name }}_Assertion renames {{ field.type_package }}.Assertion;
    package {{ field.name }}_Assert renames {{ field.name }}_Assertion.{{ field.type_model.name }}_Assert;
+{% elif field.has_float %}
+   package {{ field.name }}_Assert is new Smart_Assert.Float ({{ field.type }}, {{ name }}.Representation.{{ field.name }}_Image);
 {% else %}
    package {{ field.name }}_Assert is new Smart_Assert.Basic ({{ field.type }}, {{ name }}.Representation.{{ field.name }}_Image);
 {% endif %}

--- a/gen/test/arrays/complex_float_array.array.yaml
+++ b/gen/test/arrays/complex_float_array.array.yaml
@@ -1,0 +1,4 @@
+---
+type: Gg.T
+description: An array of Gg.Ts
+length: 25

--- a/gen/test/arrays/float_array.array.yaml
+++ b/gen/test/arrays/float_array.array.yaml
@@ -1,0 +1,5 @@
+---
+type: Short_Float
+format: F32
+description: An simple array of Short_Floats
+length: 12

--- a/gen/test/arrays/test/test.adb
+++ b/gen/test/arrays/test/test.adb
@@ -12,7 +12,9 @@ with Eight_Bit_Type_Array.Validation;
 with Unaligned_Array.Validation;
 with Enum_Array.Validation;
 with Simple_Array.Assertion; use Simple_Array.Assertion;
+with Float_Array.Assertion; use Float_Array.Assertion;
 with Complex_Array.Assertion; use Complex_Array.Assertion;
+with Complex_Float_Array.Assertion; use Complex_Float_Array.Assertion;
 with Eight_Bit_Type_Array.Assertion; use Eight_Bit_Type_Array.Assertion;
 with Unaligned_Array.Assertion; use Unaligned_Array.Assertion;
 with Enum_Array.Assertion; use Enum_Array.Assertion;
@@ -55,6 +57,11 @@ procedure Test is
    Eight2 : Eight_Bit_Type_Array.T := [others => [others => 2]];
    Unaligned2 : Unaligned_Array.T := [others => 0];
    Enum2 : Enum_Array.T := [others => First_Enum.Blue];
+   Flt : constant Float_Array.T := [others => 1.1];
+   Complex_Flt : constant Complex_Float_Array.T := [others => (Yo => 17, F => (One => 5, Two => 21.5, Three => 50.2345))];
+   Flt_U : constant Float_Array.U := [others => 1.1];
+   Flt_Le : constant Float_Array.T_Le := [others => 1.1];
+   Complex_Flt_U : constant Complex_Float_Array.U := [others => (Yo => 17, F => (One => 5, Two => 21.5, Three => 50.2345))];
 
    -- Other local vars:
    Ignore : Unsigned_32;
@@ -253,4 +260,13 @@ begin
    Put_Line ("passed.");
    Put_Line ("");
 
+   Put_Line ("Floating point assertion test: ");
+   Float_Array_Assert.Eq (Flt, [others => 5.0], Epsilon => 50.0);
+   Float_Array_U_Assert.Eq (Flt_U, [others => 4.0], Epsilon => 50.0);
+   Float_Array_Le_Assert.Eq (Flt_Le, [others => 3.0], Epsilon => 50.0);
+   Float_Array_Le_Assert.Eq (Flt_Le, [0 => 1.1, 1 => 1.1, 2 => 5.1, 3 => 0.4, others => 3.0], Epsilon => 50.0);
+   Complex_Float_Array_Assert.Eq (Complex_Flt, [others => (Yo => 17, F => (One => 5, Two => 21.5, Three => 50.23458))], Epsilon => 0.1);
+   Complex_Float_Array_U_Assert.Eq (Complex_Flt_U, [others => (Yo => 17, F => (One => 5, Two => 21.5, Three => 50.23459))], Epsilon => 0.2);
+   Put_Line ("passed.");
+   Put_Line ("");
 end Test;

--- a/gen/test/records/ff.record.yaml
+++ b/gen/test/records/ff.record.yaml
@@ -1,0 +1,15 @@
+---
+description: This is a packed record named F that has floats
+fields:
+  - name: One
+    description: Element 1
+    type: Interfaces.Unsigned_8
+    format: U8
+  - name: Two
+    description: Element 2
+    type: Short_Float
+    format: F32
+  - name: Three
+    description: Element 3
+    type: Long_Float
+    format: F64

--- a/gen/test/records/gg.record.yaml
+++ b/gen/test/records/gg.record.yaml
@@ -1,0 +1,8 @@
+---
+description: This is a packed record includes a field F that has floats
+fields:
+  - name: Yo
+    type: Interfaces.Unsigned_32
+    format: U32
+  - name: F
+    type: FF.T

--- a/gen/test/records/test/test.adb
+++ b/gen/test/records/test/test.adb
@@ -12,6 +12,8 @@ with Cc.Assertion; use Cc.Assertion;
 with Cc.C; use Cc.C;
 with Ee.Representation;
 with Ee.Assertion; use Ee.Assertion;
+with Ff.Assertion; use Ff.Assertion;
+with Gg.Assertion; use Gg.Assertion;
 with Simple_Variable.Representation;
 with Simple_Variable.Validation;
 with Simple_Variable.Assertion; use Simple_Variable.Assertion;
@@ -79,6 +81,11 @@ procedure Test is
    A2 : Aa.T;
    B2 : Bb.T;
    C2 : Cc.T;
+   F_U : constant Ff.U := (One => 5, Two => 21.5, Three => 50.2345);
+   F : constant Ff.T := (One => 5, Two => 21.5, Three => 50.2345);
+   F_Le : constant Ff.T_Le := (One => 5, Two => 21.5, Three => 50.2345);
+   G_U : constant Gg.U := (Yo => 17, F => (One => 5, Two => 21.5, Three => 50.2345));
+   G : constant Gg.T := (Yo => 17, F => (One => 5, Two => 21.5, Three => 50.2345));
 
    -- Record array definitions:
    A_Bytes : Aa.Serialization.Byte_Array := [0 => 255, others => 0];
@@ -641,4 +648,17 @@ begin
    Put_Line ("passed.");
    Put_Line ("");
 
+   Put_Line ("Floating point assertion test: ");
+   Ff_U_Assert.Eq (F_U, (5, 15.2, 45.3), Epsilon => 50.0);
+   Ff_Assert.Eq (F, (5, 15.2, 45.3), Epsilon => 50.0);
+   Ff_Le_Assert.Eq (F_Le, (5, 15.2, 45.3), Epsilon => 50.0);
+   Ff_U_Assert.Eq (F_U, (5, 21.5, 50.2), Epsilon => 0.1);
+   Ff_Assert.Eq (F, (5, 21.5, 50.2), Epsilon => 0.1);
+   Ff_Le_Assert.Eq (F_Le, (5, 21.5, 50.2), Epsilon => 0.1);
+   Gg_U_Assert.Eq (G_U, (17, (5, 15.2, 45.3)), Epsilon => 50.0);
+   Gg_Assert.Eq (G, (17, (5, 15.2, 45.3)), Epsilon => 50.0);
+   Gg_U_Assert.Eq (G_U, (17, (5, 21.5, 50.2)), Epsilon => 0.1);
+   Gg_Assert.Eq (G, (17, (5, 21.5, 50.2)), Epsilon => 0.1);
+   Put_Line ("passed.");
+   Put_Line ("");
 end Test;

--- a/src/unit_test/smart_assert/smart_assert.adb
+++ b/src/unit_test/smart_assert/smart_assert.adb
@@ -43,13 +43,13 @@ package body Smart_Assert is
    -- Low level assertion function, used for implementing comparisons of complex types
    -- Assert function for code savings:
    procedure Call_Assert (Condition : in Boolean; T1 : in T; T2 : in T; Comparison : in String := "compared to"; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line) is
-      Assertmessage : constant String := "Assertion: " & ASCII.LF & Image (T1) & ASCII.LF & Comparison & ASCII.LF & Image (T2) & ASCII.LF & "failed.";
+      Assert_Message : constant String := "Assertion: " & ASCII.LF & Image (T1) & ASCII.LF & Comparison & ASCII.LF & Image (T2) & ASCII.LF & "failed.";
    begin
       -- Call AUnit assert:
       if Message = "" then
-         Assert (Condition, Assertmessage, Filename, Line);
+         Assert (Condition, Assert_Message, Filename, Line);
       else
-         Assert (Condition, Assertmessage & ASCII.LF & "Message: " & Message, Filename, Line);
+         Assert (Condition, Assert_Message & ASCII.LF & "Message: " & Message, Filename, Line);
       end if;
 
       -- If the type is out of range, it will fail to print by the assertion
@@ -58,12 +58,12 @@ package body Smart_Assert is
    exception
       when Constraint_Error =>
          declare
-            Safeassertmessage : constant String := "Assertion: " & ASCII.LF & "Item 1" & ASCII.LF & Comparison & ASCII.LF & "Item 2" & ASCII.LF & "failed due to either Item 1 or Item 2 issuing a Constraint_Error.";
+            Safe_Assert_Message : constant String := "Assertion: " & ASCII.LF & "Item 1" & ASCII.LF & Comparison & ASCII.LF & "Item 2" & ASCII.LF & "failed due to either Item 1 or Item 2 issuing a Constraint_Error.";
          begin
             if Message = "" then
-               Assert (False, Safeassertmessage, Filename, Line);
+               Assert (False, Safe_Assert_Message, Filename, Line);
             else
-               Assert (False, Safeassertmessage & ASCII.LF & "Message: " & Message, Filename, Line);
+               Assert (False, Safe_Assert_Message & ASCII.LF & "Message: " & Message, Filename, Line);
             end if;
          end;
          -- Make sure constraint error gets thrown if assertions are disabled and the program
@@ -132,17 +132,17 @@ package body Smart_Assert is
       procedure Float_Assert is new Call_Assert (T, Image_Float);
 
       procedure Eq (T1 : in T; T2 : in T; Epsilon : in T := T'Small; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line) is
-         Condition : constant Boolean := ((T1 + Epsilon) > T2) and then ((T1 - Epsilon) < T2);
+         Condition : constant Boolean := ((T1 + Epsilon) >= T2) and then ((T1 - Epsilon) <= T2);
       begin
          -- Need to check both sides of floating point value against an epsilon.
-         Float_Assert (Condition, T1, T2, "= (epsilon => " & Image_Float (Epsilon) & ")", Message, Filename, Line);
+         Float_Assert (Condition, T1, T2, "= (with Epsilon => " & Image_Float (Epsilon) & ")", Message, Filename, Line);
       end Eq;
 
       procedure Neq (T1 : in T; T2 : in T; Epsilon : in T := T'Small; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line) is
          Condition : constant Boolean := ((T1 + Epsilon) < T2) or else ((T1 - Epsilon) > T2);
       begin
          -- Need to check both sides of floating point value against an epsilon.
-         Float_Assert (Condition, T1, T2, "/= (epsilon => " & Image_Float (Epsilon) & ")", Message, Filename, Line);
+         Float_Assert (Condition, T1, T2, "/= (with Epsilon => " & Image_Float (Epsilon) & ")", Message, Filename, Line);
       end Neq;
 
       procedure Gt (T1 : in T; T2 : in T; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line) is


### PR DESCRIPTION
Add epsilon based assertions for packed types that include one or many floating point values. ie. an Eq comparison for a floating point value will return true if the two floating point values are less than or equal to +/- 1 epsilon apart.

When using the assertion package for a packed record or array that includes one or more floating point types, you can provide a single "Epsilon" argument as part of the assertion, which is used to compare all floating point types inside of the packed record or array. Non floating point types are still compared for exact equality (or inequality) as before. By default, if not specified, the value of Epsilon will be 0.0, resulting in the same behavior as before this feature existed.

New assertion calls with Epsilon look like:

```
Gg_U_Assert.Eq (G_U, (17, (5, 21.5, 50.2)), Epsilon => 0.1);
```