### PR TITLE
Initialize the ID base of the Command_Router component Command instance

### DIFF
--- a/src/components/command_router/component-command_router-implementation.adb
+++ b/src/components/command_router/component-command_router-implementation.adb
@@ -37,6 +37,9 @@ package body Component.Command_Router.Implementation is
       Reg_Cmd_Instance : Registration_Commands.Instance;
       Reg_Cmd : Command.T;
    begin
+      -- Initialize the ID Base of our command package with the base package ID to be consistent
+      Self.Commands.Set_Id_Base (Self.Command_Id_Base);
+
       -- Manually set the ID to zero, of the register command. ID 0 is reserved
       -- especially for this internal command:
       Reg_Cmd_Instance.Set_Id_Base (0);


### PR DESCRIPTION
This pull request applies a fix to the Command_Router component.

This component contains a `Commands` instance which must have an ID Base consistent with the component. If unset, and the component is configured to use an ID other than the default, it is possible for unexpected behavior to occur when making `Command_Response_T_Recv_Async` checks, where:
```
Arg.Command_Id /= Self.Commands.Get_Reset_Data_Products_Id
```
may be inconsistent with the assembly configuration. This may present as `Command_Success_Count` incrementing when resetting the Command Router data products, and not incrementing when responding to another command ID.