### PR TITLE
Add path output to `pydep.py`

### DIFF
--- a/redo/util/pydep.py
+++ b/redo/util/pydep.py
@@ -37,7 +37,7 @@ def pydep(source_file, path=[], ignore_list=[]):
                 try:
                     spec = importlib.util.find_spec(name)
                 except ModuleNotFoundError:
-                    nonexistant_deps.append(name)
+                    nonexistent_deps.append(name)
                     continue
                 # if module (and its origin file) exists, append to the existing_deps
                 if spec is not None:
@@ -56,7 +56,7 @@ def pydep(source_file, path=[], ignore_list=[]):
                 try:
                     spec = importlib.util.find_spec(name)
                 except ModuleNotFoundError:
-                    nonexistant_deps.append(name)
+                    nonexistent_deps.append(name)
                     continue
                 if spec is not None:
                     if spec.origin is None or "built-in" in spec.origin or "site-packages" in spec.origin:
@@ -79,14 +79,14 @@ def _build_pydeps(source_file, path=[]):
 
     def _inner_build_pydeps(source_file):
         # Find the python dependencies:
-        existing_deps, nonexistant_deps = pydep(source_file, path)
+        existing_deps, nonexistent_deps = pydep(source_file, path)
 
         # For the nonexistent dependencies, see if we have a rule
         # to build those:
-        if nonexistant_deps:
+        if nonexistent_deps:
             deps_to_build = []
             with py_source_database() as db:
-                deps_to_build = db.try_get_sources(nonexistant_deps)
+                deps_to_build = db.try_get_sources(nonexistent_deps)
 
             deps_not_in_path.extend(deps_to_build)
 
@@ -103,7 +103,7 @@ def _build_pydeps(source_file, path=[]):
                     _inner_build_pydeps(dep)
 
     _inner_build_pydeps(source_file)
-    return list(set(deps_not_in_path))
+    return list(set(deps_not_in_path)) # may want to return more than one list
 
 
 class _build_python_no_update(build_rule_base):
@@ -225,7 +225,7 @@ if __name__ == "__main__":
     all_existing_deps = set()
 
     for source_file in file_args:
-        existing_deps, nonexistant_deps = pydep(source_file, ignore_list=ignore_list)
+        existing_deps, nonexistent_deps = pydep(source_file, ignore_list=ignore_list)
         all_existing_deps.update(existing_deps)
 
         if verbose:
@@ -235,7 +235,7 @@ if __name__ == "__main__":
                 print(dep)
 
             print("\nNonexistent dependencies:")
-            for dep in nonexistant_deps:
+            for dep in nonexistent_deps:
                 print(dep)
 
             print("\nBuilding nonexistent dependencies:")

--- a/redo/util/pydep.py
+++ b/redo/util/pydep.py
@@ -199,11 +199,7 @@ def run_py(source_file):
 
 # This can also be run from the command line:
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        usage="pydep.py [--verbose or -v] [--paths or -p] "
-              "[/path/to/python_file1.py /path/to/python_file2.py ...] "
-              "[--ignore or -i string1 string2 ...]"
-    )
+    parser = argparse.ArgumentParser()
 
     parser.add_argument(
         "-v", "--verbose",
@@ -214,6 +210,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "-p", "--paths",
         action="store_true",
+        required=True,
         help="Print resolved dependency paths"
     )
 
@@ -231,10 +228,6 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
-
-    if not args.file_args:
-        parser.print_usage()
-        sys.exit(1)
 
     all_static_deps = set()
 
@@ -254,8 +247,8 @@ if __name__ == "__main__":
             print("\nBuilding nonexistent dependencies:")
 
         built_deps, static_existing_deps = build_py_deps(source_file)
-        print("\n".join(sorted(built_deps)))
-        # Collect static existing dependencies:
+        # Collect all existing dependencies:
+        all_static_deps.update(built_deps)
         all_static_deps.update(static_existing_deps)
 
     # print full paths on mode flag


### PR DESCRIPTION
This PR adds an optional argument flag to `pydep.py` which allows output of full filesystem paths of dependencies which have been built or exist statically in Adamant.

This may be used to programmatically build dependencies as before, but the additional output may be piped to a utility to perform other tasks, such as collect or copy these dependencies as needed.

An example of usage on a Python file which uses static and built imports:
```
python /adamant/redo/util/pydep.py example.py -p
```
The output:
```
All dependency paths:
/home/user/adamant/gnd/base_classes/packed_type_base.py
/home/user/adamant/gnd/util/crc_16.py
/home/user/adamant/src/types/packed_types/build/py/packed_f32.py
/home/user/adamant/src/types/parameter/build/py/parameter_table_header.py
```