### PR TITLE
Remove the GNAT-specific Value_Size aspect from templates and sources

### DIFF
--- a/gen/templates/array/name.ads
+++ b/gen/templates/array/name.ads
@@ -643,8 +643,7 @@ package {{ name }} is
 {% else %}
    -- Packed type definition for array element:
    subtype Element_Packed is {{ element.type }}
-      with Object_Size => Element_Size_In_Bytes * 8,
-           Value_Size => Element_Size_In_Bytes * 8;
+      with Object_Size => Element_Size_In_Bytes * 8;
 
    -- Serializing functions for an element of the array:
    package Element_Serialization is new Serializer (Element_Packed);

--- a/gen/templates/component/component-name.ads
+++ b/gen/templates/component/component-name.ads
@@ -351,9 +351,9 @@ private
       Index : Connector_Index_Type;
    end record
       with Size => 24,
-             Object_Size => 24,
-             Alignment => 1,
-             Volatile => False;
+           Object_Size => 24,
+           Alignment => 1,
+           Volatile => False;
 
    -- Define the size of the record to be compact to save space on
    -- the queue (24 bits).

--- a/gen/templates/component/component-name.ads
+++ b/gen/templates/component/component-name.ads
@@ -352,7 +352,6 @@ private
    end record
       with Size => 24,
              Object_Size => 24,
-             Value_Size => 24,
              Alignment => 1,
              Volatile => False;
 
@@ -369,7 +368,6 @@ private
    end record
       with Size => 8,
            Object_Size => 8,
-           Value_Size => 8,
            Alignment => 1,
            Volatile => False;
 

--- a/gen/templates/record/name.ads
+++ b/gen/templates/record/name.ads
@@ -193,7 +193,6 @@ package {{ name }} is
            Scalar_Storage_Order => System.High_Order_First,
            Size => Size,
            Object_Size => Size,
-           Value_Size => Size,
            Alignment => 1,
            Volatile => False;
 
@@ -230,7 +229,6 @@ package {{ name }} is
            Scalar_Storage_Order => System.Low_Order_First,
            Size => Size,
            Object_Size => Size,
-           Value_Size => Size,
            Alignment => 1,
            Volatile => False;
 
@@ -267,7 +265,6 @@ package {{ name }} is
            Scalar_Storage_Order => System.High_Order_First,
            Size => Size,
            Object_Size => Size,
-           Value_Size => Size,
            Alignment => 4, -- Cannot be aligned at 1, must be aligned at word boundary
            Volatile => True;
 
@@ -299,7 +296,6 @@ package {{ name }} is
            Scalar_Storage_Order => System.Low_Order_First,
            Size => Size,
            Object_Size => Size,
-           Value_Size => Size,
            Alignment => 4, -- Cannot be aligned at 1, must be aligned at word boundary
            Volatile => True;
 
@@ -332,7 +328,6 @@ package {{ name }} is
            Scalar_Storage_Order => System.High_Order_First,
            Size => Size,
            Object_Size => Size,
-           Value_Size => Size,
            Alignment => 1,
            Volatile => True;
 
@@ -354,7 +349,6 @@ package {{ name }} is
            Scalar_Storage_Order => System.Low_Order_First,
            Size => Size,
            Object_Size => Size,
-           Value_Size => Size,
            Alignment => 1,
            Volatile => True;
 
@@ -382,7 +376,6 @@ package {{ name }} is
            Scalar_Storage_Order => System.High_Order_First,
            Size => Size,
            Object_Size => Size,
-           Value_Size => Size,
            Volatile => True,
            Atomic => True;
 
@@ -405,7 +398,6 @@ package {{ name }} is
            Scalar_Storage_Order => System.Low_Order_First,
            Size => Size,
            Object_Size => Size,
-           Value_Size => Size,
            Volatile => True,
            Atomic => True;
 
@@ -428,7 +420,6 @@ package {{ name }} is
            Scalar_Storage_Order => System.High_Order_First,
            Size => Size,
            Object_Size => Size,
-           Value_Size => Size,
            Volatile => True,
            Volatile_Full_Access => True;
 
@@ -451,7 +442,6 @@ package {{ name }} is
            Scalar_Storage_Order => System.Low_Order_First,
            Size => Size,
            Object_Size => Size,
-           Value_Size => Size,
            Volatile => True,
            Volatile_Full_Access => True;
 

--- a/src/core/serializer/test/test.adb
+++ b/src/core/serializer/test/test.adb
@@ -113,8 +113,6 @@ procedure Test is
       New_Line;
       Put (Natural'Object_Size);
       New_Line;
-      Put (Natural'Value_Size);
-      New_Line;
       Put ("Byte Size: ");
       Put (Byte'Size);
       New_Line;

--- a/src/types/basic_types/basic_types.ads
+++ b/src/types/basic_types/basic_types.ads
@@ -10,8 +10,7 @@ package Basic_Types is
 
    -- Define a byte as an 8-bit mod type:
    subtype Byte is Interfaces.Unsigned_8
-   with Object_Size => 8,
-        Value_Size => 8;
+   with Object_Size => 8;
 
    -- Define a collection of bytes indexed by a subtype of Natural.
    --

--- a/src/types/test/test.adb
+++ b/src/types/test/test.adb
@@ -23,7 +23,6 @@ procedure Test is
       Scalar_Storage_Order => System.High_Order_First,
       Size => Size,
       Object_Size => Size,
-      Value_Size => Size,
       Alignment => 1;
 
       -- Packed type layout:


### PR DESCRIPTION
Value_Size is a GNAT-only alias of Size and breaks Adamant's compiler portability; Size on first subtypes and the standard Object_Size cover every existing use, so the aspect adds nothing.