### PR TITLE
Keep the leaf field level in product packet descriptions

### DIFF
--- a/src/components/product_packetizer/gen/models/product_packets.py
+++ b/src/components/product_packetizer/gen/models/product_packets.py
@@ -169,7 +169,15 @@ class product_packet_item(packet_item):
 
     @property
     def flattened_description(self):
-        super_desc = super(product_packet_item, self).flattened_description
+        # The base class opens the description with the containing entity's name
+        # and description. Replace that level with one that also identifies the
+        # source data product by id.
+        #
+        # This is composed directly rather than by editing the base class string.
+        # A data product with no description of its own produces no containing
+        # level at all, so there is nothing there to replace, and editing the
+        # string would consume the first level of the flattened field chain
+        # instead.
         prefix = (
             self.packet.name
             + "."
@@ -178,7 +186,9 @@ class product_packet_item(packet_item):
             + str(self.dp.data_product.id)
             + (" (0x%04x)" % self.dp.data_product.id)
         )
-        return prefix + " -" + "-".join(super_desc.split("-")[1:])
+        if self.dp.data_product.description:
+            prefix += " - " + self.dp.data_product.description
+        return prefix + "\n." + self.flat_desc
 
     @property
     def full_name(self):


### PR DESCRIPTION
## Problem

`product_packet_item.flattened_description` replaces the containing entity level that `packet_item` composes with one that also identifies the source data product by id. It did that by string surgery on the base class result:

```python
return prefix + " -" + "-".join(super_desc.split("-")[1:])
```

That splits on *every* hyphen and drops the first element. It is correct only when the base class actually emitted a leading `Entity_Name - description` level.

It does not when the data product has no description of its own. `packet_item.flattened_description` emits nothing at all in that case, so the string begins with the flattened field chain and the split consumes the chain's **first level** instead of the entity name.

The leaf field name was therefore dropped from every item whose data product is undescribed, in the flattened packet HTML and in any other consumer of the property.

## Impact

In the EMA flight assembly this silently affected 54 telemetry items, all in one product packet:

```
before:  Downsampler_Status.Ccsds_Downsampler.Apid_896_Filter_Factor - 35 (0x0023) - The 16-bit unsigned integer.
after:   Downsampler_Status.Ccsds_Downsampler.Apid_896_Filter_Factor - 35 (0x0023)
         .Value - The 16-bit unsigned integer.
```

## Fix

Compose the level directly from the packet, the data product, and the field chain, instead of editing the base class string. There is no head to strip, so there is nothing to get wrong.
