### PR TITLE
Fix GNATprove child-package source resolution using base names

### DIFF
--- a/redo/rules/build_prove.py
+++ b/redo/rules/build_prove.py
@@ -122,7 +122,13 @@ def _prove_ada_sources(source_files, base_dir):
         + " -XSOURCE_DIRS="
         + ",".join(dep_dirs)
         + " "
-        + " ".join(source_files)
+        # GNATprove (as of 15.1.0) fails to resolve child-package sources, ie.
+        # "parent-child.ads", when passed as absolute paths, reporting that
+        # they are "not a file or compilation unit of any project". Passing
+        # base names avoids this. The directory of every source file is
+        # already included in SOURCE_DIRS above, so base names resolve
+        # unambiguously.
+        + " ".join([os.path.basename(f) for f in source_files])
         + direct
     )
 


### PR DESCRIPTION
## Summary

`redo prove` fails in any component directory whose source set includes autocoded child units (`parent-child.ads`). GNATprove (as of 15.1.0) rejects those units when they are passed as absolute paths, before analysis begins:

```
<unit> is not a file or compilation unit of any project
```

The cause is path resolution, not analysis. GNATprove resolves the same child units when they are passed as base names, and `build_prove.py` was passing absolute paths.

## Fix

Pass the source arguments to GNATprove as base names. The directory of every source is already on `-XSOURCE_DIRS`, so base names resolve unambiguously. One line in `redo/rules/build_prove.py`.

Diagnosis and fix from @dinkelk (lasp/adamant#194 review).

## Validation

In the Adamant container, on a component containing a hand-written SPARK package alongside its autocoded child units. The before/after differ only in this one line; the built source set is identical.

- **Before** (absolute paths): `admt prove` in the component directory fails at `component-<name>.ads is not a file or compilation unit of any project`, before any analysis runs.
- **After** (base names): `admt prove` runs to completion and reproduces the package's full proof through the build system — 10 checks, 0 unproved, 0 justified (6 run-time, 1 assertion, 1 functional contract, 1 data dependency, 1 termination; 8 discharged by the provers, 2 by flow), at `level: 2, mode: gold`, with the summary beside the component under `build/prove/gnatprove/gnatprove.out`.
- **Default-path regression**: `doc/example_architecture/spark_package` (a top-level SPARK unit) builds and proves clean. Base names and absolute paths both resolve for non-child units, so the change is a no-op there.

Closes #192.

---

<details>
<summary>Prior approach (superseded) — <code>packages:</code> scoping in <code>all.prove.yaml</code></summary>

> ## Summary
>
> `redo prove` analyzes every source buildable in a directory. In a component directory that includes the autocoded base classes, which GNATprove generally cannot analyze (child-package resolution failures against the framework), so a component that contains a hand-written SPARK package cannot be proven through the build system at all:
>
> ```
> <unit> is not a file or compilation unit of any project
> error: child package ... cannot be resolved
> ```
>
> The current workaround is invoking `gnatprove` directly with a hand-built project file and `-XSOURCE_DIRS`, which bypasses the build system and scatters proof output under the GPR directory instead of the component. Agents and developers should not need to call the prover by hand any more than they call the compiler by hand.
>
> Closes #192.
>
> ## Fix
>
> Model-driven scoping in the existing prove configuration. `all.prove.yaml` gains an optional `packages:` list (schema + model + rule):
>
> ```yaml
> ---
> description: GNATprove configuration for the component's step-allocation logic
> level: 2
> mode: "gold"
> packages:
>   - My_Component_Logic
> ```
>
> When present, `redo prove` resolves each named package through the source database (case-insensitive) and passes exactly those sources to GNATprove, instead of everything in the directory. A name that resolves to no sources is a hard error naming the package and the yaml file. When absent, behavior is unchanged.
>
> ## Validation
>
> Run in the Adamant container against a project component containing a proved SPARK logic package alongside its autocoded sources (project details withheld; the shape is exactly the `My_Component_Logic` example above):
>
> - Before: `redo prove` in the component directory fails with `component-<name>.ads is not a file or compilation unit of any project`.
> - After, with the logic package listed under `packages:`: `redo prove` analyzes exactly the two logic-package files and reproduces the package's full proof (10 checks, 0 unproved, 0 justified: run-time checks, assertion, and functional contracts), with the summary written beside the component under `build/prove/gnatprove/gnatprove.out`.
> - Unknown package name: clear failure (`No source files found for package 'No_Such_Package' listed in .../all.prove.yaml`), exit 1.
> - Default path regression: `redo prove` on `doc/example_architecture/spark_package` (no `packages:` key) behaves exactly as before.
>
> Context: this is the first shortcoming flagged under the "report Adamant SPARK tooling gaps" directive discussed in the skills review; it removes the direct-gnatprove workaround for component-directory proofs.

</details>
