### PR TITLE
Enforce big-endian packed types for ID'd entities

### DIFF
--- a/gen/models/data_products.py
+++ b/gen/models/data_products.py
@@ -6,7 +6,10 @@ import os.path
 
 
 class data_product(ided_entity):
-    def __init__(self, name, type, description=None, id=None, suite=None):
+    def __init__(
+        self, name, type, description=None, id=None,
+        little_endian_allowed=False, suite=None
+    ):
         super(data_product, self).__init__(
             name,
             type,
@@ -14,6 +17,7 @@ class data_product(ided_entity):
             id,
             default_value=None,
             variable_types_allowed=False,
+            little_endian_allowed=little_endian_allowed,
             suite=suite,
         )
 

--- a/gen/models/submodels/ided_suite.py
+++ b/gen/models/submodels/ided_suite.py
@@ -21,6 +21,7 @@ class ided_entity(renderable_object):
         default_value=None,
         variable_types_allowed=False,
         packed_types_required=False,
+        little_endian_allowed=False,
         suite=None,
     ):
         self.name = ada.formatType(name)
@@ -68,6 +69,19 @@ class ided_entity(renderable_object):
                 + "'. Variable length types are not (yet) supported. Consider using a static sized packed type instead."
             )
 
+        # Little-endian packed types are not supported for most ided
+        # entities. The code generation templates assume big-endian for
+        # serialization, validation, and representation of these types.
+        if type and self.is_little_endian and not little_endian_allowed:
+            raise ModelException(
+                "Entity: '"
+                + str(self.name)
+                + "' uses little-endian type '"
+                + str(self.type)
+                + "'. Little-endian types are not supported for this entity. "
+                + "Use the big-endian variant (.T) instead."
+            )
+
         # We don't allow volatile datatypes in ided entities.
         if type and self.datatype.is_volatile_type:
             raise ModelException(
@@ -111,6 +125,12 @@ class ided_entity(renderable_object):
     def has_packed_type(self):
         if self.datatype:
             return self.datatype.is_packed_type
+        return False
+
+    @property
+    def is_little_endian(self):
+        if self.datatype:
+            return self.datatype.is_little_endian
         return False
 
     @property

--- a/gen/models/submodels/ided_suite.py
+++ b/gen/models/submodels/ided_suite.py
@@ -21,6 +21,7 @@ class ided_entity(renderable_object):
         default_value=None,
         variable_types_allowed=False,
         packed_types_required=False,
+        little_endian_allowed=False,
         suite=None,
     ):
         self.name = ada.formatType(name)
@@ -68,6 +69,19 @@ class ided_entity(renderable_object):
                 + "'. Variable length types are not (yet) supported. Consider using a static sized packed type instead."
             )
 
+        # Little-endian packed types are not supported for most ided
+        # entities. The code generation templates assume big-endian for
+        # serialization, validation, and representation of these types.
+        if type and self.is_little_endian and not little_endian_allowed:
+            raise ModelException(
+                "Entity: '"
+                + str(self.name)
+                + "' uses little-endian type '"
+                + str(self.type)
+                + "'. Little-endian types are not supported for this entity. "
+                + "Use the big-endian variant (e.g. .T instead of .T_Le) instead."
+            )
+
         # We don't allow volatile datatypes in ided entities.
         if type and self.datatype.is_volatile_type:
             raise ModelException(
@@ -111,6 +125,12 @@ class ided_entity(renderable_object):
     def has_packed_type(self):
         if self.datatype:
             return self.datatype.is_packed_type
+        return False
+
+    @property
+    def is_little_endian(self):
+        if self.datatype:
+            return self.datatype.is_little_endian
         return False
 
     @property

--- a/gen/models/submodels/variable.py
+++ b/gen/models/submodels/variable.py
@@ -11,6 +11,7 @@ class datatype(object):
         self.package = None
         self.generic = False
         self.is_packed_type = False
+        self.is_little_endian = False
         self.is_volatile_type = False
         self.is_atomic_type = False
         self.is_register_type = False
@@ -33,6 +34,7 @@ class datatype(object):
             if self.name.endswith(".T") or self.name.endswith(".T_Le"):
                 self.model = model_loader.try_load_model_by_name(self.package)
                 self.is_packed_type = True
+                self.is_little_endian = self.name.endswith(".T_Le")
             elif self.name.endswith(".U"):
                 self.model = model_loader.try_load_model_by_name(self.package)
             elif self.name.endswith(".E"):
@@ -55,10 +57,12 @@ class datatype(object):
             ):
                 self.model = model_loader.try_load_model_by_name(self.package)
                 self.is_packed_type = True
+                self.is_little_endian = self.name.endswith(".Volatile_T_Le")
                 self.is_volatile_type = True
             elif self.name.endswith(".Atomic_T") or self.name.endswith(".Atomic_T_Le"):
                 self.model = model_loader.try_load_model_by_name(self.package)
                 self.is_packed_type = True
+                self.is_little_endian = self.name.endswith(".Atomic_T_Le")
                 self.is_volatile_type = True
                 self.is_atomic_type = True
             elif self.name.endswith(".Register_T") or self.name.endswith(
@@ -66,6 +70,7 @@ class datatype(object):
             ):
                 self.model = model_loader.try_load_model_by_name(self.package)
                 self.is_packed_type = True
+                self.is_little_endian = self.name.endswith(".Register_T_Le")
                 self.is_volatile_type = True
                 self.is_register_type = True
 

--- a/src/components/ccsds_product_extractor/gen/models/product_extractor_data_products.py
+++ b/src/components/ccsds_product_extractor/gen/models/product_extractor_data_products.py
@@ -36,7 +36,8 @@ class product_extractor_data_products(data_products):
         # loop through the model to get all the data products we need to add
         for apid, products in extraction_list_model.apids.items():
             for data_product_item in products:
-                # Check for the first time through to replace the dummy data product
+                # The product extractor's own template handles LE
+                # types correctly, so allow little-endian here.
                 self.entities[data_product_item.name] = data_product(
                     name=data_product_item.name,
                     type=data_product_item.product_type
@@ -44,6 +45,7 @@ class product_extractor_data_products(data_products):
                     + data_product_item.product_endian,
                     description=data_product_item.description,
                     id=None,
+                    little_endian_allowed=True,
                     suite=self,
                 )
                 dp = self.entities[data_product_item.name]


### PR DESCRIPTION
Adamant does not currently allow little-endian packed types for ID'd entities, including commands, parameters, etc.  However, there is no enforcement of this except for compilation error of incorrectly generated code. This PR provides a formal enforcement of big-endian-only ID'd entities. This ensures that code can not be generated for little-endian ID'd entities. If support for little-endian is added later, this pattern allows us to do so formally and incrementally.

## Summary

- Add `is_little_endian` property to the `datatype` class in `variable.py`, set in each packed-type branch (`T_Le`, `Volatile_T_Le`, `Atomic_T_Le`, `Register_T_Le`). For non-packed types it remains `False`.
- Expose through `ided_entity` so templates and model code can query endianness cleanly.
- Enforce big-endian for all ided entities by raising `ModelException` when a little-endian type is used. All code generation templates for commands, events, parameters, faults, data products, packets, and data dependencies hardcode big-endian `Serialization`, `Validation`, and `Representation` — using an LE type would produce silently wrong code.

The exception to this is the CCSDS Product Extractor component, which allows little-endian data products. Its templating already handles this case properly and this feature has been carried forward.