### PR TITLE
Fix nondeterministic parameter_table_router_table ID collisions

### DIFF
--- a/gen/models/assembly.py
+++ b/gen/models/assembly.py
@@ -761,7 +761,7 @@ class assembly(subassembly):
                     model_loader.try_load_model_of_subclass(
                         f, parent_class=assembly_submodel
                     )
-                    for f in list(set(self.submodel_files))
+                    for f in dict.fromkeys(self.submodel_files)
                 ],
             )
         )

--- a/src/components/parameters/gen/models/parameter_table.py
+++ b/src/components/parameters/gen/models/parameter_table.py
@@ -523,27 +523,17 @@ class parameter_table(assembly_submodel):
                         f'Each parameter can only be managed by one Parameters component instance.'
                     )
 
-    # set parameter table id here somehow
-    # add ID to autocode output
-
     def _assign_parameter_table_ids(self):
-
-        # If this table ID has not been assigned, then none of them have for
-        # any of the Parameters components in the assembly. So assign them all.
-        if self.table_id is None:
-            # Collect all parameter_table submodels (including self)
-            parameter_tables = [
-                sub
-                for _, sub in self.assembly.submodels.items()
-                if isinstance(sub, parameter_table)
-            ]
-
-            # Sort deterministically by submodel name
-            parameter_tables.sort(key=lambda s: s.name)
-
-            # Assign unique, deterministic table IDs starting at 1
-            for idx, sub in enumerate(parameter_tables, start=1):
-                sub.table_id = idx
+        # Always re-sort and re-assign every call, but do so deterministically,
+        # even with parallel processes running this simultaneously.
+        parameter_tables = [
+            sub
+            for _, sub in self.assembly.submodels.items()
+            if isinstance(sub, parameter_table)
+        ]
+        parameter_tables.sort(key=lambda s: s.name)
+        for idx, sub in enumerate(parameter_tables, start=1):
+            sub.table_id = idx
 
         assert self.table_id is not None and self.table_id >= 1
 


### PR DESCRIPTION
## Summary

- Removes the `if self.table_id is None:` shortcut in `parameter_table._assign_parameter_table_ids`. Every `set_assembly` call now unconditionally re-sorts all parameter_tables by name and re-assigns IDs 1..N. The old guard relied on the invariant "if my id is set, everyone's is set" -- which breaks whenever any `parameter_table` comes from the in-session model cache with a previously-assigned `table_id`.
- Replaces `list(set(self.submodel_files))` in `assembly.load()` with `dict.fromkeys(...)`. Set iteration order is `PYTHONHASHSEED`-dependent, which made `set_assembly` call order nondeterministic across Python processes and exposed the guard bug above as an intermittent failure.

## Failure mode this addresses

Within one `redo` invocation, child Python processes share the session model cache. `assembly.final()` (gen/models/assembly.py) calls `save_to_cache` on every submodel at end-of-load; a concurrent reader can observe partial cache state where some parameter_tables already have final `table_id` values and others still have `None` from their `__init__`-time save. Combined with the nondeterministic submodel iteration order, a fresh parameter_table whose `set_assembly` runs first can assign IDs based only on the parameter_tables visible at that moment, while cached ones later hit `self.table_id is not None` and skip reassignment. Two tables end up with the same numeric ID and the `parameter_table_router_table` generator reports:

```
table_id "X" resolves to numeric ID N which conflicts with another entry in the table.
```

With the guard removed, the final state after the last `set_assembly` call is unconditionally the deterministic sorted-by-name ordering, regardless of cache state or call order.