### PR TITLE
Fix preamble warning in reciprocal .ads

### DIFF
--- a/gen/templates/tests/component-name_reciprocal.ads
+++ b/gen/templates/tests/component-name_reciprocal.ads
@@ -10,9 +10,11 @@ with File_Logger;
 {% for include in tester_base_ads_includes %}
 {% if include in includes %}
 pragma Warnings (Off, "unit ""{{ include }}"" is not referenced");
+pragma Warnings (Off, "no entities of ""{{ include }}"" are referenced in spec");
 {% endif %}
 with {{ include }};
 {% if include in includes %}
+pragma Warnings (On, "no entities of ""{{ include }}"" are referenced in spec");
 pragma Warnings (On, "unit ""{{ include }}"" is not referenced");
 {% endif %}
 {% if include in ["Connector_Types"] %}


### PR DESCRIPTION
Sometimes preambles in component models can cause unnecessary warnings in the reciprocal. It turns out that

```
pragma Warnings (Off, "unit ""{{ include }}"" is not referenced");
```

is not enough if the `with`ed package is still used in the body. An extra suppression has been added to fix that case.