### PR TITLE
Fix empty packet name in flattened packet HTML titles

### DIFF
--- a/gen/generators/assembly.py
+++ b/gen/generators/assembly.py
@@ -305,6 +305,13 @@ class assembly_flattened_packet_html(assembly_generator, generator_base):
                 return out_dir_temp + os.sep + self.packet_name.lower().replace(".", "_") + ".html"
 
             def _generate_output(self, input_filename, packet_model):
+                # The template titles the page with the packet's full name, but
+                # render() builds its jinja context from the model's instance
+                # dictionary, which does not include properties like full_name.
+                # Add it to the instance dictionary explicitly. This does not
+                # shadow the class property for normal attribute access, since
+                # properties are data descriptors.
+                packet_model.__dict__["full_name"] = self.packet_name
                 output = packet_model.render(self.template, self.template_dir)
 
                 # Search output for html dependencies and depend on them:


### PR DESCRIPTION
## Summary

Every per-packet flattened HTML page (e.g. `build/html/<assembly>_packets/<packet>.html`) rendered its title as "** Packet**" with an empty name. The template titles the page with `{{ full_name }}`, but `render()` builds its jinja context from the model's instance dictionary, which does not include Python properties like `full_name`. The generator now provides the full name to the template through the instance dictionary (which does not shadow the class property for normal attribute access, since properties are data descriptors).