### PR TITLE
Add Clear subprogram to FIFO data structure

### DIFF
--- a/src/data_structures/fifo/fifo.adb
+++ b/src/data_structures/fifo/fifo.adb
@@ -13,6 +13,12 @@ package body Fifo is
       Free_If_Testing (Self.Items);
    end Destroy;
 
+   procedure Clear (Self : in out Instance) is
+   begin
+      Self.Head := Natural'First;
+      Self.Count := Natural'First;
+   end Clear;
+
    function Is_Full (Self : in Instance) return Boolean is
    begin
       return Self.Count = Self.Items'Length;

--- a/src/data_structures/fifo/fifo.ads
+++ b/src/data_structures/fifo/fifo.ads
@@ -17,6 +17,7 @@ package Fifo is
    -- Initialization/destruction functions:
    --
    procedure Init (Self : in out Instance; Depth : in Positive);
+   procedure Clear (Self : in out Instance);
    procedure Destroy (Self : in out Instance);
 
    --

--- a/src/data_structures/fifo/test/test.adb
+++ b/src/data_structures/fifo/test/test.adb
@@ -42,6 +42,46 @@ begin
       Put_Line ("passed.");
    end loop;
 
+   Put ("Filling queue test... ");
+   for Index in Natural'First .. Queue_Length - 1 loop
+      pragma Assert (My_Queue.Push (Index) = Success);
+      pragma Assert (My_Queue.Get_Count = Index + 1);
+   end loop;
+   pragma Assert (My_Queue.Push (16) = Full);
+   pragma Assert (My_Queue.Is_Full);
+   Put_Line ("passed.");
+
+   Put ("Clear queue test... ");
+   My_Queue.Clear;
+   pragma Assert (My_Queue.Is_Empty);
+   pragma Assert (My_Queue.Get_Count = 0);
+   Put_Line ("passed.");
+
+   for I in 0 .. 1 loop
+      Put ("Filling queue test... ");
+      for Index in Natural'First .. Queue_Length - 1 loop
+         pragma Assert (My_Queue.Push (Index) = Success);
+         pragma Assert (My_Queue.Get_Count = Index + 1);
+      end loop;
+      pragma Assert (My_Queue.Push (16) = Full);
+      pragma Assert (My_Queue.Is_Full);
+      Put_Line ("passed.");
+
+      Put ("Emptying queue test... ");
+      for Index in Natural'First .. Queue_Length - 1 loop
+         pragma Assert (My_Queue.Peek (Value) = Success);
+         pragma Assert (Value = Index, Integer'Image (Value) & " = " & Integer'Image (Index));
+         pragma Assert (My_Queue.Get_Count = Queue_Length - Index);
+         pragma Assert (My_Queue.Pop (Value) = Success);
+         pragma Assert (Value = Index, Integer'Image (Value) & " = " & Integer'Image (Index));
+         pragma Assert (My_Queue.Get_Count = Queue_Length - Index - 1);
+      end loop;
+      pragma Assert (My_Queue.Peek (Ignore) = Empty);
+      pragma Assert (My_Queue.Pop (Ignore) = Empty);
+      pragma Assert (My_Queue.Is_Empty);
+      Put_Line ("passed.");
+   end loop;
+
    Put ("Destroy queue test... ");
    My_Queue.Destroy;
    Put_Line ("passed.");


### PR DESCRIPTION
This allows `Clear` on the generic FIFO, which removes any elements stored on the FIFO, if there are any.