### PR TITLE
Preclude duplicates of hard-coded `with` clauses in Product Extractor

### DIFF
--- a/src/components/ccsds_product_extractor/gen/templates/extracted_products/name.adb
+++ b/src/components/ccsds_product_extractor/gen/templates/extracted_products/name.adb
@@ -5,7 +5,9 @@ with Ccsds_Primary_Header; use Ccsds_Primary_Header;
 with Interfaces; use Interfaces;
 with Extract_Data_Product; use Extract_Data_Product;
 {% for item in includes %}
+{% if item not in ["Sys_Time", "Ccsds_Space_Packet"] %}
 with {{ item }};
+{% endif %}
 with {{ item }}.Validation;
 {% endfor %}
 


### PR DESCRIPTION
This PR adjusts the Product Extractor autocode template to exclude the packages `Sys_Time` and `Ccsds_Space_Packet`, which already exist in the `name.ads` template. This change prevents duplication when a product extractor configuration includes one or both of these packages as a data product, but retains the corresponding `Validation` packages.