### PR TITLE
Fix CWE-571 always-true warning in Circular_Buffer.Destroy

### DIFF
--- a/src/data_structures/circular_buffer/circular_buffer.adb
+++ b/src/data_structures/circular_buffer/circular_buffer.adb
@@ -3,8 +3,6 @@ with Interfaces;
 
 package body Circular_Buffer is
 
-   use type Basic_Types.Byte_Array_Access;
-
    --
    -- Subprograms for Base
    --
@@ -28,10 +26,7 @@ package body Circular_Buffer is
    begin
       if Self.Allocated then
          Free_If_Testing (Self.Bytes);
-         -- Reset Self.Allocated if bytes was actually deallocated.
-         if Self.Bytes = null then
-            Self.Allocated := False;
-         end if;
+         Self.Allocated := False;
       end if;
       Self.Clear;
       -- Reset state:


### PR DESCRIPTION
## Summary

- Removes the redundant `if Self.Bytes = null then` check inside `Circular_Buffer.Base.Destroy`, which GNATSAS Inspector flags as CWE-571 (test always true) because the analyzer sees the **testing** body of `Safe_Deallocator.Deallocate_If_Testing` (which wraps `Ada.Unchecked_Deallocation` and always nulls its argument).
- Replaces the check with an unconditional `Self.Allocated := False;` inside the existing `if Self.Allocated then` branch.
- Drops the now-unused `use type Basic_Types.Byte_Array_Access;` clause.

## Why

Commit 0c37fcb3 (Reset state in data structure Destroy) added the inner guard as a defensive paranoia check, but it's provably true in the testing variant the analyzer sees, hence the warnings:

```
circular_buffer.adb:32:24: medium warning: test always true [CWE 571] (Inspector): test always true because Self.all.Bytes = null
```