### PR TITLE
Avoid slow redo probes for nonexistant completion prefixes

### DIFF
--- a/env/redo_completion.sh
+++ b/env/redo_completion.sh
@@ -160,6 +160,36 @@ $(compgen -d "$full_arg" | sed 's/$/\//')" | grep -v '^$')
         try_trim_leading_dir "$path" "$arg"
     }
 
+    # When we already have a cached target list for a real redo directory,
+    # treat slash-separated target prefixes as a virtual namespace and keep
+    # narrowing the cached targets instead of probing synthetic subpaths like
+    # build/what_predefined (which can be very slow to fail).
+    try_virtual_recurse () {
+        local cached_targets=$1
+        local string=$2
+        local normalized prefix suffix filtered
+
+        VIRTUAL_LEAD_DIR=
+        VIRTUAL_REST=
+        VIRTUAL_FILTERED=
+
+        echo "$string" | grep '/' >/dev/null || return 1
+
+        normalized=$(echo "$string" | sed 's/\/\/*/\//')
+        prefix=$(echo "$normalized" | cut -d '/' -f 1)
+        suffix=$(echo "$normalized" | cut -d '/' -f 2-)
+
+        [ -n "$prefix" ] || return 1
+
+        filtered=$(echo "$cached_targets" | awk -v p="$prefix/" 'index($0, p) == 1 { print substr($0, length(p) + 1) }')
+        [ -n "$filtered" ] || return 1
+
+        VIRTUAL_LEAD_DIR=$prefix
+        VIRTUAL_REST=$suffix
+        VIRTUAL_FILTERED=$filtered
+        return 0
+    }
+
     do_recurse () {
 
         # these are set by try_trim_leading_dir
@@ -189,7 +219,7 @@ $(compgen -d "$full_arg" | sed 's/$/\//')" | grep -v '^$')
 
     # the main helper function
     redo_completion_helper () {
-        local path=$1 arg=$2
+        local path=$1 arg=$2 cached_targets=$3
 
         # return value -- must reset at start of function
         RES=
@@ -206,8 +236,13 @@ $(compgen -d "$full_arg" | sed 's/$/\//')" | grep -v '^$')
         # Python subprocess (slower). A valid text cache proves this is a
         # redo directory, so we can skip what_predef_parsed entirely.
         local compgen_arg
-        if compgen_arg=$(text_cache_read "$path" 2>/dev/null); then
-            dbg '> text cache hit (fast path)'
+        if [ -n "$cached_targets" ] || compgen_arg=$(text_cache_read "$path" 2>/dev/null); then
+            if [ -n "$cached_targets" ]; then
+                compgen_arg=$cached_targets
+                dbg '> virtual target cache hit'
+            else
+                dbg '> text cache hit (fast path)'
+            fi
 
             RES=$(compgen -W "$compgen_arg" "$arg")
 
@@ -218,7 +253,20 @@ $(compgen -d "$full_arg" | sed 's/$/\//')" | grep -v '^$')
                 return 0
             fi
 
-            dbg '> text cache hit but no match for arg'
+            if [ -n "$cached_targets" ]; then
+                dbg '> virtual target cache miss for arg'
+            else
+                dbg '> text cache hit but no match for arg'
+            fi
+
+            # If the user is traversing a slash-separated target prefix inside
+            # the cached target list, recurse within that virtual namespace
+            # instead of probing synthetic redo paths like build/what_predefined.
+            if try_virtual_recurse "$compgen_arg" "$arg"; then
+                dbg "> virtual recurse: dir ($VIRTUAL_LEAD_DIR) arg ($VIRTUAL_REST)"
+                redo_completion_helper "$path/$VIRTUAL_LEAD_DIR" "$VIRTUAL_REST" "$VIRTUAL_FILTERED"
+                return $?
+            fi
 
             # no match, so check for a directory prefix
             if should_recurse; then
@@ -269,6 +317,14 @@ $(compgen -d "$full_arg" | sed 's/$/\//')" | grep -v '^$')
         fi
 
         dbg '> cache miss'
+
+        # Reuse the freshly computed target list as a virtual namespace before
+        # probing synthetic redo subpaths like build/what_predefined.
+        if try_virtual_recurse "$compgen_arg" "$arg"; then
+            dbg "> virtual recurse: dir ($VIRTUAL_LEAD_DIR) arg ($VIRTUAL_REST)"
+            redo_completion_helper "$path/$VIRTUAL_LEAD_DIR" "$VIRTUAL_REST" "$VIRTUAL_FILTERED"
+            return $?
+        fi
 
         # no match, so check for a directory prefix
         if should_recurse; then
@@ -415,7 +471,7 @@ $(compgen -d "$full_arg" | sed 's/$/\//')" | grep -v '^$')
         unset oldifs
     fi
 
-    unset -f redo_cmd_parsed what_parsed what_predef_parsed text_cache_read save_last_confirmed_dir get_last_confirmed_dir prepend try_trim_leading_dir append_compgen_dirs synchronous_work prepend_path redo_completion_helper try_cached_dir
+    unset -f redo_cmd_parsed what_parsed what_predef_parsed text_cache_read save_last_confirmed_dir get_last_confirmed_dir prepend try_trim_leading_dir try_virtual_recurse append_compgen_dirs synchronous_work prepend_path redo_completion_helper try_cached_dir
 
 }
 

--- a/redo/test/persistent_cache/test_persistent_cache.sh
+++ b/redo/test/persistent_cache/test_persistent_cache.sh
@@ -23,14 +23,14 @@ time_ms() {
 
 setup() {
     # Pick a component directory for testing
-    TEST_DIR="${ADAMANT_DIR}/src/components/oscillator"
+    TEST_DIR="${ADAMANT_DIR}/src/components/command_router"
     if [ ! -d "$TEST_DIR" ]; then
         local example_dir
         example_dir=$(dirname "$(dirname "$ADAMANT_CONFIGURATION_YAML")")
-        TEST_DIR="${example_dir}/src/components/oscillator"
+        TEST_DIR="${example_dir}/src/components/command_router"
     fi
     if [ ! -d "$TEST_DIR" ]; then
-        echo "ERROR: Cannot find oscillator component directory"
+        echo "ERROR: Cannot find command_router component directory"
         exit 1
     fi
 
@@ -89,23 +89,22 @@ else fail "second call ${ms}ms >= ${FAST_THRESHOLD}ms (expected fast)"; fi
 echo ""
 echo "Test 2: Touch existing file - still fast"
 cd "$TEST_DIR"
-touch component-oscillator-implementation.adb
+touch component-command_router-implementation.adb
 ms=$(time_ms redo what)
 if [ "$ms" -lt "$FAST_THRESHOLD" ]; then pass "after touch existing: ${ms}ms (fast)"
 else fail "after touch existing: ${ms}ms (expected fast)"; fi
 
-# Test 3: Creating new .do file — still fast (stale data OK)
+# Test 3: Creating new .do file refreshes and exposes new target
 echo ""
-echo "Test 3: Create new .do file - still fast (serves cached data)"
+echo "Test 3: Create new .do file - refreshes cache and exposes target"
 cd "$TEST_DIR"
 touch hi.do
 ms=$(time_ms redo what)
-if [ "$ms" -lt "$FAST_THRESHOLD" ]; then pass "after create .do: ${ms}ms (fast, stale OK)"
-else fail "after create .do: ${ms}ms (expected fast — stale data served)"; fi
-# hi.do should NOT appear yet (not in cache until next build)
+if [ "$ms" -ge "$SLOW_THRESHOLD" ]; then pass "after create .do: ${ms}ms (refresh)"
+else fail "after create .do: ${ms}ms (expected refresh >= ${SLOW_THRESHOLD}ms)"; fi
 targets=$(redo what 2>&1)
-if ! echo "$targets" | grep -q "^redo hi$"; then pass "hi not in output (stale cache, expected)"
-else pass "hi already in output (pre-cached)"; fi
+if echo "$targets" | grep -q "^redo hi$"; then pass "hi appears in output after refresh"
+else fail "hi missing from output after refresh"; fi
 rm -f hi.do
 
 # Test 4: Cold path (no persistent DB)
@@ -649,6 +648,102 @@ if [ "$all_match" = true ] && [ "${#COMPREPLY[@]}" -gt 0 ]; then
     pass "partial completion: ${#COMPREPLY[@]} matches for 'cl' (clean, clean_all, clear_cache)"
 else
     [ "$all_match" = true ] && fail "partial completion returned 0 results"
+fi
+
+# Test 31: Virtual target prefix no-match stays fast
+echo ""
+echo "Test 31: Virtual target prefix no-match stays fast"
+virtual_comp="$ADAMANT_DIR/src/components/command_router"
+if [ -d "$virtual_comp" ]; then
+    cd "$virtual_comp" && redo what >/dev/null 2>&1
+    start_ms=$(date +%s%3N)
+    run_completion "build/src/component-y"
+    end_ms=$(date +%s%3N)
+    elapsed=$((end_ms - start_ms))
+    if [ "$elapsed" -lt 500 ]; then
+        pass "virtual no-match fast: ${elapsed}ms, ${#COMPREPLY[@]} results"
+    else
+        fail "virtual no-match slow: ${elapsed}ms"
+    fi
+    if [ "${#COMPREPLY[@]}" -eq 0 ]; then
+        pass "virtual no-match returned 0 results"
+    else
+        fail "virtual no-match returned ${#COMPREPLY[@]} results"
+    fi
+else
+    echo "  SKIP: command_router not found"
+fi
+
+# Test 32: Deep virtual target prefix no-match stays fast
+echo ""
+echo "Test 32: Deep virtual target prefix no-match stays fast"
+if [ -d "$virtual_comp" ]; then
+    cd "$virtual_comp" && redo what >/dev/null 2>&1
+    start_ms=$(date +%s%3N)
+    run_completion "doc/build/pdf/command_router_nope"
+    end_ms=$(date +%s%3N)
+    elapsed=$((end_ms - start_ms))
+    if [ "$elapsed" -lt 500 ]; then
+        pass "deep virtual no-match fast: ${elapsed}ms, ${#COMPREPLY[@]} results"
+    else
+        fail "deep virtual no-match slow: ${elapsed}ms"
+    fi
+    if [ "${#COMPREPLY[@]}" -eq 0 ]; then
+        pass "deep virtual no-match returned 0 results"
+    else
+        fail "deep virtual no-match returned ${#COMPREPLY[@]} results"
+    fi
+fi
+
+# Test 33: Deep virtual target positive prefix stays fast and preserves prefix
+echo ""
+echo "Test 33: Deep virtual target positive prefix returns matches"
+if [ -d "$virtual_comp" ]; then
+    cd "$virtual_comp" && redo what >/dev/null 2>&1
+    start_ms=$(date +%s%3N)
+    run_completion "doc/build/pdf/command_router_"
+    end_ms=$(date +%s%3N)
+    elapsed=$((end_ms - start_ms))
+    if [ "$elapsed" -lt 500 ]; then
+        pass "deep virtual positive fast: ${elapsed}ms, ${#COMPREPLY[@]} results"
+    else
+        fail "deep virtual positive slow: ${elapsed}ms"
+    fi
+    if [ "${#COMPREPLY[@]}" -gt 0 ]; then
+        pass "deep virtual positive returned ${#COMPREPLY[@]} results"
+    else
+        fail "deep virtual positive returned 0 results"
+    fi
+    all_match=true
+    for r in "${COMPREPLY[@]}"; do
+        trimmed="${r%% }"
+        if [[ "$trimmed" != doc/build/pdf/command_router_* ]]; then
+            fail "deep virtual positive mismatch: $trimmed"
+            all_match=false
+            break
+        fi
+    done
+    if [ "$all_match" = true ]; then
+        pass "deep virtual positive preserves prefix"
+    fi
+fi
+
+# Test 34: Real filesystem directories still appear at project root
+echo ""
+echo "Test 34: Real directories still complete at project root"
+run_completion "$ADAMANT_DIR/do"
+found_doc_dir=false
+for r in "${COMPREPLY[@]}"; do
+    trimmed="${r%% }"
+    if [[ "$trimmed" == "$ADAMANT_DIR/doc/" ]]; then
+        found_doc_dir=true
+        break
+    fi
+done
+if [ "$found_doc_dir" = true ]; then
+    pass "real directory completion still includes doc/"
+else
+    fail "real directory completion missing doc/"
 fi
 
 # -------------------------------------------------------


### PR DESCRIPTION
## What this fixes
This fixes slow/no-match bash completion for slash-separated redo target prefixes such as:

- `redo build/src/component-y<TAB><TAB>`
- `redo doc/build/pdf/command_router_nope<TAB><TAB>`

Before this change, those completions could feel hung because the completion script recursed into virtual target prefixes and then probed synthetic redo paths like `build/what_predefined` and `build/src/what_predefined`, each taking the slow failure path.

## Root cause
`env/redo_completion.sh` was treating path-shaped prefixes from cached `redo what` output as if they were real redo directories.

That is correct for real filesystem directories, but wrong for virtual target paths such as:

- `build/...`
- `doc/build/...`

## Fix
When completion already has cached `redo what` output for a real directory, it now treats slash-separated target prefixes as a virtual target namespace and narrows that cached target list by prefix instead of probing deeper synthetic redo paths.

## Test Coverage
Updated `redo/test/persistent_cache/test_persistent_cache.sh` so the main suite now:
- uses `command_router`, which exists in this tree (does not require adamant_example)
- checks current cache-refresh behavior for new `.do` files
- includes the new virtual-prefix completion regression coverage
