### PR TITLE
Add skip_validation to byte/poly fields to enable Always_Valid

### DIFF
--- a/src/components/ccsds_product_extractor/types/invalid_product_data.record.yaml
+++ b/src/components/ccsds_product_extractor/types/invalid_product_data.record.yaml
@@ -13,3 +13,4 @@ fields:
     description: A polymorphic type containing the bad field data.
     type: Basic_Types.Poly_Type
     format: U8x8
+    skip_validation: True

--- a/src/types/ccsds/ccsds_space_packet.record.yaml
+++ b/src/types/ccsds/ccsds_space_packet.record.yaml
@@ -16,3 +16,4 @@ fields:
     format: U8x{{ ccsds_packet_buffer_size }}
     variable_length: Header.Packet_Length
     variable_length_offset: 1
+    skip_validation: True

--- a/src/types/command/invalid_command_info.record.yaml
+++ b/src/types/command/invalid_command_info.record.yaml
@@ -13,3 +13,4 @@ fields:
     description: A polymorphic type containing the bad field data, or length when Errant_Field_Number is 2**32.
     type: Basic_Types.Poly_Type
     format: U8x8
+    skip_validation: True

--- a/src/types/parameter/invalid_parameter_info.record.yaml
+++ b/src/types/parameter/invalid_parameter_info.record.yaml
@@ -13,3 +13,4 @@ fields:
     description: A polymorphic type containing the bad field data, or length when Errant_Field_Number is 2**32.
     type: Basic_Types.Poly_Type
     format: U8x8
+    skip_validation: True


### PR DESCRIPTION
## Summary

Adds `skip_validation: True` to four records whose only blocker for `Always_Valid = True` was a `Byte_Array` or `Basic_Types.Poly_Type` field that the generator conservatively treats as not-always-valid. This allows these commonly used types to be treated as Always_Valid, providing optimizations in validation code across the framework. This takes advantage of the recently merged https://github.com/lasp/adamant/pull/163.

## Files changed

| File | Field |
|---|---|
| `src/types/ccsds/ccsds_space_packet.record.yaml` | `Data` |
| `src/types/command/invalid_command_info.record.yaml` | `Errant_Field` |
| `src/types/parameter/invalid_parameter_info.record.yaml` | `Errant_Field` |
| `src/components/ccsds_product_extractor/types/invalid_product_data.record.yaml` | `Errant_Field` |