### PR TITLE
Add prove_all rule and workflow to prove all SPARK packages

### DIFF
--- a/.github/workflows/prove_all.yml
+++ b/.github/workflows/prove_all.yml
@@ -1,0 +1,32 @@
+name: Prove All SPARK Packages
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+jobs:
+  compile_job:
+    name: prove_all
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/lasp/adamant:0.2
+      options: --user root
+    steps:
+      - run: echo "Starting job triggered by a ${{ github.event_name }} event on a ${{ runner.os }} server hosted by GitHub."
+      - run: echo "Checking out ${{ github.repository }} on branch ${{ github.ref }}."
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Prove all SPARK packages
+        run: bash env/github_run.sh "redo prove_all"
+      - name: Archive prove logs
+        if: always() # Make sure this runs even if `redo prove_all` fails
+        uses: actions/upload-artifact@v4
+        with:
+          name: prove_logs
+          path: ${{ github.workspace }}/build
+          if-no-files-found: ignore
+      - run: echo "Finished with status - ${{ job.status }}."
+        if: always()

--- a/.github/workflows/prove_all_arm64.yml
+++ b/.github/workflows/prove_all_arm64.yml
@@ -1,0 +1,37 @@
+name: Prove All SPARK Packages (ARM64)
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+jobs:
+  compile_job:
+    name: prove_all (arm64)
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Starting job triggered by a ${{ github.event_name }} event on a ${{ runner.os }} server hosted by GitHub."
+      - run: echo "Checking out ${{ github.repository }} on branch ${{ github.ref }}."
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Prove all SPARK packages
+        run: |
+          docker run --rm --platform linux/arm64 \
+            -v ${{ github.workspace }}:/workspace \
+            -w /workspace \
+            ghcr.io/lasp/adamant:0.2 \
+            bash env/github_run.sh "redo prove_all"
+
+      - name: Archive prove logs
+        if: always() # Make sure this runs even if `redo prove_all` fails
+        uses: actions/upload-artifact@v4
+        with:
+          name: prove_logs_arm64
+          path: ${{ github.workspace }}/build
+          if-no-files-found: ignore
+
+      - run: echo "Finished with status - ${{ job.status }}."
+        if: always()

--- a/default.do
+++ b/default.do
@@ -48,6 +48,8 @@ if __name__ == "__main__":
         from rules.build_what_predefined import build_what_predefined as rule_cls
     elif base == "prove":
         from rules.build_prove import build_prove as rule_cls
+    elif base == "prove_all":
+        from rules.build_prove_all import build_prove_all as rule_cls
     elif base == "analyze":
         from rules.build_analyze import build_analyze as rule_cls
     elif base == "analyze_all":

--- a/redo/rules/build_prove_all.py
+++ b/redo/rules/build_prove_all.py
@@ -1,0 +1,155 @@
+import os.path
+import re
+import sys
+from util import redo
+from util import error
+from util import filesystem
+from base_classes.build_rule_base import build_rule_base
+from shutil import copytree
+
+# Definitions for producing colored text on the terminal
+NO_COLOR = "\033[0m"
+BOLD = "\033[1m"
+RED = "\033[31m"
+GREEN = "\033[32m"
+if "REDO_PROVE_ALL_NO_COLOR" in os.environ and os.environ["REDO_PROVE_ALL_NO_COLOR"]:
+    PASSED = "PASSED"
+    FAILED = "FAILED"
+else:
+    PASSED = BOLD + GREEN + "PASSED" + NO_COLOR
+    FAILED = BOLD + RED + "FAILED" + NO_COLOR
+
+SPARK_ON_REGEX = re.compile(r"SPARK_Mode\s*=>\s*On")
+
+
+def _dir_has_spark_on(files, root):
+    """Return True if any Ada source in this directory enables SPARK."""
+    for f in files:
+        if f.endswith(".ads") or f.endswith(".adb"):
+            try:
+                with open(os.path.join(root, f), "r", errors="ignore") as fh:
+                    if SPARK_ON_REGEX.search(fh.read()):
+                        return True
+            except OSError:
+                pass
+    return False
+
+
+class build_prove_all(build_rule_base):
+    """
+    This build rule looks for SPARK packages in the directory it is
+    passed and recursively below. A directory is eligible if it contains
+    an "all.prove.yaml" GNATprove configuration or any source with
+    "SPARK_Mode => On". It then runs "redo prove" in each eligible
+    directory in sequence and prints a report to the terminal as the
+    proofs are run. Eligibility is recomputed from the source tree on
+    every run, so a package converted to SPARK is picked up
+    automatically. Note that "redo prove" analyzes a directory's full
+    object closure, including generated code, so SPARK inside autocode
+    is proved through its owning directory.
+
+    A directory containing a ".skip_prove" marker is skipped along with
+    everything below it. This is intended for deliberate proof-failure
+    fixtures used to test the build system itself.
+    """
+
+    def _write_to_both(self, message):
+        """Write message to both stderr and summary file."""
+        sys.stderr.write(message)
+        self.summary_file.write(message)
+        self.summary_file.flush()
+
+    def _build(self, redo_1, redo_2, redo_3):
+        pass  # We are overriding build instead since
+        # we don't need to usual build boilerplate
+        # for prove_all
+
+    def build(self, redo_1, redo_2, redo_3):
+        import database.setup
+
+        # Figure out build directory location
+        directory = os.path.abspath(os.path.dirname(redo_1))
+
+        # Find all SPARK directories below this directory:
+        prove_dirs = []
+        for root, dirnames, files in filesystem.recurse_through_repo(directory):
+            if os.sep + "gen" + os.sep + "templates" in root:
+                pass  # template text, not compilable source
+            elif ".skip_prove" in files:
+                sys.stderr.write("Skipping " + root + "\n")
+                dirnames[:] = []  # also skip everything below
+            elif "all.prove.yaml" in files or _dir_has_spark_on(files, root):
+                prove_dirs.append(root)
+        prove_dirs.sort()
+
+        if not prove_dirs:
+            sys.stderr.write(
+                "No SPARK packages found in or below '" + directory + "'.\n"
+            )
+            error.abort(0)
+
+        # Create summary report file
+        build_dir = os.path.join(directory, "build")
+        filesystem.safe_makedir(build_dir)
+        summary_report_path = os.path.join(build_dir, "prove_all_summary.txt")
+        self.summary_file = open(summary_report_path, "w")
+
+        # Print the prove plan:
+        num_dirs = "%02d" % len(prove_dirs)
+        self._write_to_both(
+            "Will be proving a total of " + num_dirs + " SPARK packages:\n"
+        )
+        for number, prove_dir in enumerate(prove_dirs):
+            rel_dir = os.path.relpath(prove_dir, directory)
+            self._write_to_both(
+                ("%02d" % (number + 1)) + "/" + num_dirs + " " + rel_dir + "\n"
+            )
+
+        # Turn off debug mode. This isn't really compatible with the
+        # report print out:
+        try:
+            del os.environ["DEBUG"]
+        except BaseException:
+            pass
+
+        # Make a build directory at the top level:
+        failed_prove_log_dir = os.path.join(directory, "build" + os.sep + "failed_prove_logs")
+        log_dir = os.path.join(directory, "build" + os.sep + "prove_logs")
+        filesystem.safe_makedir(failed_prove_log_dir)
+        filesystem.safe_makedir(log_dir)
+
+        # Run proofs:
+        exit_code = 0
+        self._write_to_both("\nProving...\n")
+        for number, prove_dir in enumerate(prove_dirs):
+            rel_dir = os.path.relpath(prove_dir, directory)
+            self._write_to_both(
+                "{0:80}   ".format(
+                    (("%02d" % (number + 1)) + "/" + num_dirs + " " + rel_dir)[:80]
+                )
+            )
+            database.setup.reset()
+            try:
+                prove_log = os.path.join(log_dir, rel_dir.replace(os.sep, "_") + ".log")
+                redo.redo([os.path.join(prove_dir, "prove"), "1>&2", "2>" + prove_log])
+                self._write_to_both(" " + PASSED + "\n")
+            except BaseException:
+                exit_code = 1
+                self._write_to_both(" " + FAILED + "\n")
+
+                # On a failed proof, save off the prove logs for inspection. This is
+                # especially useful on a remote CI server.
+                try:
+                    copytree(
+                        os.path.join(prove_dir, "build" + os.sep + "prove"),
+                        os.path.join(failed_prove_log_dir, prove_dir.replace(os.sep, "_"))
+                    )
+                except BaseException:
+                    pass
+
+        self.summary_file.close()
+        error.abort(exit_code)
+
+    # No need to provide these for "redo prove_all"
+    # def input_file_regex(self): pass
+    # def output_filename(self, input_filename): pass

--- a/redo/rules/build_what_predefined.py
+++ b/redo/rules/build_what_predefined.py
@@ -16,6 +16,7 @@ def get_predefined_targets() -> list:
         "publish",
         "targets",
         "prove",
+        "prove_all",
         "analyze",
         "style",
         "pretty",


### PR DESCRIPTION
Adds `prove_all`, the recursive prove counterpart to `test_all`/`coverage_all`, and workflows that run it on push/PR to `main` plus an arm64 variant on release.

It walks the repo and runs `redo prove` in every directory with an `all.prove.yaml` or a `SPARK_Mode => On` source (only `gen/templates` is excluded, as in `style_all`), so SPARK packages are proved automatically as they're added. Nothing is hardcoded, and SPARK inside autocode is proved through its owning directory. A directory can opt out with `.skip_prove`.

- `redo/rules/build_prove_all.py` + `default.do` / `build_what_predefined.py` wiring
- `.github/workflows/prove_all.yml` and `.github/workflows/prove_all_arm64.yml`
- `.skip_prove` on the `spark_compile` proof-failure fixture

Today it discovers and proves `src/util/stopwatch`, the two `doc/example_architecture` SPARK examples, and `redo/test/aspect_compile`.