### PR TITLE
Fix implicit parent package discovery for multi-line package declarations

### DIFF
--- a/redo/test/README.md
+++ b/redo/test/README.md
@@ -8,4 +8,5 @@ This directory contains a set of unit tests which ensure the functionality of th
 
 The following is a description of what you can expect to find in the subdirectories of this directory.
 
+* `aspect_compile/` - a test which makes sure a child package declared with an aspect specification (which puts the `is` keyword on its own line) still has its implicit parent-package dependency discovered
 * `c_compile/` - a test which makes sure the compilation of c source code and linking with an ada main file is working properly

--- a/redo/test/README.md
+++ b/redo/test/README.md
@@ -10,3 +10,4 @@ The following is a description of what you can expect to find in the subdirector
 
 * `aspect_compile/` - a test which makes sure a child package declared with an aspect specification (which puts the `is` keyword on its own line) still has its implicit parent-package dependency discovered
 * `c_compile/` - a test which makes sure the compilation of c source code and linking with an ada main file is working properly
+* `source_dependencies/` - a unit test for the Ada source scanning in `redo/util/ada.py`, locking in the dependency extraction and body-dependency heuristics over a set of declaration shapes; runs under `redo test` like the python tests in `gen/test/`

--- a/redo/test/aspect_compile/aspect_parent-child.adb
+++ b/redo/test/aspect_compile/aspect_parent-child.adb
@@ -1,0 +1,7 @@
+package body Aspect_Parent.Child
+   with SPARK_Mode => On
+is
+
+   function Doubled_Base return Natural is (2 * Base_Value);
+
+end Aspect_Parent.Child;

--- a/redo/test/aspect_compile/aspect_parent-child.ads
+++ b/redo/test/aspect_compile/aspect_parent-child.ads
@@ -1,0 +1,13 @@
+-- Child package declared with an aspect specification. The aspect pushes the
+-- "is" keyword onto its own line, which is the shape that used to break the
+-- build system's implicit parent-package dependency extraction: the parent's
+-- directory never made it onto the source path and gprbuild failed to find
+-- Aspect_Parent. This test compiles only when that extraction handles a
+-- multi-line package declaration.
+package Aspect_Parent.Child
+   with SPARK_Mode => On
+is
+
+   function Doubled_Base return Natural;
+
+end Aspect_Parent.Child;

--- a/redo/test/aspect_compile/aspect_parent-private_child.ads
+++ b/redo/test/aspect_compile/aspect_parent-private_child.ads
@@ -1,0 +1,13 @@
+-- A private child package. The leading "private" keyword used to prevent the
+-- build system from recognizing this as a package declaration at all, so the
+-- implicit dependency on the parent was never recorded.
+--
+-- Deliberately body-less: every declaration in this directory must be one the
+-- old extraction could not parse. A single plain "package body X.Y is" here
+-- would recover the parent dependency on its own and mask the regression this
+-- directory exists to catch.
+private package Aspect_Parent.Private_Child is
+
+   Tripled_Base : constant Natural := 3 * Base_Value;
+
+end Aspect_Parent.Private_Child;

--- a/redo/test/aspect_compile/depends/aspect_parent.ads
+++ b/redo/test/aspect_compile/depends/aspect_parent.ads
@@ -1,0 +1,8 @@
+-- Parent package for the aspect_compile test. It lives in a separate
+-- directory so that it is only found if the build system correctly extracts
+-- the implicit parent dependency from the child package declaration below.
+package Aspect_Parent is
+
+   Base_Value : constant Natural := 17;
+
+end Aspect_Parent;

--- a/redo/test/aspect_compile/env.py
+++ b/redo/test/aspect_compile/env.py
@@ -1,0 +1,11 @@
+from environments import modify_build_path
+import os
+
+this_dir = os.path.dirname(os.path.realpath(__file__))
+# Overwrite the normal build path mechanism and just use
+# this directory as the build path. This prevents any
+# name conflicts we might get from using the regular
+# ".all_path".
+modify_build_path.set_build_path(
+    this_dir + os.pathsep + os.path.join(this_dir, "depends")
+)

--- a/redo/test/source_dependencies/coverage.do
+++ b/redo/test/source_dependencies/coverage.do
@@ -1,0 +1,1 @@
+python test.py

--- a/redo/test/source_dependencies/test.do
+++ b/redo/test/source_dependencies/test.do
@@ -1,0 +1,1 @@
+python test.py

--- a/redo/test/source_dependencies/test.py
+++ b/redo/test/source_dependencies/test.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+
+# Unit test for the Ada source scanning in redo/util/ada.py: the "with"
+# dependency and implicit parent-package extraction in get_source_dependencies,
+# and the body-dependency heuristics in should_depend_on_adb. Each fixture
+# below locks in the handling of one declaration shape, most of which have
+# broken (or silently produced wrong dependencies) at some point.
+import os
+import sys
+import tempfile
+
+from util import ada
+
+
+def println(strn=""):
+    sys.stderr.write(strn + "\n")
+
+
+def write_temp_source(source):
+    handle, path = tempfile.mkstemp(suffix=".ads", text=True)
+    with os.fdopen(handle, "w") as f:
+        f.write(source)
+    return path
+
+
+def get_deps(source):
+    path = write_temp_source(source)
+    try:
+        return ada.get_source_dependencies(path)
+    finally:
+        os.unlink(path)
+
+
+def get_adb(source):
+    path = write_temp_source(source)
+    try:
+        return ada.should_depend_on_adb(path)
+    finally:
+        os.unlink(path)
+
+
+# Each entry: (name, source, dependencies that must be found, names that must
+# NOT appear as dependencies).
+dependency_cases = [
+    (
+        "multiline aspect declaration yields parent",
+        "with Interfaces;\n"
+        "package Component.Foo.Implementation\n"
+        "   with SPARK_Mode => On\n"
+        "is\n"
+        "end Component.Foo.Implementation;\n",
+        ["Interfaces", "Component.Foo"],
+        [],
+    ),
+    (
+        "single-line aspect declaration yields clean parent",
+        "package Component.Bar.Implementation with SPARK_Mode => On is\n"
+        "end Component.Bar.Implementation;\n",
+        ["Component.Bar"],
+        [],
+    ),
+    (
+        "private child yields parent",
+        "private package A.B.C is\nend A.B.C;\n",
+        ["A.B"],
+        [],
+    ),
+    (
+        "plain body yields parent",
+        "package body A.B is\nend A.B;\n",
+        ["A"],
+        [],
+    ),
+    (
+        "multi-line with clause keeps trailing units",
+        "with Foo,\n     Bar;\npackage P is\nend P;\n",
+        ["Foo", "Bar"],
+        [],
+    ),
+    (
+        "declaration after a semicolon on the same line still matches",
+        "pragma Elaborate_Body; package A.B is\nend A.B;\n",
+        ["A"],
+        [],
+    ),
+    (
+        "argument-less aspect on a package is not an include",
+        "package P\n   with Pure\nis\nend P;\n",
+        [],
+        ["Pure"],
+    ),
+    (
+        "with Ghost on a declaration is not an include",
+        "package P is\n   procedure Foo\n      with Ghost;\nend P;\n",
+        [],
+        ["Ghost"],
+    ),
+    (
+        "with Always_Terminates is not an include",
+        "package P is\n"
+        "   function F return Integer\n"
+        "      with Always_Terminates;\n"
+        "end P;\n",
+        [],
+        ["Always_Terminates"],
+    ),
+    (
+        "aspect expression does not mangle the parent",
+        "package A.B with Abstract_State => (X) is\nend A.B;\n",
+        ["A"],
+        [],
+    ),
+    (
+        "mixed case declaration yields clean parent",
+        "PACKAGE A.B IS\nEND A.B;\n",
+        ["A"],
+        [],
+    ),
+    (
+        "child generic instantiation yields parent",
+        "with G;\npackage A.B is new G (Integer);\n",
+        ["G", "A"],
+        [],
+    ),
+    (
+        "child renaming yields parent",
+        "with C.D;\npackage A.B renames C.D;\n",
+        ["C.D", "A"],
+        [],
+    ),
+    (
+        "commented-out declaration is ignored",
+        "-- package Zz.Yy is\npackage P is\nend P;\n",
+        [],
+        ["Zz"],
+    ),
+    (
+        "comment following a semicolon is ignored",
+        "pragma Pure; -- package Qq.Rr is\npackage P is\nend P;\n",
+        [],
+        ["Qq"],
+    ),
+    (
+        "generic formal package is not an include",
+        "generic\n   with package Q is new R (<>);\npackage G is\nend G;\n",
+        [],
+        ["Q"],
+    ),
+]
+
+# Each entry: (name, source, expected result).
+adb_cases = [
+    (
+        "argument-less Inline aspect",
+        "package P is\n   procedure Foo\n      with Inline;\nend P;\n",
+        True,
+    ),
+    (
+        "Inline aspect without spaces",
+        "package P is\n   procedure Foo with Inline=>True;\nend P;\n",
+        True,
+    ),
+    (
+        "Inline aspect with spaces",
+        "package P is\n   procedure Foo with Inline => True;\nend P;\n",
+        True,
+    ),
+    (
+        "one-line generic package header",
+        "generic package G is\nend G;\n",
+        True,
+    ),
+    (
+        "generic keyword alone ahead of formals",
+        "generic\n   type T is private;\npackage G is\nend G;\n",
+        True,
+    ),
+    (
+        "pragma Inline",
+        "package P is\n   procedure Foo;\n   pragma Inline (Foo);\nend P;\n",
+        True,
+    ),
+    (
+        "plain package needs no body dependency",
+        "package P is\n   procedure Foo;\nend P;\n",
+        False,
+    ),
+]
+
+
+if __name__ == "__main__":
+    println("testing get_source_dependencies:")
+    for name, source, must_have, must_not_have in dependency_cases:
+        deps = get_deps(source)
+        for dep in must_have:
+            assert dep in deps, (
+                name + ": expected '" + dep + "' in " + str(deps)
+            )
+        for dep in must_not_have:
+            assert dep not in deps, (
+                name + ": did not expect '" + dep + "' in " + str(deps)
+            )
+        for dep in deps:
+            assert dep and " " not in dep, (
+                name + ": malformed dependency '" + dep + "' in " + str(deps)
+            )
+        println("  " + name)
+
+    println("testing should_depend_on_adb:")
+    for name, source, expected in adb_cases:
+        result = get_adb(source)
+        assert result == expected, (
+            name + ": expected " + str(expected) + ", got " + str(result)
+        )
+        println("  " + name)
+
+    println("passed.")
+    println()

--- a/redo/util/ada.py
+++ b/redo/util/ada.py
@@ -107,6 +107,22 @@ def isTypePrimitive(adaType):
     return os.path.splitext(_rawType(adaType))[1] == ""
 
 
+def _source_statements(content):
+    """
+    Split Ada source text into statements, with comments removed.
+
+    Comments are stripped line by line, then the remaining text is broken on
+    semicolons and each statement is collapsed onto a single line. Splitting on
+    semicolons rather than on newlines matters: a clause naming several units
+    ("with Foo,\\n Bar;") or a declaration carrying an aspect specification
+    ("package P\\n with SPARK_Mode => On\\nis") is one statement, and treating
+    each of its lines separately either loses part of it or turns a fragment
+    into something it is not.
+    """
+    lines = [line.split("--")[0] for line in content.splitlines()]
+    return [" ".join(s.split()) for s in "\n".join(lines).split(";")]
+
+
 def get_source_dependencies(source_filename):
     """
     Simple function which reads the "with" dependencies from
@@ -130,8 +146,7 @@ def get_source_dependencies(source_filename):
         content = f.read()
 
         # Split the file into statements and remove comments:
-        statements = re.split("[\n/;]", content)
-        statements = [x.strip().split("--")[0] for x in statements]
+        statements = _source_statements(content)
 
         # Find all with statements
         r = re.compile(r"^\s*with\s+.*$", re.IGNORECASE)
@@ -174,11 +189,14 @@ def get_source_dependencies(source_filename):
         # trailing "is" on the same line -- an aspect specification (e.g.
         # "with SPARK_Mode => On") or a line break can separate the name from its
         # "is", and private child packages carry a leading "private" keyword.
+        # Matching statements rather than raw text keeps a declaration that
+        # follows another on the same line (after a semicolon) in scope, and
+        # keeps commented-out text out of it.
         r = re.compile(
             r"^\s*(?:private\s+)?package\s+(?:body\s+)?([A-Za-z][\w.]*)",
-            re.IGNORECASE | re.MULTILINE,
+            re.IGNORECASE,
         )
-        packages = r.findall(content)
+        packages = [match.group(1) for match in map(r.match, statements) if match]
         parents = []
         for package in packages:
             split_package = package.split(".")
@@ -189,8 +207,9 @@ def get_source_dependencies(source_filename):
         includes.extend(parents)
         includes = list(dict.fromkeys(includes))
         # Any include that is not a single word is probably in a "generic" statement and we
-        # should filter it out:
-        includes = list(filter(lambda x: x.split() != 1, includes))
+        # should filter it out. This also drops the empty strings left behind by trailing
+        # separators.
+        includes = [x for x in includes if len(x.split()) == 1]
         return includes
 
 
@@ -254,19 +273,24 @@ def should_depend_on_adb(spec_file):
         content = f.read()
 
         # Split the file into statements and remove comments:
-        statements = re.split("[\n/;]", content)
-        statements = [x.strip().split("--")[0] for x in statements]
+        statements = _source_statements(content)
 
-        # See if there is any lines that only contain the word 'generic' on it:
-        r = re.compile(r"^\s*generic\s*$", re.IGNORECASE)
-        lines_with_only_generic = list(filter(r.match, statements))
-        if lines_with_only_generic:
+        # See if any statement begins a generic unit. The keyword can stand alone
+        # ahead of the formal part, or introduce the unit directly when there are
+        # no formals ("generic package G is ...").
+        r = re.compile(r"^\s*generic\b", re.IGNORECASE)
+        statements_with_generic = list(filter(r.match, statements))
+        if statements_with_generic:
             return True
 
-        # See if there is any lines that specify inlining:
-        r = re.compile(r"^.*with\s+inline\s+=>\s+true.*$", re.IGNORECASE)
-        lines_with_inline_aspect = list(filter(r.match, statements))
-        if lines_with_inline_aspect:
+        # See if any statement specifies inlining. The aspect may be given without
+        # an argument ("with Inline", equivalent to "=> True"), with one and any
+        # spacing ("with Inline=>True"), or alongside other aspects. Matching the
+        # aspect name loosely errs toward depending on the body, which is the safe
+        # direction: a missed dependency means a stale object under -gnatn.
+        r = re.compile(r"^.*\bwith\b.*\binline.*$", re.IGNORECASE)
+        statements_with_inline_aspect = list(filter(r.match, statements))
+        if statements_with_inline_aspect:
             return True
 
         r = re.compile(r"^.*pragma\s+inline.*$", re.IGNORECASE)

--- a/redo/util/ada.py
+++ b/redo/util/ada.py
@@ -119,11 +119,6 @@ def get_source_dependencies(source_filename):
             return text[len(prefix):]
         return text
 
-    def remove_postfix(text, prefix):
-        if text.endswith(prefix):
-            return text[:-len(prefix)]
-        return text
-
     # Make sure the file is Ada source code:
     assert source_filename.endswith(".ads") or source_filename.endswith(".adb"), (
         "Cannot get dependencies for '"
@@ -174,12 +169,16 @@ def get_source_dependencies(source_filename):
         includes = list(chain.from_iterable([x.split(",") for x in includes]))
         includes = [x.strip() for x in includes]
 
-        # If package has a parent package, that is an implicit include:
-        r = re.compile(r"package .* is\s*$", re.IGNORECASE)
-        packages = list(filter(r.match, statements))
-        packages = [remove_prefix(x.strip(), "package").strip() for x in packages]
-        packages = [remove_prefix(x.strip(), "body").strip() for x in packages]
-        packages = [remove_postfix(x.strip(), "is").strip() for x in packages]
+        # If package has a parent package, that is an implicit include. Match the
+        # package name right after the "package" keyword instead of requiring the
+        # trailing "is" on the same line -- an aspect specification (e.g.
+        # "with SPARK_Mode => On") or a line break can separate the name from its
+        # "is", and private child packages carry a leading "private" keyword.
+        r = re.compile(
+            r"^\s*(?:private\s+)?package\s+(?:body\s+)?([A-Za-z][\w.]*)",
+            re.IGNORECASE | re.MULTILINE,
+        )
+        packages = r.findall(content)
         parents = []
         for package in packages:
             split_package = package.split(".")


### PR DESCRIPTION
## Summary

Source-dependency scanning extracts a package's implicit parent dependency by matching `package .* is\s*$` against newline/semicolon-split statement fragments. Any package declaration where the name and the `is` keyword are not on the same line defeats the match, so the parent include is silently dropped, the parent's directory never lands on the source path, and gprbuild fails to find the parent unit.

The common way to hit this is the SPARK aspect form, which conventionally puts `is` on its own line:

```ada
package Component.Foo.Implementation
   with SPARK_Mode => On
is
```

Symptom:

```
aspect_parent-child.ads:7:22: error: file "Aspect_Parent.ads" not found
```

Two adjacent latent cases fall out of the same match: `private package A.B.C is` never matched (leading keyword), and the single-line aspect form only produced a correct parent by accident of greedy stripping.

Closes #191.

## Fix

Extract the package name directly after the `package` keyword with a multiline regex over the file content, instead of requiring the trailing `is` on the same fragment:

```python
r"^\s*(?:private\s+)?package\s+(?:body\s+)?([A-Za-z][\w.]*)"
```

Parent derivation is unchanged. The now-unused `remove_postfix` helper is deleted.

## Validation

- Before/after harness over four declaration shapes (multiline aspect, single-line aspect, private child, plain body): old code loses the parent on the multiline-aspect and private-child cases; new code passes all four with no mangled names.
- End-to-end in the Adamant container: a child package in the aspect form with its parent in a separate directory fails to build before the change (`file "Aspect_Parent.ads" not found`) and builds cleanly after.
- That reproduction is added as `redo/test/aspect_compile/` (mirroring `spark_compile`'s structure, listed in the test README), so `redo` in that directory regresses this permanently: it only compiles when the implicit parent of a multi-line declaration is discovered.

Context: found while adding SPARK contracts to a component (the aspect form on a spec is the idiomatic SPARK entry point), where the failure presents as an inexplicable missing-source error two steps removed from its cause.
