### PR TITLE
Make Sys_Time.Assertion safe on coarse-tick runtimes

### DIFF
--- a/src/types/sys_time/subseconds_16/sys_time-assertion.adb
+++ b/src/types/sys_time/subseconds_16/sys_time-assertion.adb
@@ -1,5 +1,4 @@
 with Sys_Time.Arithmetic;
-with Delta_Time.Arithmetic;
 
 -- Smart assert for comparing system times
 -- Useful when you need to use the >, >=, <, and <= operators.
@@ -24,26 +23,33 @@ package body Sys_Time.Assertion is
       end if;
    end Sys_Time_Equal;
 
+   -- Diagnostic text for a failed comparison. The difference and tolerance
+   -- are rendered in seconds via To_Duration.
+   function Failure_Message (T1 : in Sys_Time.T; T2 : in Sys_Time.T; Eps : in Time_Span; Message : in String) return String is
+      ("Difference (s): " & Duration'Image (To_Duration (T1 - T2)) & ASCII.LF &
+          "Eps (s): " & Duration'Image (To_Duration (Eps)) & ASCII.LF & Message);
+
    package body Sys_Time_Assert is
-      procedure Eq (T1 : in Sys_Time.T; T2 : in Sys_Time.T; Eps : in Ada.Real_Time.Time_Span := Ada.Real_Time.Nanoseconds (300); Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line) is
-         use Delta_Time.Arithmetic;
-         Td : Delta_Time.T;
-         Ignore : Sys_Time_Status := To_Delta_Time (Eps, Td);
-         Message_Text : constant String :=
-            "Difference (nsec): " & Integer'Image ((T1 - T2) / Nanoseconds (1)) & ASCII.LF & "eps: (Subseconds: " & Td.Subseconds'Image & " Nanoseconds: " & Integer'Image (Eps / Nanoseconds (1)) & ") " & ASCII.LF & Message;
+      procedure Eq (T1 : in Sys_Time.T; T2 : in Sys_Time.T; Eps : in Ada.Real_Time.Time_Span := Default_Eps; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line) is
       begin
-         -- Check equality using Sys_Time_Equal
-         Sys_Time_Call_Assert (Sys_Time_Equal (T1, T2, Eps), T1, T2, "=", Message_Text, Filename, Line);
+         -- Only construct the diagnostic text when the assertion fails: it is
+         -- not needed on success, and building it eagerly would run the time
+         -- arithmetic on every call.
+         if Sys_Time_Equal (T1, T2, Eps) then
+            Sys_Time_Call_Assert (True, T1, T2, "=", Message, Filename, Line);
+         else
+            Sys_Time_Call_Assert (False, T1, T2, "=", Failure_Message (T1, T2, Eps, Message), Filename, Line);
+         end if;
       end Eq;
-      procedure Neq (T1 : in Sys_Time.T; T2 : in Sys_Time.T; Eps : in Ada.Real_Time.Time_Span := Ada.Real_Time.Nanoseconds (300); Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line) is
-         use Delta_Time.Arithmetic;
-         Td : Delta_Time.T;
-         Ignore : Sys_Time_Status := To_Delta_Time (Eps, Td);
-         Message_Text : constant String :=
-            "Difference (nsec): " & Integer'Image ((T1 - T2) / Nanoseconds (1)) & ASCII.LF & "eps: (Subseconds: " & Td.Subseconds'Image & " Nanoseconds: " & Integer'Image (Eps / Nanoseconds (1)) & ") " & ASCII.LF & Message;
+      procedure Neq (T1 : in Sys_Time.T; T2 : in Sys_Time.T; Eps : in Ada.Real_Time.Time_Span := Default_Eps; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line) is
       begin
-         -- Check equality using Sys_Time_Equal
-         Sys_Time_Call_Assert (not Sys_Time_Equal (T1, T2, Eps), T1, T2, "/=", Message_Text, Filename, Line);
+         -- Only construct the diagnostic text when the assertion fails, as in
+         -- Eq above.
+         if Sys_Time_Equal (T1, T2, Eps) then
+            Sys_Time_Call_Assert (False, T1, T2, "/=", Failure_Message (T1, T2, Eps, Message), Filename, Line);
+         else
+            Sys_Time_Call_Assert (True, T1, T2, "/=", Message, Filename, Line);
+         end if;
       end Neq;
       procedure Gt (T1 : in Sys_Time.T; T2 : in Sys_Time.T; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line) is
       begin

--- a/src/types/sys_time/subseconds_16/sys_time-assertion.ads
+++ b/src/types/sys_time/subseconds_16/sys_time-assertion.ads
@@ -8,9 +8,33 @@ with Sys_Time.Representation;
 package Sys_Time.Assertion is
    package Sinfo renames GNAT.Source_Info;
 
+   use type Ada.Real_Time.Time_Span;
+
+   -- The default tolerance used when comparing two times for (in)equality.
+   -- Two times are considered equal when their difference is less than or
+   -- equal to the tolerance. The default is the largest of:
+   --   1. Half a subsecond LSB - differences below this are representational
+   --      rounding of Sys_Time.T itself, not meaningful time differences.
+   --   2. 300 nanoseconds - allowance for Sys_Time to Ada.Real_Time
+   --      conversion error.
+   --   3. One Time_Span_Unit - the runtime's clock resolution, so the
+   --      tolerance never rounds to zero on targets with a coarse tick.
+   -- Note that Neq with the default tolerance asserts that two times differ
+   -- by MORE than the tolerance.
+   function Time_Span_Max (Left : in Ada.Real_Time.Time_Span; Right : in Ada.Real_Time.Time_Span) return Ada.Real_Time.Time_Span is
+      (if Left > Right then Left else Right);
+   Default_Eps : constant Ada.Real_Time.Time_Span :=
+      Time_Span_Max (
+         Time_Span_Max (
+            Ada.Real_Time.To_Time_Span (Duration (0.5 / Long_Long_Float (Subseconds_Type'Modulus))),
+            Ada.Real_Time.Nanoseconds (300)
+         ),
+         Ada.Real_Time.Time_Span_Unit
+      );
+
    package Sys_Time_Assert is
-      procedure Eq (T1 : in Sys_Time.T; T2 : in Sys_Time.T; Eps : in Ada.Real_Time.Time_Span := Ada.Real_Time.Nanoseconds (300); Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line);
-      procedure Neq (T1 : in Sys_Time.T; T2 : in Sys_Time.T; Eps : in Ada.Real_Time.Time_Span := Ada.Real_Time.Nanoseconds (300); Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line);
+      procedure Eq (T1 : in Sys_Time.T; T2 : in Sys_Time.T; Eps : in Ada.Real_Time.Time_Span := Default_Eps; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line);
+      procedure Neq (T1 : in Sys_Time.T; T2 : in Sys_Time.T; Eps : in Ada.Real_Time.Time_Span := Default_Eps; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line);
       procedure Gt (T1 : in Sys_Time.T; T2 : in Sys_Time.T; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line);
       procedure Ge (T1 : in Sys_Time.T; T2 : in Sys_Time.T; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line);
       procedure Lt (T1 : in Sys_Time.T; T2 : in Sys_Time.T; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line);

--- a/src/types/sys_time/sys_time-assertion.adb
+++ b/src/types/sys_time/sys_time-assertion.adb
@@ -1,5 +1,4 @@
 with Sys_Time.Arithmetic;
-with Delta_Time.Arithmetic;
 
 -- Smart assert for comparing system times
 -- Useful when you need to use the >, >=, <, and <= operators.
@@ -24,26 +23,33 @@ package body Sys_Time.Assertion is
       end if;
    end Sys_Time_Equal;
 
+   -- Diagnostic text for a failed comparison. The difference and tolerance
+   -- are rendered in seconds via To_Duration.
+   function Failure_Message (T1 : in Sys_Time.T; T2 : in Sys_Time.T; Eps : in Time_Span; Message : in String) return String is
+      ("Difference (s): " & Duration'Image (To_Duration (T1 - T2)) & ASCII.LF &
+          "Eps (s): " & Duration'Image (To_Duration (Eps)) & ASCII.LF & Message);
+
    package body Sys_Time_Assert is
-      procedure Eq (T1 : in Sys_Time.T; T2 : in Sys_Time.T; Eps : in Ada.Real_Time.Time_Span := Ada.Real_Time.Nanoseconds (300); Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line) is
-         use Delta_Time.Arithmetic;
-         Td : Delta_Time.T;
-         Ignore : Sys_Time_Status := To_Delta_Time (Eps, Td);
-         Message_Text : constant String :=
-            "Difference (nsec): " & Integer'Image ((T1 - T2) / Nanoseconds (1)) & ASCII.LF & "eps: (Subseconds: " & Td.Subseconds'Image & " Nanoseconds: " & Integer'Image (Eps / Nanoseconds (1)) & ") " & ASCII.LF & Message;
+      procedure Eq (T1 : in Sys_Time.T; T2 : in Sys_Time.T; Eps : in Ada.Real_Time.Time_Span := Default_Eps; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line) is
       begin
-         -- Check equality using Sys_Time_Equal
-         Sys_Time_Call_Assert (Sys_Time_Equal (T1, T2, Eps), T1, T2, "=", Message_Text, Filename, Line);
+         -- Only construct the diagnostic text when the assertion fails: it is
+         -- not needed on success, and building it eagerly would run the time
+         -- arithmetic on every call.
+         if Sys_Time_Equal (T1, T2, Eps) then
+            Sys_Time_Call_Assert (True, T1, T2, "=", Message, Filename, Line);
+         else
+            Sys_Time_Call_Assert (False, T1, T2, "=", Failure_Message (T1, T2, Eps, Message), Filename, Line);
+         end if;
       end Eq;
-      procedure Neq (T1 : in Sys_Time.T; T2 : in Sys_Time.T; Eps : in Ada.Real_Time.Time_Span := Ada.Real_Time.Nanoseconds (300); Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line) is
-         use Delta_Time.Arithmetic;
-         Td : Delta_Time.T;
-         Ignore : Sys_Time_Status := To_Delta_Time (Eps, Td);
-         Message_Text : constant String :=
-            "Difference (nsec): " & Integer'Image ((T1 - T2) / Nanoseconds (1)) & ASCII.LF & "eps: (Subseconds: " & Td.Subseconds'Image & " Nanoseconds: " & Integer'Image (Eps / Nanoseconds (1)) & ") " & ASCII.LF & Message;
+      procedure Neq (T1 : in Sys_Time.T; T2 : in Sys_Time.T; Eps : in Ada.Real_Time.Time_Span := Default_Eps; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line) is
       begin
-         -- Check equality using Sys_Time_Equal
-         Sys_Time_Call_Assert (not Sys_Time_Equal (T1, T2, Eps), T1, T2, "/=", Message_Text, Filename, Line);
+         -- Only construct the diagnostic text when the assertion fails, as in
+         -- Eq above.
+         if Sys_Time_Equal (T1, T2, Eps) then
+            Sys_Time_Call_Assert (False, T1, T2, "/=", Failure_Message (T1, T2, Eps, Message), Filename, Line);
+         else
+            Sys_Time_Call_Assert (True, T1, T2, "/=", Message, Filename, Line);
+         end if;
       end Neq;
       procedure Gt (T1 : in Sys_Time.T; T2 : in Sys_Time.T; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line) is
       begin

--- a/src/types/sys_time/sys_time-assertion.ads
+++ b/src/types/sys_time/sys_time-assertion.ads
@@ -8,9 +8,33 @@ with Sys_Time.Representation;
 package Sys_Time.Assertion is
    package Sinfo renames GNAT.Source_Info;
 
+   use type Ada.Real_Time.Time_Span;
+
+   -- The default tolerance used when comparing two times for (in)equality.
+   -- Two times are considered equal when their difference is less than or
+   -- equal to the tolerance. The default is the largest of:
+   --   1. Half a subsecond LSB - differences below this are representational
+   --      rounding of Sys_Time.T itself, not meaningful time differences.
+   --   2. 300 nanoseconds - allowance for Sys_Time to Ada.Real_Time
+   --      conversion error.
+   --   3. One Time_Span_Unit - the runtime's clock resolution, so the
+   --      tolerance never rounds to zero on targets with a coarse tick.
+   -- Note that Neq with the default tolerance asserts that two times differ
+   -- by MORE than the tolerance.
+   function Time_Span_Max (Left : in Ada.Real_Time.Time_Span; Right : in Ada.Real_Time.Time_Span) return Ada.Real_Time.Time_Span is
+      (if Left > Right then Left else Right);
+   Default_Eps : constant Ada.Real_Time.Time_Span :=
+      Time_Span_Max (
+         Time_Span_Max (
+            Ada.Real_Time.To_Time_Span (Duration (0.5 / Long_Long_Float (Subseconds_Type'Modulus))),
+            Ada.Real_Time.Nanoseconds (300)
+         ),
+         Ada.Real_Time.Time_Span_Unit
+      );
+
    package Sys_Time_Assert is
-      procedure Eq (T1 : in Sys_Time.T; T2 : in Sys_Time.T; Eps : in Ada.Real_Time.Time_Span := Ada.Real_Time.Nanoseconds (300); Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line);
-      procedure Neq (T1 : in Sys_Time.T; T2 : in Sys_Time.T; Eps : in Ada.Real_Time.Time_Span := Ada.Real_Time.Nanoseconds (300); Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line);
+      procedure Eq (T1 : in Sys_Time.T; T2 : in Sys_Time.T; Eps : in Ada.Real_Time.Time_Span := Default_Eps; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line);
+      procedure Neq (T1 : in Sys_Time.T; T2 : in Sys_Time.T; Eps : in Ada.Real_Time.Time_Span := Default_Eps; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line);
       procedure Gt (T1 : in Sys_Time.T; T2 : in Sys_Time.T; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line);
       procedure Ge (T1 : in Sys_Time.T; T2 : in Sys_Time.T; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line);
       procedure Lt (T1 : in Sys_Time.T; T2 : in Sys_Time.T; Message : in String := ""; Filename : in String := Sinfo.File; Line : in Natural := Sinfo.Line);


### PR DESCRIPTION
## Summary

`Sys_Time_Assert.Eq`/`Neq` raise `CONSTRAINT_ERROR` on every call on embedded cross targets, even when the compared times are equal. Found via a renode (RV32) unit test in adamant-xmera-components (lasp/adamant-xmera-components#43): the first test there to call `Sys_Time_Assert.Eq` on the cross target died with an unexplained `CONSTRAINT_ERROR`.

Two defects, both fixed:

1. **Eager message construction.** The diagnostic text was built as a declaration, so its arithmetic ran even when the assertion passed. The text is now constructed only in the failure branch (the assert call itself is preserved on both paths so AUnit's assertion accounting is unchanged).

2. **Target-dependent unit conversion.** The text rendered the difference as `(T1 - T2) / Nanoseconds (1)`. Per the RM, `Nanoseconds` rounds to the nearest multiple of `Time_Span_Unit`, so on any runtime with a tick coarser than 1 ns it returns a zero span and the division raises `CONSTRAINT_ERROR`. (`Eps / Nanoseconds (1)` on the next line had the same bug.) The difference and tolerance are now rendered in seconds via `Duration'Image (To_Duration (...))`, which constructs no `Time_Span` and cannot overflow for any representable span — unlike an integer-nanoseconds rendering via `To_Duration (...) * 1e9`, which overflows for differences over ~9.2 s.

Additionally, the default tolerance is now derived from the type instead of the bare `Nanoseconds (300)`: the largest of

- **half a subsecond LSB** — differences below this are representational rounding of `Sys_Time.T` itself,
- **300 ns** — the historical conversion-error allowance, preserved as a floor so no existing test gets a tighter default,
- **one `Time_Span_Unit`** — so the tolerance never rounds to zero on coarse-tick targets (previously the 300 ns default silently degraded to exact-match there).

For the base (1/2^32 subseconds) variant the default is unchanged at 300 ns. For subseconds_16 it widens to half a tick (~7.6 µs), which only affects `Eq` in the passing direction; the repo has no `Neq` call sites relying on the default.

Both variants' spec/body files remain byte-identical to each other.