### PR TITLE
Static analysis: code fixes

### DIFF
--- a/src/components/ccsds_parameter_table_router/component-ccsds_parameter_table_router-implementation.adb
+++ b/src/components/ccsds_parameter_table_router/component-ccsds_parameter_table_router-implementation.adb
@@ -38,9 +38,9 @@ package body Component.Ccsds_Parameter_Table_Router.Implementation is
       -- null here which would fail the Init assertion, but the binary tree
       -- comparison only uses Table_Id so this is safe for searching:
       Search_Key : constant Router_Table_Entry := (Table_Id => Table_Id, Destinations => null);
-      Found_Index : Positive;
+      Ignore : Positive;
    begin
-      if Self.Table.Search (Search_Key, Found, Found_Index) then
+      if Self.Table.Search (Search_Key, Found, Ignore) then
          return True;
       else
          Self.Event_T_Send_If_Connected (Self.Events.Unrecognized_Table_Id (

--- a/src/components/event_filter/component-event_filter-implementation.adb
+++ b/src/components/event_filter/component-event_filter-implementation.adb
@@ -183,7 +183,6 @@ package body Component.Event_Filter.Implementation is
       use Command_Execution_Status;
       use Event_Filter_Enums;
       Status : Event_Filter_Entry.Event_Entry_Status;
-      Ret : Command_Execution_Status.E := Success;
    begin
       Self.Event_Entries.Set_Filter_State (Arg.Event_To_Update.Id, Event_Filter_State.Filtered, Status);
       case Status is
@@ -197,12 +196,12 @@ package body Component.Event_Filter.Implementation is
       -- Now check if ground wants to dump the state packet
       case Arg.Issue_State_Packet is
          when Issue_Packet_Type.Issue =>
-            Ret := Self.Dump_Event_States;
+            -- Return the dump status so a dump failure fails the command:
+            return Self.Dump_Event_States;
          when Issue_Packet_Type.No_Issue =>
-            null; -- Don't send a packet so nothing to do
+            -- Don't send a packet so nothing to do:
+            return Success;
       end case;
-
-      return Ret;
    end Filter_Event;
 
    -- Disable the event filter for a specific event ID.
@@ -210,7 +209,6 @@ package body Component.Event_Filter.Implementation is
       use Command_Execution_Status;
       use Event_Filter_Enums;
       Status : Event_Filter_Entry.Event_Entry_Status;
-      Ret : Command_Execution_Status.E := Success;
    begin
       Self.Event_Entries.Set_Filter_State (Arg.Event_To_Update.Id, Event_Filter_State.Unfiltered, Status);
       case Status is
@@ -224,12 +222,12 @@ package body Component.Event_Filter.Implementation is
       -- Now check if ground wants to dump the state packet
       case Arg.Issue_State_Packet is
          when Issue_Packet_Type.Issue =>
-            Ret := Self.Dump_Event_States;
+            -- Return the dump status so a dump failure fails the command:
+            return Self.Dump_Event_States;
          when Issue_Packet_Type.No_Issue =>
-            null; -- Don't send a packet so nothing to do
+            -- Don't send a packet so nothing to do:
+            return Success;
       end case;
-
-      return Ret;
    end Unfilter_Event;
 
    -- Enable the event filter for a specific range of event IDs.
@@ -237,7 +235,6 @@ package body Component.Event_Filter.Implementation is
       use Command_Execution_Status;
       use Event_Filter_Enums;
       Status : Event_Filter_Entry.Event_Entry_Status;
-      Ret : Command_Execution_Status.E := Success;
       Id_Stop : Event_Types.Event_Id;
       Id_Start : constant Event_Types.Event_Id := Self.Event_Entries.Get_Event_Start_Stop_Range (Id_Stop);
    begin
@@ -261,12 +258,12 @@ package body Component.Event_Filter.Implementation is
       -- Now check if ground wants to dump the state packet
       case Arg.Issue_State_Packet is
          when Issue_Packet_Type.Issue =>
-            Ret := Self.Dump_Event_States;
+            -- Return the dump status so a dump failure fails the command:
+            return Self.Dump_Event_States;
          when Issue_Packet_Type.No_Issue =>
-            null; -- Don't send a packet so nothing to do
+            -- Don't send a packet so nothing to do:
+            return Success;
       end case;
-
-      return Ret;
    end Filter_Event_Range;
 
    -- Disable the event filter for a specific range of event IDs.
@@ -274,7 +271,6 @@ package body Component.Event_Filter.Implementation is
       use Command_Execution_Status;
       use Event_Filter_Enums;
       Status : Event_Filter_Entry.Event_Entry_Status;
-      Ret : Command_Execution_Status.E := Success;
       Id_Stop : Event_Types.Event_Id;
       Id_Start : constant Event_Types.Event_Id := Self.Event_Entries.Get_Event_Start_Stop_Range (Id_Stop);
    begin
@@ -298,12 +294,12 @@ package body Component.Event_Filter.Implementation is
       -- Now check if ground wants to dump the state packet
       case Arg.Issue_State_Packet is
          when Issue_Packet_Type.Issue =>
-            Ret := Self.Dump_Event_States;
+            -- Return the dump status so a dump failure fails the command:
+            return Self.Dump_Event_States;
          when Issue_Packet_Type.No_Issue =>
-            null; -- Don't send a packet so nothing to do
+            -- Don't send a packet so nothing to do:
+            return Success;
       end case;
-
-      return Ret;
    end Unfilter_Event_Range;
 
    -- Enable the component to filter events that have been set to be filtered.

--- a/src/components/event_limiter/component-event_limiter-implementation.adb
+++ b/src/components/event_limiter/component-event_limiter-implementation.adb
@@ -289,7 +289,6 @@ package body Component.Event_Limiter.Implementation is
       use Command_Execution_Status;
       use Event_Limiter_Enums;
       Status : Two_Counter_Entry.Enable_State_Status;
-      Ret : Command_Execution_Status.E := Success;
    begin
       Self.Event_Array.Set_Enable_State (Arg.Event_To_Update.Id, Event_State_Type.Enabled, Status);
       case Status is
@@ -303,12 +302,12 @@ package body Component.Event_Limiter.Implementation is
       -- Now check if ground wants to dump the state packet
       case Arg.Issue_State_Packet is
          when Issue_Packet_Type.Issue =>
-            Ret := Self.Dump_Event_States;
+            -- Return the dump status so a dump failure fails the command:
+            return Self.Dump_Event_States;
          when Issue_Packet_Type.No_Issue =>
-            null; -- Don't send a packet so nothing to do
+            -- Don't send a packet so nothing to do:
+            return Success;
       end case;
-
-      return Ret;
    end Enable_Event_Limit;
 
    -- Disable the event limiter for a specific event ID.
@@ -316,7 +315,6 @@ package body Component.Event_Limiter.Implementation is
       use Command_Execution_Status;
       use Event_Limiter_Enums;
       Status : Two_Counter_Entry.Enable_State_Status;
-      Ret : Command_Execution_Status.E := Success;
    begin
       Self.Event_Array.Set_Enable_State (Arg.Event_To_Update.Id, Event_State_Type.Disabled, Status);
       case Status is
@@ -330,12 +328,12 @@ package body Component.Event_Limiter.Implementation is
       -- Now check if ground wants to dump the state packet
       case Arg.Issue_State_Packet is
          when Issue_Packet_Type.Issue =>
-            Ret := Self.Dump_Event_States;
+            -- Return the dump status so a dump failure fails the command:
+            return Self.Dump_Event_States;
          when Issue_Packet_Type.No_Issue =>
-            null; -- Don't send a packet so nothing to do
+            -- Don't send a packet so nothing to do:
+            return Success;
       end case;
-
-      return Ret;
    end Disable_Event_Limit;
 
    -- Enable the event limiter for a specific range of event ID.
@@ -343,7 +341,6 @@ package body Component.Event_Limiter.Implementation is
       use Command_Execution_Status;
       use Event_Limiter_Enums;
       Status : Two_Counter_Entry.Enable_State_Status;
-      Ret : Command_Execution_Status.E := Success;
       Id_Stop : Event_Types.Event_Id;
       Id_Start : constant Event_Types.Event_Id := Self.Event_Array.Get_Event_Start_Stop_Range (Id_Stop);
    begin
@@ -367,12 +364,12 @@ package body Component.Event_Limiter.Implementation is
       -- Now check if ground wants to dump the state packet
       case Arg.Issue_State_Packet is
          when Issue_Packet_Type.Issue =>
-            Ret := Self.Dump_Event_States;
+            -- Return the dump status so a dump failure fails the command:
+            return Self.Dump_Event_States;
          when Issue_Packet_Type.No_Issue =>
-            null; -- Don't send a packet so nothing to do
+            -- Don't send a packet so nothing to do:
+            return Success;
       end case;
-
-      return Ret;
    end Enable_Event_Limit_Range;
 
    -- Disable the event limiter for a specific range of event ID.
@@ -380,7 +377,6 @@ package body Component.Event_Limiter.Implementation is
       use Command_Execution_Status;
       use Event_Limiter_Enums;
       Status : Two_Counter_Entry.Enable_State_Status;
-      Ret : Command_Execution_Status.E := Success;
       Id_Stop : Event_Types.Event_Id;
       Id_Start : constant Event_Types.Event_Id := Self.Event_Array.Get_Event_Start_Stop_Range (Id_Stop);
    begin
@@ -404,12 +400,12 @@ package body Component.Event_Limiter.Implementation is
       -- Now check if ground wants to dump the state packet
       case Arg.Issue_State_Packet is
          when Issue_Packet_Type.Issue =>
-            Ret := Self.Dump_Event_States;
+            -- Return the dump status so a dump failure fails the command:
+            return Self.Dump_Event_States;
          when Issue_Packet_Type.No_Issue =>
-            null; -- Don't send a packet so nothing to do
+            -- Don't send a packet so nothing to do:
+            return Success;
       end case;
-
-      return Ret;
    end Disable_Event_Limit_Range;
 
    -- Enable the event limiters for all event IDs.

--- a/src/data_structures/circular_buffer/circular_buffer.adb
+++ b/src/data_structures/circular_buffer/circular_buffer.adb
@@ -353,11 +353,15 @@ package body Circular_Buffer is
 
    overriding function Pop (Self : in out Circular; Bytes : in out Basic_Types.Byte_Array; Num_Bytes_Returned : out Natural) return Pop_Status is
    begin
+      -- Initialize the number of bytes returned to zero:
+      Num_Bytes_Returned := 0;
       return Base (Self).Pop (Bytes, Num_Bytes_Returned);
    end Pop;
 
    overriding function Peek (Self : in Circular; Bytes : in out Basic_Types.Byte_Array; Num_Bytes_Returned : out Natural; Offset : in Natural := 0) return Pop_Status is
    begin
+      -- Initialize the number of bytes returned to zero:
+      Num_Bytes_Returned := 0;
       return Base (Self).Peek (Bytes, Num_Bytes_Returned, Offset);
    end Peek;
 
@@ -556,6 +560,8 @@ package body Circular_Buffer is
    overriding function Peek (Self : in Queue; Bytes : in out Basic_Types.Byte_Array; Length : out Natural; Offset : in Natural := 0) return Pop_Status is
       Ignore : Natural;
    begin
+      -- Initialize the length to zero:
+      Length := 0;
       return Self.Do_Peek (Bytes, Length, Ignore, Offset);
    end Peek;
 

--- a/src/unit_test/string_util/bb/string_util.adb
+++ b/src/unit_test/string_util/bb/string_util.adb
@@ -13,16 +13,15 @@ package body String_Util is
       Toreturn : String (1 .. Bytes'Length * 4);
       function Get_Number (Index : in Natural) return String is
          Temp : constant String := Natural'Image (Natural (Bytes (Index)));
+         -- 'Image of a byte value yields two to four characters (a leading
+         -- space and up to three digits). Right-align the last (up to) three
+         -- characters in a fixed three-character result so every caller sees
+         -- a provably constant width.
+         Len : constant Natural := Natural'Min (Temp'Length, 3);
+         Result : String (1 .. 3) := [others => ' '];
       begin
-         if Temp'Length = 1 then
-            return "   " & Temp;
-         elsif Temp'Length = 2 then
-            return " " & Temp;
-         elsif Temp'Length = 3 then
-            return Temp;
-         else
-            return Temp ((Temp'Last - 2) .. Temp'Last);
-         end if;
+         Result (4 - Len .. 3) := Temp (Temp'Last - Len + 1 .. Temp'Last);
+         return Result;
       end Get_Number;
       Cnt : Natural := 0;
    begin


### PR DESCRIPTION
## Summary

Four standalone code fixes for findings reported by GNAT SAS deep-mode whole-program analysis. One commit per change, each message naming the exact finding it resolves and why the change is correct:

| Commit | Change | Findings fixed |
|---|---|---|
| `79fe7ee6` | circular_buffer: initialize out parameters in the thin Pop/Peek wrappers before delegating | 3 high validity checks (Infer): 'out parameter is not initialized at the end of the subprogram' |
| `dc426423` | ccsds_parameter_table_router: rename the unneeded search index output to `Ignore` | 1 medium 'unused out parameter Found_Index' (follows framework convention, AdamantMessagePatterns.xml rules 117/118) |
| `398a7558` | event_filter + event_limiter: return the dump status directly instead of via a `Ret` variable | 8 medium 'useless reassignment of Ret' (same-value dead store; status still propagates) |
| `b59139fd` | string_util (bareboard): rewrite `Get_Number` with a provably fixed-width result | 2 low 'test always false', 2 medium 'dead code', 1 medium 'array index check' — and removes a latent Constraint_Error in an unreachable branch |