### PR TITLE
Eliminate set/hash-order nondeterminism in generators and build rules

### DIFF
--- a/gen/models/assembly.py
+++ b/gen/models/assembly.py
@@ -997,7 +997,7 @@ class assembly(subassembly):
                 self.dependencies += [c.full_filename] + c.get_dependencies()
             for m in submodels:
                 self.dependencies.extend([m.full_filename] + m.get_dependencies())
-            self.dependencies = list(set(self.dependencies))
+            self.dependencies = list(dict.fromkeys(self.dependencies))
 
             # FOR DEBUG ONLY
             # Print a histogram of connection types in the assembly:

--- a/gen/models/base.py
+++ b/gen/models/base.py
@@ -33,7 +33,8 @@ import textwrap
 
 # Helper functions:
 def unique(lst):
-    return list(set(lst))
+    # Use dict.fromkeys for insertion-order-preserving dedup.
+    return list(dict.fromkeys(lst))
 
 
 def printMultiLine(stringList, prefix="   ", max_line_length=79):

--- a/gen/models/component.py
+++ b/gen/models/component.py
@@ -322,7 +322,7 @@ class component(base):
                     model_loader.try_load_model_of_subclass(
                         f, parent_class=component_submodel
                     )
-                    for f in list(set(submodel_files))
+                    for f in dict.fromkeys(submodel_files)
                 ],
             )
         )
@@ -392,12 +392,9 @@ class component(base):
         for ided_suite in self.ided_suites.values():
             complex_type_models.extend(ided_suite.type_models)
         # Add connector type models:
-        complex_type_models += list(
-            set(self.connectors.type_models if self.connectors else [])
-            | set(additional_type_models)
-        )
+        complex_type_models += (self.connectors.type_models if self.connectors else []) + additional_type_models
         # Make sure we have a unique list of type models, no dupes:
-        complex_type_models = list(set(complex_type_models))
+        complex_type_models = list(dict.fromkeys(complex_type_models))
 
         # Some models depend on other models, make sure those are loaded into
         # the complex_types dict as well.
@@ -627,7 +624,7 @@ class component(base):
         self.dependencies.extend(ut_model_files)
         for m in submodels:
             self.dependencies.extend([m.full_filename] + m.get_dependencies())
-        self.dependencies = list(set(self.dependencies))
+        self.dependencies = list(dict.fromkeys(self.dependencies))
 
     def _load_unit_tests(self):
         """

--- a/gen/models/record.py
+++ b/gen/models/record.py
@@ -333,7 +333,7 @@ class record(packed_type):
         # Store useful lists:
 
         # Includes:
-        self.includes = list(set(self.includes))
+        self.includes = list(dict.fromkeys(self.includes))
         # Store all types that have a model associated with them:
         complex_typed_fields = list(
             OrderedDict.fromkeys([f for f in self.fields.values() if f.type_model])

--- a/gen/models/submodels/ided_suite.py
+++ b/gen/models/submodels/ided_suite.py
@@ -318,7 +318,7 @@ class ided_suite(renderable_object):
         self.deps_list = [e.full_filename for e in self.type_models]
         for m in self.type_models:
             self.deps_list += [m.full_filename] + m.get_dependencies()
-        self.deps_list = list(set(self.deps_list))
+        self.deps_list = list(dict.fromkeys(self.deps_list))
 
     def __nonzero__(self):
         return bool(self.entities)

--- a/gen/models/type.py
+++ b/gen/models/type.py
@@ -56,7 +56,7 @@ class type(packed_type):
         # Store useful lists:
 
         # Includes:
-        self.includes = list(set(self.includes))
+        self.includes = list(dict.fromkeys(self.includes))
         # Store all types that have a model associated with them:
         self.complex_types = [self.element.type] if self.element.is_packed_type else []
 

--- a/gen/models/view.py
+++ b/gen/models/view.py
@@ -65,7 +65,7 @@ def check_connector_names(filter_obj, assm):
     # Include non-indexed names in the list too. ie. if Tick_Divider_Instance.Tick_T_Send[3]
     # is in the list also include Tick_Divider_Instance.Tick_T_Send
     connector_names_no_indexes = [re.sub(r'\[[^\]]*\]$', '', x) for x in connector_names if x.endswith(']')]
-    connector_names = list(set(connector_names + connector_names_no_indexes))
+    connector_names = list(dict.fromkeys(connector_names + connector_names_no_indexes))
     for t in filter_obj.item_list:
         if t not in connector_names:
             warn(
@@ -615,12 +615,12 @@ def prune(assm_to_filter):
     assm_to_filter.num_data_dependencies = sum(len(dd_list) for dd_list in new_data_dependencies.values())
 
     # Cleanup 3: Remove components for which there is no connectors or data dependencies (if selected):
+    # Build the allowed set, then filter in input order.
     if assm_to_filter.show_switches["show_data_dependencies"]:
-        component_names = list(
-            set(component_names).intersection(set(components_with_connections).union(set(components_with_data_dependencies)))
-        )
+        allowed = set(components_with_connections) | set(components_with_data_dependencies)
     else:
-        component_names = list(set(component_names).intersection(set(components_with_connections)))
+        allowed = set(components_with_connections)
+    component_names = [c for c in component_names if c in allowed]
 
     filtered_components = OrderedDict()
     for name, c in assm_to_filter.components.items():
@@ -724,7 +724,10 @@ def assembly_intersection(filter1, filter2):
         # Intersect data dependencies: keep only dds present in both filters
         # (matched by component instance name + dd name):
         data_deps = {}
-        for id in set(assm_to_filter1.data_dependencies.keys()) & set(assm_to_filter2.data_dependencies.keys()):
+        ids2 = set(assm_to_filter2.data_dependencies.keys())
+        for id in assm_to_filter1.data_dependencies.keys():
+            if id not in ids2:
+                continue
             names2 = {
                 dd.suite.component.instance_name + "." + dd.name
                 for dd in assm_to_filter2.data_dependencies[id]
@@ -780,7 +783,10 @@ def assembly_union(filter1, filter2):
         # Merge data dependency lists from both filters. For shared ids, combine
         # lists and deduplicate by component.instance_name + dd.name:
         data_deps = {}
-        all_ids = set(assm_to_filter1.data_dependencies.keys()) | set(assm_to_filter2.data_dependencies.keys())
+        all_ids = list(dict.fromkeys(
+            list(assm_to_filter1.data_dependencies.keys())
+            + list(assm_to_filter2.data_dependencies.keys())
+        ))
         for id in all_ids:
             list1 = assm_to_filter1.data_dependencies.get(id, [])
             list2 = assm_to_filter2.data_dependencies.get(id, [])
@@ -821,16 +827,16 @@ class Filter(object):
 
         # Format lists correctly:
         if self.type in ["component_type", "connector_type", "component_type_context", "data_dependency_type"]:
-            self.item_list = list(set(map(lambda x: ada.formatType(x), item_list)))
+            self.item_list = list(dict.fromkeys(map(lambda x: ada.formatType(x), item_list)))
         elif self.type in [
             "component_name",
             "connector_name",
             "component_name_context",
             "data_dependency_name",
         ]:
-            self.item_list = list(set(map(lambda x: ada.formatVariable(x), item_list)))
+            self.item_list = list(dict.fromkeys(map(lambda x: ada.formatVariable(x), item_list)))
         elif self.type in ["component_execution", "component_kind", "connector_kind"]:
-            self.item_list = list(set(map(lambda x: x.lower().strip(), item_list)))
+            self.item_list = list(dict.fromkeys(map(lambda x: x.lower().strip(), item_list)))
         else:
             raise ModelException(
                 'cannot process filter "'

--- a/redo/base_classes/build_target_base.py
+++ b/redo/base_classes/build_target_base.py
@@ -285,13 +285,13 @@ class build_target(object):
         )
 
     def ada_linker_depends_on(self):
-        return list(set(self.btb.ada_linker_depends_on()))
+        return list(dict.fromkeys(self.btb.ada_linker_depends_on()))
 
     def c_compiler_depends_on(self):
-        return list(set(self.btb.c_compiler_depends_on()))
+        return list(dict.fromkeys(self.btb.c_compiler_depends_on()))
 
     def cpp_compiler_depends_on(self):
-        return list(set(self.btb.cpp_compiler_depends_on()))
+        return list(dict.fromkeys(self.btb.cpp_compiler_depends_on()))
 
     def ada_compiler_flags(self):
         flags = self.__flag_constructor(self.btb.ada_compiler_flags())

--- a/redo/database/_setup.py
+++ b/redo/database/_setup.py
@@ -206,7 +206,7 @@ def _get_build_roots(cwd):
         adamant_root = _get_git_root(os.path.realpath(__file__))
         # Get root of the current git repo:
         current_root = _get_git_root(cwd)
-        return list(set([adamant_root, current_root]))
+        return list(dict.fromkeys([adamant_root, current_root]))
 
 
 def _sanitize_path(path):
@@ -215,7 +215,7 @@ def _sanitize_path(path):
     strings and removing duplicates.
     """
     path = list(filter(bool, path))
-    path = list(set(path))
+    path = list(dict.fromkeys(path))
     return path
 
 

--- a/redo/database/c_source_database.py
+++ b/redo/database/c_source_database.py
@@ -194,7 +194,7 @@ class c_source_database(database):
         all_objects = [
             redo_arg.src_file_to_obj_file(source, target) for source in flat_source_list
         ]
-        return list(set(all_objects))
+        return list(dict.fromkeys(all_objects))
 
     def get_all_source_dirs(self):
         # Return all directories where source code can be located?
@@ -202,4 +202,4 @@ class c_source_database(database):
         all_source = [a[0] for a in self.values()]
         flat_source_list = [item for sublist in all_source for item in sublist]
         all_dir_list = [os.path.dirname(source) for source in flat_source_list]
-        return list(set(all_dir_list))
+        return list(dict.fromkeys(all_dir_list))

--- a/redo/database/create.py
+++ b/redo/database/create.py
@@ -585,7 +585,7 @@ def create(build_path):
     # Utility database load:
     #######################################
     # Form the source build path and the object build path:
-    source_build_path = list(set(source_build_path))
+    source_build_path = list(dict.fromkeys(source_build_path))
     build_target = target.get_default_target()
     object_build_path = [
         os.path.join(path, "build" + os.sep + "obj" + os.sep + build_target)

--- a/redo/database/model_database.py
+++ b/redo/database/model_database.py
@@ -118,4 +118,4 @@ class model_database(database):
             record = self.fetch(key)
             for record_key, model_list in record.items():
                 models.extend(model_list)
-        return list(set(models))
+        return list(dict.fromkeys(models))

--- a/redo/environments/modify_build_path.py
+++ b/redo/environments/modify_build_path.py
@@ -24,7 +24,7 @@ def update_env_var(variable_name, paths, overwrite=False):
         all_paths = filter(None, current_paths + paths)
 
     # Ensure paths are unique
-    unique_paths = list(set(all_paths))
+    unique_paths = list(dict.fromkeys(all_paths))
 
     # Set the environment variable with paths joined by os.pathsep
     os.environ[variable_name] = os.pathsep.join(unique_paths)

--- a/redo/rules/build_analyze.py
+++ b/redo/rules/build_analyze.py
@@ -40,7 +40,7 @@ def _get_source_files(object_files):
             obj_file
         ), "All build object file must have same build target!"
 
-    to_return = list(set(to_return))
+    to_return = list(dict.fromkeys(to_return))
     return to_return, build_target
 
 
@@ -152,7 +152,7 @@ def _analyze_ada_sources(source_files, base_dir, build_target, binary_mode=False
         deps += build_object._build_all_ada_dependencies(
             source_files, db
         )
-    deps = list(set(deps))
+    deps = list(dict.fromkeys(deps))
 
     # We behave a bit differently when analyzing a directory that can produce a binary (.elf)
     # vs. a directory that can only produce objects. In the latter case, we only analyze

--- a/redo/rules/build_bindings.py
+++ b/redo/rules/build_bindings.py
@@ -22,7 +22,7 @@ def _generate_bindings(redo_1, redo_2, redo_3, source_file, c_source_db):
     build_target = redo_arg.get_target(redo_2)
     build_target_instance, _ = _get_build_target_instance(build_target)
     deps = _build_all_c_dependencies([source_file], c_source_db, build_target_instance=build_target_instance)
-    dep_dirs = list(set([os.path.dirname(dep) for dep in deps]))
+    dep_dirs = list(dict.fromkeys([os.path.dirname(dep) for dep in deps]))
     include_str = ""
     if dep_dirs:
         include_str = " -I" + " -I".join(dep_dirs)

--- a/redo/rules/build_executable.py
+++ b/redo/rules/build_executable.py
@@ -72,7 +72,7 @@ def _build_all_ada_object_dependencies(
 
         # Read the dependency files for each object we just built and construct
         # a list of dependencies:
-        dep_files = list(set([of + ".deps" for of in object_files]))
+        dep_files = list(dict.fromkeys([of + ".deps" for of in object_files]))
         obj_deps = []
         for dep_file in dep_files:
             with open(dep_file, "r") as f:
@@ -81,11 +81,11 @@ def _build_all_ada_object_dependencies(
         # Filter out files that are not Ada/C/C++ source files:
         obj_deps = [d for d in obj_deps if d.endswith('.ads') or d.endswith('.adb') or
                     d.endswith('.c') or d.endswith('.h') or d.endswith('.hpp') or d.endswith('.cpp')]
-        obj_deps = list(set(obj_deps))
+        obj_deps = list(dict.fromkeys(obj_deps))
 
         # Only include dependencies that exist in the database:
         dep_objects = []
-        dep_packages = list(set([ada.file_name_to_package_name(dep) for dep in obj_deps]))
+        dep_packages = list(dict.fromkeys([ada.file_name_to_package_name(dep) for dep in obj_deps]))
         for package in dep_packages:
             objects_in_db = source_db.get_objects([package], the_target=build_target)
             if not objects_in_db:
@@ -257,7 +257,7 @@ class build_executable(build_rule_base):
         gpr_project_file = build_target_instance.gpr_project_file().strip()
         gpr_project_file_dir = os.path.dirname(gpr_project_file)
         gprbuild_flags = build_target_instance.gprbuild_flags()
-        # dep_dirs = list(set([os.path.dirname(f) for f in deps]))
+        # dep_dirs = list(dict.fromkeys([os.path.dirname(f) for f in deps]))
         gprbuild_prefix = (
             "gprbuild"
             + verbosity

--- a/redo/rules/build_metric.py
+++ b/redo/rules/build_metric.py
@@ -196,7 +196,7 @@ class build_metric(build_rule_base):
             deps = [
                 d for d in deps.split("\n") if d.endswith(".ads") or d.endswith(".adb")
             ]
-            deps = list(set(deps))
+            deps = list(dict.fromkeys(deps))
 
             # Separate the autocoded deps from the hand coded deps:
             reg = re.compile(r".*build/src/.*\.ad[sb]$")
@@ -249,7 +249,7 @@ class build_metric(build_rule_base):
             deps = [
                 d for d in deps.split("\n") if d.endswith(".ads") or d.endswith(".adb")
             ]
-            deps = list(set(deps))
+            deps = list(dict.fromkeys(deps))
 
             # Separate the autocoded deps from the hand coded deps:
             reg = re.compile(r".*build/src/.*\.ad[sb]$")

--- a/redo/rules/build_object.py
+++ b/redo/rules/build_object.py
@@ -86,7 +86,7 @@ def _build_all_ada_dependencies(ada_source_files, source_db, dry_run=False):
             if source_file.endswith(".ads") or source_file.endswith(".adb"):
                 dependency_packages.extend(ada.get_source_dependencies(source_file))
         dependency_packages = filter(bool, dependency_packages)
-        dependency_packages = list(set(dependency_packages))
+        dependency_packages = list(dict.fromkeys(dependency_packages))
 
         # Get all the source files that correspond to these packages:
         sources = source_db.try_get_sources(dependency_packages)
@@ -254,7 +254,7 @@ def _build_all_c_dependencies(
             # Get dependencies for this source file. Ignore assembly files.
             if not source_file.endswith(".S") and not source_file.endswith(".s"):
                 all_deps.extend(get_c_source_dependencies(source_file, build_target_instance, c_source_db))
-        return list(set(all_deps))
+        return list(dict.fromkeys(all_deps))
 
     def _get_all_dependencies(source_files):
         sources = _get_immediate_dependencies(source_files)
@@ -280,7 +280,7 @@ def _run_gprbuild_command(build_target_instance, sources_to_compile, source_depe
     gpr_project_file = build_target_instance.gpr_project_file().strip()
     gpr_project_file_dir = os.path.dirname(gpr_project_file)
     gprbuild_flags = build_target_instance.gprbuild_flags()
-    dep_dirs = list(set([os.path.dirname(f) for f in source_dependencies]))
+    dep_dirs = list(dict.fromkeys([os.path.dirname(f) for f in source_dependencies]))
 
     # Set the verbosity level to low if debug is on:
     verbosity = ""
@@ -432,7 +432,7 @@ def _build_all_ada_and_c_dependencies_for_object(object_files, dry_run=False):
             )
 
     # Uniquify the dependency list for this object and return them.
-    sources_to_depend = list(set(sources_to_depend))
+    sources_to_depend = list(dict.fromkeys(sources_to_depend))
     return sources_to_compile, [build_target_file, __file__] + sources_to_depend, build_target_instance
 
 
@@ -652,7 +652,7 @@ def _compile_ada_object(redo_1, redo_2, redo_3, source_files, db):
     deps += _build_all_ada_dependencies(
         source_files, db
     )
-    deps = list(set(deps))
+    deps = list(dict.fromkeys(deps))
 
     # Compile:
     _compile_single_object(redo_1, redo_2, redo_3, build_target_instance, source_to_compile, deps)
@@ -690,7 +690,7 @@ def _compile_c_object(redo_1, redo_2, redo_3, source_files, db):
     deps += _build_all_c_dependencies(
         source_files, db, build_target_instance
     )
-    deps = list(set(deps))
+    deps = list(dict.fromkeys(deps))
 
     # Compile:
     _compile_single_object(redo_1, redo_2, redo_3, build_target_instance, source_to_compile, deps)

--- a/redo/rules/build_prove.py
+++ b/redo/rules/build_prove.py
@@ -67,7 +67,7 @@ def _prove_ada_sources(source_files, base_dir):
 
     # Form the gnatprove command:
     gpr_project_file = build_target_instance.gpr_project_file().strip()
-    dep_dirs = list(set([os.path.dirname(f) for f in deps]))
+    dep_dirs = list(dict.fromkeys([os.path.dirname(f) for f in deps]))
     output_file = build_dir + os.sep + "prove.txt"
     direct = " >&2"
 

--- a/redo/rules/build_via_generator.py
+++ b/redo/rules/build_via_generator.py
@@ -82,7 +82,7 @@ def _generate(output_filename):
     if dependencies:
         if isinstance(dependencies, str):
             dependencies = [dependencies]
-        redo.redo_ifchange(list(set(dependencies)))
+        redo.redo_ifchange(list(dict.fromkeys(dependencies)))
 
     # Make sure the output directory for the file exists. If it doesn't, create it:
     dirname = os.path.dirname(output_filename)

--- a/redo/targets/linux.py
+++ b/redo/targets/linux.py
@@ -11,7 +11,7 @@ import os.path
 
 class Linux_Base(gprbuild_target_base):
     def path_files(self):
-        return list(set(super(Linux_Base, self).path_files() + ["64bit", "Linux"]))
+        return list(dict.fromkeys(super(Linux_Base, self).path_files() + ["64bit", "Linux"]))
 
 
 #
@@ -59,7 +59,7 @@ class Linux_Coverage(Linux_Base):
                 "via gcov.")
 
     def path_files(self):
-        return list(set(super(Linux_Coverage, self).path_files() + ["Linux_Test"]))
+        return list(dict.fromkeys(super(Linux_Coverage, self).path_files() + ["Linux_Test"]))
 
     def gpr_project_file(self):
         return os.path.join(

--- a/redo/util/ada.py
+++ b/redo/util/ada.py
@@ -188,7 +188,7 @@ def get_source_dependencies(source_filename):
 
         # Print the results:
         includes.extend(parents)
-        includes = list(set(includes))
+        includes = list(dict.fromkeys(includes))
         # Any include that is not a single word is probably in a "generic" statement and we
         # should filter it out:
         includes = list(filter(lambda x: x.split() != 1, includes))

--- a/redo/util/pydep.py
+++ b/redo/util/pydep.py
@@ -74,7 +74,7 @@ def pydep(source_file, path=[], ignore_list=[]):
                 else:
                     nonexistent_deps.append(name)
 
-    return list(set(existing_deps)), nonexistent_deps
+    return list(dict.fromkeys(existing_deps)), nonexistent_deps
 
 
 def _build_pydeps(source_file, path=[]):
@@ -124,7 +124,7 @@ def _build_pydeps(source_file, path=[]):
             _inner_build_pydeps(dep)
 
     _inner_build_pydeps(source_file)
-    return list(set(deps_not_in_path)), list(set(all_existing_deps))
+    return list(dict.fromkeys(deps_not_in_path)), list(dict.fromkeys(all_existing_deps))
 
 
 class _build_python_no_update(build_rule_base):
@@ -147,7 +147,7 @@ class _build_python(build_rule_base):
         deps_not_in_path, existing_deps = _build_pydeps(redo_1)
 
         # Figure out what we need to add to the path:
-        paths_to_add = list(set([os.path.dirname(d) for d in deps_not_in_path]))
+        paths_to_add = list(dict.fromkeys([os.path.dirname(d) for d in deps_not_in_path]))
 
         # Add the paths to the path:
         sys.path.extend(paths_to_add)
@@ -166,7 +166,7 @@ class _run_python(build_rule_base):
         deps_not_in_path = _build_pydeps(redo_1)
 
         # Figure out what we need to add to the path:
-        paths_to_add = list(set([os.path.dirname(d) for d in deps_not_in_path]))
+        paths_to_add = list(dict.fromkeys([os.path.dirname(d) for d in deps_not_in_path]))
 
         # Run the python script:
         shell.run_command(

--- a/redo/util/tex.py
+++ b/redo/util/tex.py
@@ -16,7 +16,7 @@ def _depend_on_tex_links(tex, base_dir=None):
     # Ignore comments:
     tex = re.sub(r"%.*\n", "\n", tex)
     # Search output for tex dependencies and depend on them:
-    links = list(set(re.findall(r"\\input{(.*)}", tex, re.IGNORECASE)))
+    links = list(dict.fromkeys(re.findall(r"\\input{(.*)}", tex, re.IGNORECASE)))
     # Resolve paths:
     if base_dir:
         links = [link if os.path.isabs(link) else os.path.join(base_dir, link) for link in links]
@@ -36,7 +36,7 @@ def _depend_on_tex_graphics(tex, base_dir=None):
     # Ignore comments:
     tex = re.sub(r"%.*\n", "\n", tex)
     # Search output for tex dependencies and depend on them:
-    links = list(set(re.findall(r"\\includegraphics.*{(.*)}", tex, re.IGNORECASE)))
+    links = list(dict.fromkeys(re.findall(r"\\includegraphics.*{(.*)}", tex, re.IGNORECASE)))
     # Resolve paths:
     if base_dir:
         links = [link if os.path.isabs(link) else os.path.join(base_dir, link) for link in links]
@@ -54,10 +54,10 @@ def _depend_on_tex_lstinputlistings(tex, base_dir=None):
     # Ignore comments:
     tex = re.sub(r"%.*\n", "\n", tex)
     # Search output for tex dependencies and depend on them:
-    links = list(set(re.findall(r"\\lstinputlisting.*{(.*)}", tex, re.IGNORECASE)))
-    links += list(set(re.findall(r"\\yamlcodef.*{(.*)}", tex, re.IGNORECASE)))
-    links += list(set(re.findall(r"\\adacodef.*{(.*)}", tex, re.IGNORECASE)))
-    links += list(set(re.findall(r"\\pythoncodef.*{(.*)}", tex, re.IGNORECASE)))
+    links = list(dict.fromkeys(re.findall(r"\\lstinputlisting.*{(.*)}", tex, re.IGNORECASE)))
+    links += list(dict.fromkeys(re.findall(r"\\yamlcodef.*{(.*)}", tex, re.IGNORECASE)))
+    links += list(dict.fromkeys(re.findall(r"\\adacodef.*{(.*)}", tex, re.IGNORECASE)))
+    links += list(dict.fromkeys(re.findall(r"\\pythoncodef.*{(.*)}", tex, re.IGNORECASE)))
     # Resolve paths:
     if base_dir:
         links = [link if os.path.isabs(link) else os.path.join(base_dir, link) for link in links]

--- a/src/components/ccsds_parameter_table_router/gen/models/parameter_table_router_table.py
+++ b/src/components/ccsds_parameter_table_router/gen/models/parameter_table_router_table.py
@@ -344,4 +344,4 @@ class parameter_table_router_table(assembly_submodel):
                     )
 
         # Remove duplicate dependencies:
-        self.dependencies = list(set(self.dependencies))
+        self.dependencies = list(dict.fromkeys(self.dependencies))

--- a/src/components/ccsds_router/gen/models/ccsds_router_table.py
+++ b/src/components/ccsds_router/gen/models/ccsds_router_table.py
@@ -242,4 +242,4 @@ class ccsds_router_table(assembly_submodel):
             ]
 
         # Remove duplicate dependencies
-        self.dependencies = list(set(self.dependencies))
+        self.dependencies = list(dict.fromkeys(self.dependencies))

--- a/src/components/fault_correction/gen/models/fault_responses.py
+++ b/src/components/fault_correction/gen/models/fault_responses.py
@@ -272,4 +272,4 @@ class fault_responses(assembly_submodel):
 
         # Uniquify includes:
         self.includes = list(OrderedDict.fromkeys(self.includes))
-        self.dependencies = list(set(self.dependencies))
+        self.dependencies = list(dict.fromkeys(self.dependencies))

--- a/src/components/parameters/gen/models/parameter_table.py
+++ b/src/components/parameters/gen/models/parameter_table.py
@@ -473,7 +473,7 @@ class parameter_table(assembly_submodel):
                 param.component_id = self.destinations[param.component.instance_name][0]
 
         # Remove duplicate dependencies
-        self.dependencies = list(set(self.dependencies))
+        self.dependencies = list(dict.fromkeys(self.dependencies))
 
     def _check_duplicate_parameters_across_tables(self):
         """

--- a/src/components/product_packetizer/gen/models/product_packets.py
+++ b/src/components/product_packetizer/gen/models/product_packets.py
@@ -397,7 +397,7 @@ class product_packets(assembly_submodel):
             self.includes = self.data["with"]
         for include in self.includes:
             include = ada.formatType(include)
-        self.includes = list(set(self.includes))
+        self.includes = list(dict.fromkeys(self.includes))
 
         # Load the packets:
         for packet_data in self.data["packets"]:
@@ -581,7 +581,7 @@ class product_packets(assembly_submodel):
             # Set the packet size
             pkt.size = packet_size
 
-        self.dependencies = list(set(self.dependencies))
+        self.dependencies = list(dict.fromkeys(self.dependencies))
 
     def final(self):
         """We use the final function to create the item list and resolve the data product IDS."""

--- a/src/components/sequence_store/gen/models/sequence_store.py
+++ b/src/components/sequence_store/gen/models/sequence_store.py
@@ -130,7 +130,7 @@ class sequence_store(base):
             self.slots.append(new_slot)
             self.includes.extend(new_slot.includes)
             num += 1
-        self.includes = list(set(self.includes))
+        self.includes = list(dict.fromkeys(self.includes))
 
         self.summary_size = len(self.slots) * _get_slot_summary_size()
         if self.summary_size > _get_packet_buffer_size():

--- a/src/components/task_watchdog/gen/models/task_watchdog_list.py
+++ b/src/components/task_watchdog/gen/models/task_watchdog_list.py
@@ -206,7 +206,7 @@ class task_watchdog_list(assembly_submodel):
         )
 
         # Remove duplicate dependencies
-        self.dependencies = list(set(self.dependencies))
+        self.dependencies = list(dict.fromkeys(self.dependencies))
 
     @throw_exception_with_filename
     def set_assembly(self, assembly):


### PR DESCRIPTION
## Summary

Audits `gen/`, `redo/`, and per-component `gen/models/` for patterns whose iteration order depends on Python's `PYTHONHASHSEED`, and replaces them with insertion-order-preserving equivalents. Each one is a latent reproducibility hazard: outputs that transitively depend on a set's iteration order can differ across Python processes even though inputs are identical.

## Changes

- `list(set(X))` -> `list(dict.fromkeys(X))` throughout. Same deduplication semantics, but `dict` preserves insertion order so the result is stable across processes.
- `gen/models/view.py`: rewrite two set-operation-into-dict-insertion patterns in `assembly_intersection`/`assembly_union` to iterate ordered dict keys filtered by set membership, instead of iterating the set result directly. These were feeding `data_dependencies` dict insertion order, which flowed into generated Ada code ordering.
- `gen/models/component.py`: same fix as `gen/models/assembly.py` for the component-level submodel loader (`for f in list(set(submodel_files))`), which had the same structural issue as the assembly submodel loader but for component submodels. Also cleans up `complex_type_models` to do dedup without going through a set.
- `gen/models/base.py` `unique()` helper: same swap.

Membership-only uses of `set(...)` (sets that are only queried with `in`, never iterated) are left alone -- those are already order-insensitive.

## Behavioral impact

No change to the element set of any affected container. No change to any logic that uses the containers for `in` membership. Templates that iterate `data_dependencies` built by `assembly_intersection`/`assembly_union` may produce entries in a different but now stable order -- blocks of `data_dependencies`-driven entries in generated Ada will be permuted relative to a prior nondeterministic run, not added or removed.