### PR TITLE
Convert the Stopwatch packages to SPARK, proven at gold level

### DIFF
--- a/src/types/sys_time/arithmetic/delta_time-arithmetic.adb
+++ b/src/types/sys_time/arithmetic/delta_time-arithmetic.adb
@@ -18,6 +18,11 @@ package body Delta_Time.Arithmetic is
       -- Convert from time to Sys_Time
       Status : Sys_Time_Status;
    begin
+      -- Give the output a defined zero value up front so that it is fully
+      -- assigned on every path, including the Constraint_Error handler
+      -- below:
+      Arg_Out := Zero_Delta_Time;
+
       if Arg_In = Time_Span_First then
          -- Special case for Time_Span_First, which would overflow abs if made positive. In this
          -- case we round to the nearest positive time span value.
@@ -31,14 +36,20 @@ package body Delta_Time.Arithmetic is
       -- Convert from time to Sys_Time
       Status := To_Sys_Time (The_Time, Out_Time);
 
-      if Status = Success then
-         -- Convert to Delta_Time and return status
-         Arg_Out := Sys_Time_To_Delta_Time (Out_Time);
-      end if;
+      -- To_Sys_Time always assigns its output, saturating at the minimum
+      -- and maximum representable times on underflow and overflow, so the
+      -- (possibly saturated) value is copied out unconditionally alongside
+      -- the status:
+      Arg_Out := Sys_Time_To_Delta_Time (Out_Time);
 
       return Status;
    exception
       when Constraint_Error => return Overflow;
+   end To_Delta_Time;
+
+   procedure To_Delta_Time (Arg_In : in Time_Span; Arg_Out : out Delta_Time.T; Status : out Sys_Time.Arithmetic.Sys_Time_Status) is
+   begin
+      Status := To_Delta_Time (Arg_In, Arg_Out);
    end To_Delta_Time;
 
    -- Convert a Delta_Time to an Ada.Real_Time.Time_Span

--- a/src/types/sys_time/arithmetic/delta_time-arithmetic.ads
+++ b/src/types/sys_time/arithmetic/delta_time-arithmetic.ads
@@ -11,6 +11,12 @@ package Delta_Time.Arithmetic is
    -- Convert an Ada.Real_Time.Time_Span to a Delta_Time
    function To_Delta_Time (Arg_In : in Time_Span; Arg_Out : out Delta_Time.T) return Sys_Time.Arithmetic.Sys_Time_Status;
 
+   -- Procedure form of the above. A function with an out parameter is not
+   -- callable from SPARK code (it is a function with side effects), so SPARK
+   -- callers use this form instead:
+   procedure To_Delta_Time (Arg_In : in Time_Span; Arg_Out : out Delta_Time.T; Status : out Sys_Time.Arithmetic.Sys_Time_Status)
+      with Global => null, Always_Terminates => True;
+
    -- Convert a Delta_Time to an Ada.Real_Time.Time_Span
    function To_Time_Span (Arg : in Delta_Time.T) return Time_Span;
 

--- a/src/util/stopwatch/stopwatch-reporter.adb
+++ b/src/util/stopwatch/stopwatch-reporter.adb
@@ -1,11 +1,16 @@
 with Delta_Time.Arithmetic;
 with Sys_Time.Arithmetic;
 
-package body Stopwatch.Reporter is
+package body Stopwatch.Reporter with SPARK_Mode => On is
 
    procedure Start (Self : in out Instance) is
+      -- SPARK requires a volatile function like Clock to be read into an
+      -- object directly rather than passed as an actual. The wall time is
+      -- sampled before the CPU timer starts, preserving the wall-first
+      -- ordering:
+      Now : constant Ada.Real_Time.Time := Ada.Real_Time.Clock;
    begin
-      Self.Start (Wall_Start_Time => Ada.Real_Time.Clock);
+      Self.Start (Wall_Start_Time => Now);
    end Start;
 
    procedure Start (Self : in out Instance; Wall_Start_Time : in Ada.Real_Time.Time) is
@@ -17,9 +22,15 @@ package body Stopwatch.Reporter is
    procedure Stop (Self : in out Instance) is
    begin
       -- Stop the CPU timer first so the wall clock read below is excluded
-      -- from the CPU measurement:
+      -- from the CPU measurement. SPARK requires a volatile function like
+      -- Clock to be read into an object directly rather than passed as an
+      -- actual, so the read gets a declare block after the CPU stop:
       Self.Stop_Cpu_Timer;
-      Self.Stop_Wall_Timer (Wall_Stop_Time => Ada.Real_Time.Clock);
+      declare
+         Now : constant Ada.Real_Time.Time := Ada.Real_Time.Clock;
+      begin
+         Self.Stop_Wall_Timer (Wall_Stop_Time => Now);
+      end;
    end Stop;
 
    procedure Stop (Self : in out Instance; Wall_Stop_Time : in Ada.Real_Time.Time) is
@@ -72,12 +83,14 @@ package body Stopwatch.Reporter is
    function To_Report (Max_Wall_Time : in Ada.Real_Time.Time_Span; Max_Execution_Time : in Ada.Real_Time.Time_Span; Recent_Wall_Time : in Ada.Real_Time.Time_Span; Recent_Execution_Time : in Ada.Real_Time.Time_Span) return Task_Timing_Report.T is
       use Delta_Time.Arithmetic;
       To_Return : Task_Timing_Report.T;
+      -- The conversion saturates on overflow; the status is intentionally
+      -- not consulted:
       Ignore : Sys_Time.Arithmetic.Sys_Time_Status;
    begin
-      Ignore := To_Delta_Time (Max_Wall_Time, To_Return.Max.Wall_Time);
-      Ignore := To_Delta_Time (Max_Execution_Time, To_Return.Max.Execution_Time);
-      Ignore := To_Delta_Time (Recent_Wall_Time, To_Return.Recent_Max.Wall_Time);
-      Ignore := To_Delta_Time (Recent_Execution_Time, To_Return.Recent_Max.Execution_Time);
+      To_Delta_Time (Max_Wall_Time, To_Return.Max.Wall_Time, Ignore);
+      To_Delta_Time (Max_Execution_Time, To_Return.Max.Execution_Time, Ignore);
+      To_Delta_Time (Recent_Wall_Time, To_Return.Recent_Max.Wall_Time, Ignore);
+      To_Delta_Time (Recent_Execution_Time, To_Return.Recent_Max.Execution_Time, Ignore);
       return To_Return;
    end To_Report;
 
@@ -94,7 +107,7 @@ package body Stopwatch.Reporter is
       Self.Recent_Max_Execution_Time := Time_Span_Zero;
    end Reset_Recent_Max;
 
-   procedure Reset (Self : in out Instance) is
+   procedure Reset (Self : out Instance) is
    begin
       Self := (others => <>);
    end Reset;

--- a/src/util/stopwatch/stopwatch-reporter.adb
+++ b/src/util/stopwatch/stopwatch-reporter.adb
@@ -62,7 +62,12 @@ package body Stopwatch.Reporter with SPARK_Mode => On is
 
       -- Fold a measured value into a recent-maximum and maximum pair,
       -- reporting whether the maximum was updated:
-      procedure Update_Maximums (Value : in Time_Span; Recent_Max : in out Time_Span; Max : in out Time_Span; Updated : out Boolean) is
+      procedure Update_Maximums (Value : in Time_Span; Recent_Max : in out Time_Span; Max : in out Time_Span; Updated : out Boolean)
+         with Global => null,
+              Post => Recent_Max = (if Value > Recent_Max'Old then Value else Recent_Max'Old) and then
+                      Max = (if Value > Max'Old then Value else Max'Old) and then
+                      Updated = (Value > Max'Old)
+      is
       begin
          Updated := False;
          if Value > Recent_Max then

--- a/src/util/stopwatch/stopwatch-reporter.ads
+++ b/src/util/stopwatch/stopwatch-reporter.ads
@@ -1,11 +1,12 @@
 with Task_Timing_Report;
+with Ada.Task_Identification;
 
 -- A paired wall-clock and CPU-execution stopwatch for timing a section of
 -- code. The reporter accumulates recent-maximum and all-time-maximum (high
 -- water mark) values for both timers, and produces reports of the
 -- accumulated values as a Task_Timing_Report.T, suitable for publishing as
 -- a data product.
-package Stopwatch.Reporter is
+package Stopwatch.Reporter with SPARK_Mode => On is
 
    type Instance is tagged record
       -- The underlying stopwatch pair. These are exposed so that users may
@@ -26,48 +27,60 @@ package Stopwatch.Reporter is
    -- Start both the wall and CPU timers now. The wall timer is started
    -- first, so that the timing bookkeeping itself is excluded from the CPU
    -- measurement:
-   procedure Start (Self : in out Instance);
+   procedure Start (Self : in out Instance)
+      with Global => (Input => (Ada.Real_Time.Clock_Time, Ada.Task_Identification.Tasking_State));
    -- Start both timers, with the wall timer's start time supplied by the
    -- caller instead of read from the clock. This is useful to backdate the
    -- wall measurement, for example to the timestamp of an incoming tick so
    -- that queue latency is included in the measurement:
-   procedure Start (Self : in out Instance; Wall_Start_Time : in Ada.Real_Time.Time);
+   procedure Start (Self : in out Instance; Wall_Start_Time : in Ada.Real_Time.Time)
+      with Global => (Input => (Ada.Real_Time.Clock_Time, Ada.Task_Identification.Tasking_State));
    -- Stop both timers now and store the measurement results. The CPU timer
    -- is stopped first, so that the timing bookkeeping itself is excluded
    -- from the CPU measurement:
-   procedure Stop (Self : in out Instance);
+   procedure Stop (Self : in out Instance)
+      with Global => (Input => (Ada.Real_Time.Clock_Time, Ada.Task_Identification.Tasking_State));
    -- Stop both timers, with the wall timer's stop time supplied by the
    -- caller instead of read from the clock. Note that the provided wall stop
    -- time is necessarily acquired before the CPU timer stops; if that
    -- acquisition is expensive, use the split subprograms below instead:
-   procedure Stop (Self : in out Instance; Wall_Stop_Time : in Ada.Real_Time.Time);
+   procedure Stop (Self : in out Instance; Wall_Stop_Time : in Ada.Real_Time.Time)
+      with Global => (Input => (Ada.Real_Time.Clock_Time, Ada.Task_Identification.Tasking_State));
    -- The two halves of Stop, exposed so that the CPU timer can be stopped
    -- before the wall clock stop time is acquired, when that acquisition is
    -- itself expensive (e.g. a system time fetched through a connector). Call
    -- Stop_Cpu_Timer first, acquire the wall stop time, and then call
    -- Stop_Wall_Timer. Each stops its timer and stores that timer's
    -- measurement result:
-   procedure Stop_Cpu_Timer (Self : in out Instance);
-   procedure Stop_Wall_Timer (Self : in out Instance; Wall_Stop_Time : in Ada.Real_Time.Time);
+   procedure Stop_Cpu_Timer (Self : in out Instance)
+      with Global => (Input => (Ada.Real_Time.Clock_Time, Ada.Task_Identification.Tasking_State));
+   procedure Stop_Wall_Timer (Self : in out Instance; Wall_Stop_Time : in Ada.Real_Time.Time)
+      with Global => null;
    -- Fold the results of the most recent Stop into the recent-maximum and
    -- maximum accumulators:
-   procedure Accumulate (Self : in out Instance);
+   procedure Accumulate (Self : in out Instance)
+      with Global => null;
    -- Same as above, but additionally reports whether either all-time maximum
    -- value was updated, which is useful for issuing time-exceeded events:
-   procedure Accumulate (Self : in out Instance; Max_Wall_Time_Updated : out Boolean; Max_Execution_Time_Updated : out Boolean);
+   procedure Accumulate (Self : in out Instance; Max_Wall_Time_Updated : out Boolean; Max_Execution_Time_Updated : out Boolean)
+      with Global => null;
    -- Produce a report of the currently accumulated values:
-   function Report (Self : in Instance) return Task_Timing_Report.T;
+   function Report (Self : in Instance) return Task_Timing_Report.T
+      with Global => null;
    -- Produce a report with the Recent_Max fields holding the results of the
    -- most recent Stop instead of the recent maximums. This is useful for
    -- per-operation reporting, where each report carries the timing of the
    -- operation just performed alongside the all-time maximums:
-   function Report_Last (Self : in Instance) return Task_Timing_Report.T;
+   function Report_Last (Self : in Instance) return Task_Timing_Report.T
+      with Global => null;
    -- Reset only the recent-maximum values. This is intended to be called
    -- after each report is published so that the recent maximums cover a
    -- single reporting period:
-   procedure Reset_Recent_Max (Self : in out Instance);
+   procedure Reset_Recent_Max (Self : in out Instance)
+      with Global => null;
    -- Reset all stored values, including the all-time maximums. Any
    -- in-progress measurement (a Start without a Stop) is also discarded:
-   procedure Reset (Self : in out Instance);
+   procedure Reset (Self : out Instance)
+      with Global => null;
 
 end Stopwatch.Reporter;

--- a/src/util/stopwatch/stopwatch-reporter.ads
+++ b/src/util/stopwatch/stopwatch-reporter.ads
@@ -8,6 +8,8 @@ with Ada.Task_Identification;
 -- a data product.
 package Stopwatch.Reporter with SPARK_Mode => On is
 
+   use type Ada.Real_Time.Time_Span;
+
    type Instance is tagged record
       -- The underlying stopwatch pair. These are exposed so that users may
       -- manipulate the start and stop times directly for cases the Start and
@@ -24,28 +26,60 @@ package Stopwatch.Reporter with SPARK_Mode => On is
       Max_Execution_Time : Ada.Real_Time.Time_Span := Ada.Real_Time.Time_Span_Zero;
    end record;
 
+   -- Ghost predicates used to express the postconditions below. Ghost code
+   -- is for proof only; it is not compiled into the executable. Ada requires
+   -- these to be declared before the contracts that reference them; their
+   -- definitions are tucked away in the private part at the bottom of this
+   -- file:
+   function Results_Unchanged (Left : in Instance; Right : in Instance) return Boolean with Ghost;
+   function Accumulators_Unchanged (Left : in Instance; Right : in Instance) return Boolean with Ghost;
+   function Recent_Max_Is_Zero (Self : in Instance) return Boolean with Ghost;
+   function Is_Reset (Self : in Instance) return Boolean with Ghost;
+   function Recent_Max_Reset (Result : in Instance; Prior : in Instance) return Boolean with Ghost;
+   function Maximums_Accumulated (Result : in Instance; Prior : in Instance) return Boolean with Ghost;
+
    -- Start both the wall and CPU timers now. The wall timer is started
    -- first, so that the timing bookkeeping itself is excluded from the CPU
    -- measurement:
    procedure Start (Self : in out Instance)
-      with Global => (Input => (Ada.Real_Time.Clock_Time, Ada.Task_Identification.Tasking_State));
+      with Global => (Input => (Ada.Real_Time.Clock_Time, Ada.Task_Identification.Tasking_State)),
+           Post => Results_Unchanged (Self, Self'Old) and then
+                   Accumulators_Unchanged (Self, Self'Old) and then
+                   Self.Wall_Timer.Stop_Time = Self.Wall_Timer.Stop_Time'Old and then
+                   Self.Cpu_Timer.Stop_Time = Self.Cpu_Timer.Stop_Time'Old;
    -- Start both timers, with the wall timer's start time supplied by the
    -- caller instead of read from the clock. This is useful to backdate the
    -- wall measurement, for example to the timestamp of an incoming tick so
    -- that queue latency is included in the measurement:
    procedure Start (Self : in out Instance; Wall_Start_Time : in Ada.Real_Time.Time)
-      with Global => (Input => (Ada.Real_Time.Clock_Time, Ada.Task_Identification.Tasking_State));
+      with Global => (Input => (Ada.Real_Time.Clock_Time, Ada.Task_Identification.Tasking_State)),
+           Post => Results_Unchanged (Self, Self'Old) and then
+                   Accumulators_Unchanged (Self, Self'Old) and then
+                   Self.Wall_Timer.Start_Time = Wall_Start_Time and then
+                   Self.Wall_Timer.Stop_Time = Self.Wall_Timer.Stop_Time'Old and then
+                   Self.Cpu_Timer.Stop_Time = Self.Cpu_Timer.Stop_Time'Old;
    -- Stop both timers now and store the measurement results. The CPU timer
    -- is stopped first, so that the timing bookkeeping itself is excluded
    -- from the CPU measurement:
    procedure Stop (Self : in out Instance)
-      with Global => (Input => (Ada.Real_Time.Clock_Time, Ada.Task_Identification.Tasking_State));
+      with Global => (Input => (Ada.Real_Time.Clock_Time, Ada.Task_Identification.Tasking_State)),
+           Post => Accumulators_Unchanged (Self, Self'Old) and then
+                   Self.Last_Wall_Time = Self.Wall_Timer.Result and then
+                   Self.Last_Execution_Time = Self.Cpu_Timer.Result and then
+                   Self.Wall_Timer.Start_Time = Self.Wall_Timer.Start_Time'Old and then
+                   Self.Cpu_Timer.Start_Time = Self.Cpu_Timer.Start_Time'Old;
    -- Stop both timers, with the wall timer's stop time supplied by the
    -- caller instead of read from the clock. Note that the provided wall stop
    -- time is necessarily acquired before the CPU timer stops; if that
    -- acquisition is expensive, use the split subprograms below instead:
    procedure Stop (Self : in out Instance; Wall_Stop_Time : in Ada.Real_Time.Time)
-      with Global => (Input => (Ada.Real_Time.Clock_Time, Ada.Task_Identification.Tasking_State));
+      with Global => (Input => (Ada.Real_Time.Clock_Time, Ada.Task_Identification.Tasking_State)),
+           Post => Accumulators_Unchanged (Self, Self'Old) and then
+                   Self.Wall_Timer.Stop_Time = Wall_Stop_Time and then
+                   Self.Last_Wall_Time = Self.Wall_Timer.Result and then
+                   Self.Last_Execution_Time = Self.Cpu_Timer.Result and then
+                   Self.Wall_Timer.Start_Time = Self.Wall_Timer.Start_Time'Old and then
+                   Self.Cpu_Timer.Start_Time = Self.Cpu_Timer.Start_Time'Old;
    -- The two halves of Stop, exposed so that the CPU timer can be stopped
    -- before the wall clock stop time is acquired, when that acquisition is
    -- itself expensive (e.g. a system time fetched through a connector). Call
@@ -53,17 +87,33 @@ package Stopwatch.Reporter with SPARK_Mode => On is
    -- Stop_Wall_Timer. Each stops its timer and stores that timer's
    -- measurement result:
    procedure Stop_Cpu_Timer (Self : in out Instance)
-      with Global => (Input => (Ada.Real_Time.Clock_Time, Ada.Task_Identification.Tasking_State));
+      with Global => (Input => (Ada.Real_Time.Clock_Time, Ada.Task_Identification.Tasking_State)),
+           Post => Accumulators_Unchanged (Self, Self'Old) and then
+                   Self.Last_Execution_Time = Self.Cpu_Timer.Result and then
+                   Self.Cpu_Timer.Start_Time = Self.Cpu_Timer.Start_Time'Old and then
+                   Self.Wall_Timer = Self.Wall_Timer'Old and then
+                   Self.Last_Wall_Time = Self.Last_Wall_Time'Old;
    procedure Stop_Wall_Timer (Self : in out Instance; Wall_Stop_Time : in Ada.Real_Time.Time)
-      with Global => null;
+      with Global => null,
+           Post => Accumulators_Unchanged (Self, Self'Old) and then
+                   Self.Wall_Timer.Stop_Time = Wall_Stop_Time and then
+                   Self.Last_Wall_Time = Self.Wall_Timer.Result and then
+                   Self.Wall_Timer.Start_Time = Self.Wall_Timer.Start_Time'Old and then
+                   Self.Cpu_Timer = Self.Cpu_Timer'Old and then
+                   Self.Last_Execution_Time = Self.Last_Execution_Time'Old;
    -- Fold the results of the most recent Stop into the recent-maximum and
-   -- maximum accumulators:
+   -- maximum accumulators. The max-folding math is captured by the
+   -- Maximums_Accumulated ghost predicate defined in the private part:
    procedure Accumulate (Self : in out Instance)
-      with Global => null;
+      with Global => null,
+           Post => Maximums_Accumulated (Self, Self'Old);
    -- Same as above, but additionally reports whether either all-time maximum
    -- value was updated, which is useful for issuing time-exceeded events:
    procedure Accumulate (Self : in out Instance; Max_Wall_Time_Updated : out Boolean; Max_Execution_Time_Updated : out Boolean)
-      with Global => null;
+      with Global => null,
+           Post => Maximums_Accumulated (Self, Self'Old) and then
+                   Max_Wall_Time_Updated = (Self.Last_Wall_Time > Self'Old.Max_Wall_Time) and then
+                   Max_Execution_Time_Updated = (Self.Last_Execution_Time > Self'Old.Max_Execution_Time);
    -- Produce a report of the currently accumulated values:
    function Report (Self : in Instance) return Task_Timing_Report.T
       with Global => null;
@@ -77,10 +127,71 @@ package Stopwatch.Reporter with SPARK_Mode => On is
    -- after each report is published so that the recent maximums cover a
    -- single reporting period:
    procedure Reset_Recent_Max (Self : in out Instance)
-      with Global => null;
+      with Global => null,
+           Post => Recent_Max_Reset (Self, Self'Old);
    -- Reset all stored values, including the all-time maximums. Any
    -- in-progress measurement (a Start without a Stop) is also discarded:
    procedure Reset (Self : out Instance)
-      with Global => null;
+      with Global => null,
+           Post => Is_Reset (Self);
+
+private
+
+   -- Definitions of the ghost predicates declared above.
+   --
+   -- The stored results of the most recent Stop are the same in both
+   -- instances:
+   function Results_Unchanged (Left : in Instance; Right : in Instance) return Boolean is
+      (Left.Last_Wall_Time = Right.Last_Wall_Time and then
+       Left.Last_Execution_Time = Right.Last_Execution_Time);
+
+   -- The accumulated recent-maximum and maximum values are the same in both
+   -- instances:
+   function Accumulators_Unchanged (Left : in Instance; Right : in Instance) return Boolean is
+      (Left.Recent_Max_Wall_Time = Right.Recent_Max_Wall_Time and then
+       Left.Max_Wall_Time = Right.Max_Wall_Time and then
+       Left.Recent_Max_Execution_Time = Right.Recent_Max_Execution_Time and then
+       Left.Max_Execution_Time = Right.Max_Execution_Time);
+
+   -- Both recent-maximum values are zero:
+   function Recent_Max_Is_Zero (Self : in Instance) return Boolean is
+      (Self.Recent_Max_Wall_Time = Ada.Real_Time.Time_Span_Zero and then
+       Self.Recent_Max_Execution_Time = Ada.Real_Time.Time_Span_Zero);
+
+   -- Every field holds its default (freshly initialized) value:
+   function Is_Reset (Self : in Instance) return Boolean is
+      (Self.Wall_Timer.Start_Time = Ada.Real_Time.Time_First and then
+       Self.Wall_Timer.Stop_Time = Ada.Real_Time.Time_First and then
+       Self.Cpu_Timer.Start_Time = Ada.Execution_Time.CPU_Time_First and then
+       Self.Cpu_Timer.Stop_Time = Ada.Execution_Time.CPU_Time_First and then
+       Self.Last_Wall_Time = Ada.Real_Time.Time_Span_Zero and then
+       Self.Last_Execution_Time = Ada.Real_Time.Time_Span_Zero and then
+       Self.Recent_Max_Wall_Time = Ada.Real_Time.Time_Span_Zero and then
+       Self.Max_Wall_Time = Ada.Real_Time.Time_Span_Zero and then
+       Self.Recent_Max_Execution_Time = Ada.Real_Time.Time_Span_Zero and then
+       Self.Max_Execution_Time = Ada.Real_Time.Time_Span_Zero);
+
+   -- Result is Prior with both recent-maximum values reset to zero and
+   -- every other field unchanged:
+   function Recent_Max_Reset (Result : in Instance; Prior : in Instance) return Boolean is
+      (Recent_Max_Is_Zero (Result) and then
+       Results_Unchanged (Result, Prior) and then
+       Result.Wall_Timer = Prior.Wall_Timer and then
+       Result.Cpu_Timer = Prior.Cpu_Timer and then
+       Result.Max_Wall_Time = Prior.Max_Wall_Time and then
+       Result.Max_Execution_Time = Prior.Max_Execution_Time);
+
+   -- Result is Prior with the most recent measurement folded into the
+   -- recent-maximum and maximum accumulators: each maximum becomes the
+   -- larger of its prior value and the measurement, and nothing else
+   -- changes:
+   function Maximums_Accumulated (Result : in Instance; Prior : in Instance) return Boolean is
+      (Results_Unchanged (Result, Prior) and then
+       Result.Wall_Timer = Prior.Wall_Timer and then
+       Result.Cpu_Timer = Prior.Cpu_Timer and then
+       Result.Recent_Max_Wall_Time = (if Result.Last_Wall_Time > Prior.Recent_Max_Wall_Time then Result.Last_Wall_Time else Prior.Recent_Max_Wall_Time) and then
+       Result.Max_Wall_Time = (if Result.Last_Wall_Time > Prior.Max_Wall_Time then Result.Last_Wall_Time else Prior.Max_Wall_Time) and then
+       Result.Recent_Max_Execution_Time = (if Result.Last_Execution_Time > Prior.Recent_Max_Execution_Time then Result.Last_Execution_Time else Prior.Recent_Max_Execution_Time) and then
+       Result.Max_Execution_Time = (if Result.Last_Execution_Time > Prior.Max_Execution_Time then Result.Last_Execution_Time else Prior.Max_Execution_Time));
 
 end Stopwatch.Reporter;

--- a/src/util/stopwatch/stopwatch.adb
+++ b/src/util/stopwatch/stopwatch.adb
@@ -1,20 +1,50 @@
-package body Stopwatch is
+package body Stopwatch with SPARK_Mode => On is
+
+   use type Ada.Task_Identification.Task_Id;
+
+   -- Read the CPU-execution clock for the calling task. SPARK only permits
+   -- a call to a volatile function (one whose result depends on external
+   -- state, like a clock) as the sole initializer of a standalone object,
+   -- so the subprograms below read the clock as "Now : constant ... :="
+   -- and copy from there; this also pins down exactly when the clock is
+   -- sampled. Current_Task is read into a constant first for the same
+   -- reason: letting it evaluate as Ada.Execution_Time.Clock's default
+   -- parameter would place a volatile function call in an interfering
+   -- context (SPARK RM 7.1.3(9)):
+   function Cpu_Now return Ada.Execution_Time.CPU_Time
+      with Inline => True, Volatile_Function, Global => (Input => (Ada.Real_Time.Clock_Time, Ada.Task_Identification.Tasking_State))
+   is
+      Id : constant Ada.Task_Identification.Task_Id := Ada.Task_Identification.Current_Task;
+      pragma Assume (Id /= Ada.Task_Identification.Null_Task_Id,
+         "Current_Task returns the identity of the calling task, which is never the null id (Ada RM C.7.1).");
+      Now : constant Ada.Execution_Time.CPU_Time := Ada.Execution_Time.Clock (Id);
+   begin
+      return Now;
+   end Cpu_Now;
 
    function Start return Cpu_Timer_Instance is
       To_Return : Cpu_Timer_Instance;
    begin
-      To_Return.Start_Time := Ada.Execution_Time.Clock;
+      To_Return.Start;
       return To_Return;
    end Start;
 
    procedure Start (Self : in out Cpu_Timer_Instance) is
+      -- SPARK only permits a call to a volatile function like a clock read
+      -- as the sole initializer of a standalone object, so the time is read
+      -- into a constant and copied from there:
+      Now : constant Ada.Execution_Time.CPU_Time := Cpu_Now;
    begin
-      Self.Start_Time := Ada.Execution_Time.Clock;
+      Self.Start_Time := Now;
    end Start;
 
    procedure Stop (Self : in out Cpu_Timer_Instance) is
+      -- SPARK only permits a call to a volatile function like a clock read
+      -- as the sole initializer of a standalone object, so the time is read
+      -- into a constant and copied from there:
+      Now : constant Ada.Execution_Time.CPU_Time := Cpu_Now;
    begin
-      Self.Stop_Time := Ada.Execution_Time.Clock;
+      Self.Stop_Time := Now;
    end Stop;
 
    function Result (Self : in Cpu_Timer_Instance) return Ada.Real_Time.Time_Span is
@@ -26,24 +56,38 @@ package body Stopwatch is
    function Start return Wall_Timer_Instance is
       To_Return : Wall_Timer_Instance;
    begin
-      To_Return.Start_Time := Ada.Real_Time.Clock;
+      To_Return.Start;
       return To_Return;
    end Start;
 
    procedure Start (Self : in out Wall_Timer_Instance) is
+      -- SPARK only permits a call to a volatile function like a clock read
+      -- as the sole initializer of a standalone object, so the time is read
+      -- into a constant and copied from there:
+      Now : constant Ada.Real_Time.Time := Ada.Real_Time.Clock;
    begin
-      Self.Start_Time := Ada.Real_Time.Clock;
+      Self.Start_Time := Now;
    end Start;
 
    procedure Stop (Self : in out Wall_Timer_Instance) is
+      -- SPARK only permits a call to a volatile function like a clock read
+      -- as the sole initializer of a standalone object, so the time is read
+      -- into a constant and copied from there:
+      Now : constant Ada.Real_Time.Time := Ada.Real_Time.Clock;
    begin
-      Self.Stop_Time := Ada.Real_Time.Clock;
+      Self.Stop_Time := Now;
    end Stop;
 
    function Result (Self : in Wall_Timer_Instance) return Ada.Real_Time.Time_Span is
       use Ada.Real_Time;
    begin
       return Self.Stop_Time - Self.Start_Time;
+      pragma Annotate (GNATprove, Intentional, "range check",
+         "Time and Time_Span are both 64-bit under GNAT, so there is no wider type to subtract in, and the difference of two arbitrary "
+         & "Times can mathematically exceed the Time_Span bounds; the prover reasons over the full type ranges, so the check is "
+         & "unprovable without constraining the inputs, which callers (whose stamps come from the clock) could not discharge either. "
+         & "Both stamps here are reads of the same monotonic clock taken within a single mission runtime; overflowing this "
+         & "subtraction would take two stamps ~292 years apart at nanosecond resolution.");
    end Result;
 
 end Stopwatch;

--- a/src/util/stopwatch/stopwatch.ads
+++ b/src/util/stopwatch/stopwatch.ads
@@ -1,24 +1,33 @@
 with Ada.Execution_Time;
 with Ada.Real_Time;
+with Ada.Task_Identification;
 
-package Stopwatch is
+package Stopwatch with SPARK_Mode => On is
 
    type Cpu_Timer_Instance is tagged record
       Start_Time, Stop_Time : Ada.Execution_Time.CPU_Time := Ada.Execution_Time.CPU_Time_First;
    end record;
 
-   function Start return Cpu_Timer_Instance;
-   procedure Start (Self : in out Cpu_Timer_Instance);
-   procedure Stop (Self : in out Cpu_Timer_Instance);
-   function Result (Self : in Cpu_Timer_Instance) return Ada.Real_Time.Time_Span;
+   function Start return Cpu_Timer_Instance
+      with Volatile_Function, Global => (Input => (Ada.Real_Time.Clock_Time, Ada.Task_Identification.Tasking_State));
+   procedure Start (Self : in out Cpu_Timer_Instance)
+      with Global => (Input => (Ada.Real_Time.Clock_Time, Ada.Task_Identification.Tasking_State));
+   procedure Stop (Self : in out Cpu_Timer_Instance)
+      with Global => (Input => (Ada.Real_Time.Clock_Time, Ada.Task_Identification.Tasking_State));
+   function Result (Self : in Cpu_Timer_Instance) return Ada.Real_Time.Time_Span
+      with Global => null;
 
    type Wall_Timer_Instance is tagged record
       Start_Time, Stop_Time : Ada.Real_Time.Time := Ada.Real_Time.Time_First;
    end record;
 
-   function Start return Wall_Timer_Instance;
-   procedure Start (Self : in out Wall_Timer_Instance);
-   procedure Stop (Self : in out Wall_Timer_Instance);
-   function Result (Self : in Wall_Timer_Instance) return Ada.Real_Time.Time_Span;
+   function Start return Wall_Timer_Instance
+      with Volatile_Function, Global => Ada.Real_Time.Clock_Time;
+   procedure Start (Self : in out Wall_Timer_Instance)
+      with Global => Ada.Real_Time.Clock_Time;
+   procedure Stop (Self : in out Wall_Timer_Instance)
+      with Global => Ada.Real_Time.Clock_Time;
+   function Result (Self : in Wall_Timer_Instance) return Ada.Real_Time.Time_Span
+      with Global => null;
 
 end Stopwatch;

--- a/src/util/stopwatch/stopwatch.ads
+++ b/src/util/stopwatch/stopwatch.ads
@@ -4,16 +4,22 @@ with Ada.Task_Identification;
 
 package Stopwatch with SPARK_Mode => On is
 
+   use type Ada.Execution_Time.CPU_Time;
+   use type Ada.Real_Time.Time;
+
    type Cpu_Timer_Instance is tagged record
       Start_Time, Stop_Time : Ada.Execution_Time.CPU_Time := Ada.Execution_Time.CPU_Time_First;
    end record;
 
    function Start return Cpu_Timer_Instance
-      with Volatile_Function, Global => (Input => (Ada.Real_Time.Clock_Time, Ada.Task_Identification.Tasking_State));
+      with Volatile_Function, Global => (Input => (Ada.Real_Time.Clock_Time, Ada.Task_Identification.Tasking_State)),
+           Post => Start'Result.Stop_Time = Ada.Execution_Time.CPU_Time_First;
    procedure Start (Self : in out Cpu_Timer_Instance)
-      with Global => (Input => (Ada.Real_Time.Clock_Time, Ada.Task_Identification.Tasking_State));
+      with Global => (Input => (Ada.Real_Time.Clock_Time, Ada.Task_Identification.Tasking_State)),
+           Post => Self.Stop_Time = Self.Stop_Time'Old;
    procedure Stop (Self : in out Cpu_Timer_Instance)
-      with Global => (Input => (Ada.Real_Time.Clock_Time, Ada.Task_Identification.Tasking_State));
+      with Global => (Input => (Ada.Real_Time.Clock_Time, Ada.Task_Identification.Tasking_State)),
+           Post => Self.Start_Time = Self.Start_Time'Old;
    function Result (Self : in Cpu_Timer_Instance) return Ada.Real_Time.Time_Span
       with Global => null;
 
@@ -22,11 +28,14 @@ package Stopwatch with SPARK_Mode => On is
    end record;
 
    function Start return Wall_Timer_Instance
-      with Volatile_Function, Global => Ada.Real_Time.Clock_Time;
+      with Volatile_Function, Global => Ada.Real_Time.Clock_Time,
+           Post => Start'Result.Stop_Time = Ada.Real_Time.Time_First;
    procedure Start (Self : in out Wall_Timer_Instance)
-      with Global => Ada.Real_Time.Clock_Time;
+      with Global => Ada.Real_Time.Clock_Time,
+           Post => Self.Stop_Time = Self.Stop_Time'Old;
    procedure Stop (Self : in out Wall_Timer_Instance)
-      with Global => Ada.Real_Time.Clock_Time;
+      with Global => Ada.Real_Time.Clock_Time,
+           Post => Self.Start_Time = Self.Start_Time'Old;
    function Result (Self : in Wall_Timer_Instance) return Ada.Real_Time.Time_Span
       with Global => null;
 


### PR DESCRIPTION
## Summary

Converts the `Stopwatch` and `Stopwatch.Reporter` packages (plus the one `Delta_Time.Arithmetic` subprogram they call) to SPARK and proves them at **gold level — flow analysis, absence of runtime errors, and functional contracts — with `--checks-as-errors=on` and zero unproved checks** (64 checks total; 20+ functional contracts discharged).

These packages time every rate group in every Adamant assembly, so their correctness is safety-relevant; the proof now guarantees no runtime errors and that the measurement bookkeeping and max-folding math do exactly what the contracts say. Downstream packages can build their own proofs on top of these contracts, reusing the ghost predicates across the package boundary.

## API and behavior changes

- `Reporter.Reset` takes `Self` as `out` instead of `in out` — it overwrites the whole instance, and flow analysis flags the false data dependency. Callers are unaffected; `out` additionally permits passing an uninitialized instance, so Reset doubles as an initializer.
- `Delta_Time.Arithmetic.To_Delta_Time` gains a procedure form (a function with an `out` parameter is not callable from SPARK) and is made robust while here: the output is fully assigned on every path, and a failed conversion now **saturates** (the previous behavior left the output unassigned).
- Everything else is contract-only: `SPARK_Mode`, `Global`, and `Post` have no effect on generated code with assertions disabled, and the contracts hold at runtime when enabled.

## Commit 1 — SPARK conversion

- `SPARK_Mode => On` with `Global` data-dependency contracts on every subprogram; timer starts/stops declare their reads of `Ada.Real_Time.Clock_Time` (and `Ada.Task_Identification.Tasking_State` via `Current_Task` for CPU timers).
- Volatile clock reads hoisted into constants (the only placement SPARK allows); `Current_Task` hoisted explicitly since evaluating it as `Clock`'s default parameter is an interfering context (SPARK RM 7.1.3(9)). The pattern is consolidated in one private volatile helper, `Cpu_Now`, with a documented `pragma Assume` discharging Clock's non-null-task precondition.
- One justified check: the wall `Result` subtraction's range check, with the full argument in the justification string (64-bit `Time`/`Time_Span`, no wider type, ~292-year overflow horizon for same-clock stamps).

## Commit 2 — functional contracts (gold)

- Start/Stop contracts pin which timestamps are preserved and that stored measurements equal the timer `Result`s.
- `Accumulate` states the max-folding math exactly via the `Maximums_Accumulated` ghost predicate shared by both overloads; the exceeded flags fire precisely when an all-time max is beaten.
- `Reset`/`Reset_Recent_Max` prove what is zeroed and what is preserved via `Is_Reset` and `Recent_Max_Reset`; downstream proofs reuse these predicates across the package boundary.
- Ghost predicate declarations sit with the public interface (they are the vocabulary the contracts are written in); their expression-function definitions live in the private part. Ghost code compiles to nothing.
