### PR TITLE
Define Packed_F64 on Long_Float, matching Packed_F32

### DIFF
--- a/src/types/packed_types/packed_f64.record.yaml
+++ b/src/types/packed_types/packed_f64.record.yaml
@@ -1,11 +1,7 @@
 ---
 description: Single component record for holding packed 64-bit floating point number.
-with:
-  - Interfaces
-preamble: |
-   subtype Float_64 is Interfaces.IEEE_Float_64;
 fields:
   - name: Value
     description: The 64-bit floating point number.
-    type: Float_64
+    type: Long_Float
     format: F64


### PR DESCRIPTION
Change `Packed_F64` to be consistant with `Packed_F32` packed record.

`Packed_F64` declared its field through a `Float_64` subtype of `Interfaces.IEEE_Float_64`, while `Packed_F32` uses plain `Short_Float`. This defines `Packed_F64.Value` directly as `Long_Float`, matching the `Packed_F32` convention — no `with`, no preamble, no subtype.

`Long_Float` and `Interfaces.IEEE_Float_64` are attribute-identical (`'Size`, `'Digits`, `'Machine_Mantissa`, `'Machine_Emin`/`'Machine_Emax`, `'Denorm`, `'Machine_Rounds`) on both the native x86_64 GNAT and cross embedded GNAT Pro targets. The subtype therefore only forced no-op nominal-type conversions at every boundary with `Long_Float` code.