### PR TITLE
Avoid a miscompiled static aggregate in the product packetizer test

### DIFF
--- a/src/components/product_packetizer/test/tests-implementation.adb
+++ b/src/components/product_packetizer/test/tests-implementation.adb
@@ -465,7 +465,8 @@ package body Tests.Implementation is
       T : Component.Product_Packetizer.Implementation.Tester.Instance_Access renames Self.Tester;
       The_Tick : constant Tick.T := ((0, 0), 1);
       The_Packet : Packet.T;
-      Pd_Ids : constant Packet_Data_Product_Ids.T := (Packet_Id => 7, Data_Product_Id => 1);
+      Pd_Packet_Id : constant Packet_Data_Product_Ids.Packet_Id_Type := 7;
+      Pd_Data_Product_Id : constant Packet_Data_Product_Ids.Data_Product_Id_Type := 1;
    begin
       -- Send tick, expect no packets received:
       T.Tick_T_Send (The_Tick);
@@ -513,7 +514,7 @@ package body Tests.Implementation is
       -- Check event:
       Natural_Assert.Eq (T.Event_T_Recv_Sync_History.Get_Count, 1);
       Natural_Assert.Eq (T.Data_Product_Missing_On_Fetch_History.Get_Count, 1);
-      Packet_Data_Product_Ids_Assert.Eq (T.Data_Product_Missing_On_Fetch_History.Get (1), Pd_Ids);
+      Packet_Data_Product_Ids_Assert.Eq (T.Data_Product_Missing_On_Fetch_History.Get (1), (Packet_Id => Pd_Packet_Id, Data_Product_Id => Pd_Data_Product_Id));
 
       -- Send tick, expect no packets received:
       T.Tick_T_Send (The_Tick);
@@ -538,7 +539,7 @@ package body Tests.Implementation is
       -- Check event:
       Natural_Assert.Eq (T.Event_T_Recv_Sync_History.Get_Count, 2);
       Natural_Assert.Eq (T.Data_Product_Missing_On_Fetch_History.Get_Count, 2);
-      Packet_Data_Product_Ids_Assert.Eq (T.Data_Product_Missing_On_Fetch_History.Get (2), Pd_Ids);
+      Packet_Data_Product_Ids_Assert.Eq (T.Data_Product_Missing_On_Fetch_History.Get (2), (Packet_Id => Pd_Packet_Id, Data_Product_Id => Pd_Data_Product_Id));
 
       -- Set the data product return status to success:
       T.Data_Product_Fetch_Return_Status := Fetch_Status.Success;


### PR DESCRIPTION
`Pd_Ids` was a single constant of `Packet_Data_Product_Ids.T`, a 32-bit record with two whole-byte fields and `Scalar_Storage_Order => High_Order_First`, used as the expected value in two assertions.

Some GNAT versions miscompile that shape on RISC targets. When a small static aggregate is the ultimate source of the value and it is passed by value, the code generator emits a full write for the first component instead of a read-modify-write sequence and mishandles the widening of the value when the storage order is reversed. The first field silently reads as zero.

## Why it matters here

This test passes today because the suite builds native, where the fault does not appear. Cross-compiled and run on a RISC target it would **fail**: the actual value comes from the component at run time and is correct, while the expected value would arrive with `Packet_Id` zeroed.

Worth noting the failure mode is not always this visible. Where a test both stimulates and checks with the same miscompiled constant, wrong matches wrong and the test passes while the code under test is broken. This one is the loud variety.

## The change

Hold the two identifiers as scalars and assemble the record at each point of use. An aggregate written at the point of use is not affected.