### PR TITLE
Validate each component's default parameter values at assembly startup

### DIFF
--- a/doc/example_architecture/parameter_component/component-parameter_component-implementation.ads
+++ b/doc/example_architecture/parameter_component/component-parameter_component-implementation.ads
@@ -53,12 +53,13 @@ private
    -- hardware registers, or performing other special functionality that only needs to be performed after parameters have
    -- been updated.
    overriding procedure Update_Parameters_Action (Self : in out Instance);
-   -- This function is called when the parameter operation type is "Validate". The default implementation of this
+   -- This function is called when the parameter operation type is "Validate", and once at startup by
+   -- Assert_Valid_Parameters to check the compiled-in default parameter values. The default implementation of this
    -- subprogram in the implementation package is a function that returns "Valid". However, this function can, and should be
-   -- overridden if something special needs to happen to further validate a parameter. Examples of this might be validation of
-   -- certain parameters beyond individual type ranges, or performing other special functionality that only needs to be
-   -- performed after parameters have been validated. Note that range checking is performed during staging, and does not need
-   -- to be implemented here.
+   -- overridden if a parameter requires validation beyond its individual type range, such as enforcing a relationship
+   -- between parameters. Note that range checking is performed during staging, and does not need to be implemented here.
+   -- The startup call runs before components are connected or initialized, so an override must be a pure function of its
+   -- parameter arguments - it must not invoke connectors or rely on state established during component initialization.
    overriding function Validate_Parameters (
       Self : in out Instance;
       Start_Count : in Packed_U16.U;

--- a/gen/templates/assembly/name.adb
+++ b/gen/templates/assembly/name.adb
@@ -50,6 +50,13 @@ package body {{ name }} is
 {% for component in component_kind_dict["data_dependencies"] %}
       {{ component.instance_name }}.Map_Data_Dependencies{% if component.map_data_dependencies.parameter_call_string() %} ({{ component.map_data_dependencies.parameter_call_string() }}){% endif %};
 {% endfor %}
+
+      -----------------------------------
+      -- Default Parameter Validation:
+      -----------------------------------
+{% for component in component_kind_dict["parameters"] %}
+      {{ component.instance_name }}.Assert_Valid_Parameters;
+{% endfor %}
    end Set_Id_Bases;
 
 {% endif %}

--- a/gen/templates/assembly/name.ads
+++ b/gen/templates/assembly/name.ads
@@ -25,7 +25,8 @@ package {{ name }} is
 {% if component_kind_dict["set_id_bases"] %}
    -- Set the appropriate command, event, parameter, packet and data product id bases in all the
    -- components. This also resolves the data dependency ids for components that have data
-   -- dependencies.
+   -- dependencies, and validates the default parameter values of components that have
+   -- parameters.
    procedure Set_Id_Bases;
 {% endif %}
 {% if connections %}

--- a/gen/templates/component/component-name-implementation.ads
+++ b/gen/templates/component/component-name-implementation.ads
@@ -170,12 +170,13 @@ private
    -- hardware registers, or performing other special functionality that only needs to be performed after parameters have
    -- been updated.
    overriding procedure Update_Parameters_Action (Self : in out Instance) is null;
-   -- This function is called when the parameter operation type is "Validate". The default implementation of this
+   -- This function is called when the parameter operation type is "Validate", and once at startup by
+   -- Assert_Valid_Parameters to check the compiled-in default parameter values. The default implementation of this
    -- subprogram in the implementation package is a function that returns "Valid". However, this function can, and should be
-   -- overridden if something special needs to happen to further validate a parameter. Examples of this might be validation of
-   -- certain parameters beyond individual type ranges, or performing other special functionality that only needs to be
-   -- performed after parameters have been validated. Note that range checking is performed during staging, and does not need
-   -- to be implemented here.
+   -- overridden if a parameter requires validation beyond its individual type range, such as enforcing a relationship
+   -- between parameters. Note that range checking is performed during staging, and does not need to be implemented here.
+   -- The startup call runs before components are connected or initialized, so an override must be a pure function of its
+   -- parameter arguments - it must not invoke connectors or rely on state established during component initialization.
    overriding function Validate_Parameters (
       Self : in out Instance;
 {% for par in parameters %}

--- a/gen/templates/component/component-name.adb
+++ b/gen/templates/component/component-name.adb
@@ -271,6 +271,27 @@ package body Component.{{ name }} is
    end Map_Data_Dependencies;
 
 {% endif %}
+{% if parameters %}
+   -----------------------------------------------------------------------
+   -- Assert that the component's default parameter values are valid:
+   -----------------------------------------------------------------------
+   not overriding procedure Assert_Valid_Parameters (Self : in out Base_Instance) is
+      use Parameter_Validation_Status;
+   begin
+      -- An assertion failure here means the default parameter values of {{ name }}
+      -- failed validation. The assertion carries no message string to keep it out of
+      -- the binary; the failure is traceable through this subprogram's symbol and the
+      -- assertion's file and line.
+      pragma Assert (
+         Base_Instance'Class (Self).Validate_Parameters (
+{% for par in parameters %}
+            {{ par.name }} => Self.{{ par.name }}{{ "," if not loop.last }}
+{% endfor %}
+         ) = Valid
+      );
+   end Assert_Valid_Parameters;
+
+{% endif %}
 {% if connectors.requires_queue() %}
    ---------------------------------------------------------------
    -- Visible private dispatching procedures for component queue:

--- a/gen/templates/component/component-name.ads
+++ b/gen/templates/component/component-name.ads
@@ -145,6 +145,16 @@ package Component.{{ name }} is
    not overriding procedure Map_Data_Dependencies (Self : in out Base_Instance{% if map_data_dependencies.parameters %}; {{ map_data_dependencies.parameter_declaration_string() }}{% endif %});
 
 {% endif %}
+{% if parameters %}
+   -----------------------------------------------------------------------
+   -- Assert that the component's default parameter values are valid:
+   -----------------------------------------------------------------------
+   -- Runs the component's Validate_Parameters function against the compiled-in
+   -- default parameter values. Called once at startup, before components are
+   -- connected or initialized. An invalid result fails an assertion.
+   not overriding procedure Assert_Valid_Parameters (Self : in out Base_Instance);
+
+{% endif %}
 {% if connectors.invokee() %}
    ---------------------------------------
    -- Invokee connector primitives:
@@ -269,12 +279,13 @@ package Component.{{ name }} is
    -- been updated.
    not overriding procedure Update_Parameters_Action (Self : in out Base_Instance) is abstract;
 
-   -- This function is called when the parameter operation type is "Validate". The default implementation of this
+   -- This function is called when the parameter operation type is "Validate", and once at startup by
+   -- Assert_Valid_Parameters to check the compiled-in default parameter values. The default implementation of this
    -- subprogram in the implementation package is a function that returns "Valid". However, this function can, and should be
-   -- overridden if something special needs to happen to further validate a parameter. Examples of this might be validation of
-   -- certain parameters beyond individual type ranges, or performing other special functionality that only needs to be
-   -- performed after parameters have been validated. Note that range checking is performed during staging, and does not need
-   -- to be implemented here.
+   -- overridden if a parameter requires validation beyond its individual type range, such as enforcing a relationship
+   -- between parameters. Note that range checking is performed during staging, and does not need to be implemented here.
+   -- The startup call runs before components are connected or initialized, so an override must be a pure function of its
+   -- parameter arguments - it must not invoke connectors or rely on state established during component initialization.
    not overriding function Validate_Parameters (
       Self : in out Base_Instance;
 {% for par in parameters %}

--- a/gen/templates/tests/name-implementation.adb
+++ b/gen/templates/tests/name-implementation.adb
@@ -23,6 +23,13 @@ package body {{ name }}.Implementation is
       -- Set the logger in the component
       Self.Tester.Set_Logger (Self.Logger'Unchecked_Access);
 
+{% if component.parameters %}
+      -- Assert that the component's compiled-in default parameter values are valid.
+      -- The generated test base performs this check for non-generic components; a
+      -- generic component's tester only exists here, so the call is made here.
+      Self.Tester.Component_Instance.Assert_Valid_Parameters;
+
+{% endif %}
 {% endif %}
 {% if component.connectors.invoker() or component.connectors.of_kind("recv_async") or component.events %}
       -- Allocate heap memory to component:

--- a/gen/templates/tests/name.adb
+++ b/gen/templates/tests/name.adb
@@ -74,6 +74,10 @@ package body {{ name }} is
       Self.Tester := Tester_Alloc.Allocate;
       -- Link the log access type to the logger in the reciprocal
       Self.Tester.Set_Logger (Self.Logger'Unchecked_Access);
+{% if component.parameters %}
+      -- Assert that the component's compiled-in default parameter values are valid:
+      Self.Tester.Component_Instance.Assert_Valid_Parameters;
+{% endif %}
 {% endif %}
       -- Call up to the implementation setup
       Base_Instance'Class (Self).Set_Up_Test;

--- a/src/components/limiter/component-limiter-implementation.ads
+++ b/src/components/limiter/component-limiter-implementation.ads
@@ -100,12 +100,13 @@ private
    -- hardware registers, or performing other special functionality that only needs to be performed after parameters have
    -- been updated.
    overriding procedure Update_Parameters_Action (Self : in out Instance);
-   -- This function is called when the parameter operation type is "Validate". The default implementation of this
+   -- This function is called when the parameter operation type is "Validate", and once at startup by
+   -- Assert_Valid_Parameters to check the compiled-in default parameter values. The default implementation of this
    -- subprogram in the implementation package is a function that returns "Valid". However, this function can, and should be
-   -- overridden if something special needs to happen to further validate a parameter. Examples of this might be validation of
-   -- certain parameters beyond individual type ranges, or performing other special functionality that only needs to be
-   -- performed after parameters have been validated. Note that range checking is performed during staging, and does not need
-   -- to be implemented here.
+   -- overridden if a parameter requires validation beyond its individual type range, such as enforcing a relationship
+   -- between parameters. Note that range checking is performed during staging, and does not need to be implemented here.
+   -- The startup call runs before components are connected or initialized, so an override must be a pure function of its
+   -- parameter arguments - it must not invoke connectors or rely on state established during component initialization.
    overriding function Validate_Parameters (
       Self : in out Instance;
       Max_Sends_Per_Tick : in Packed_U16.U

--- a/src/components/limiter/test/limiter_tests-implementation.adb
+++ b/src/components/limiter/test/limiter_tests-implementation.adb
@@ -32,6 +32,11 @@ package body Limiter_Tests.Implementation is
       -- Set the logger in the component
       Self.Tester.Set_Logger (Self.Logger'Unchecked_Access);
 
+      -- Assert that the component's compiled-in default parameter values are valid.
+      -- The generated test base performs this check for non-generic components; a
+      -- generic component's tester only exists here, so the call is made here.
+      Self.Tester.Component_Instance.Assert_Valid_Parameters;
+
       -- Allocate heap memory to component:
       Self.Tester.Init_Base (Queue_Size => Self.Tester.Component_Instance.Get_Max_Queue_Element_Size * 4);
 

--- a/src/components/parameters/test/parameters.tests.yaml
+++ b/src/components/parameters/test/parameters.tests.yaml
@@ -31,3 +31,5 @@ tests:
     description: This unit test tests a command or memory region being dropped due to a full queue.
   - name: Test_Invalid_Command
     description: This unit test exercises that an invalid command throws the appropriate event.
+  - name: Test_Assert_Valid_Parameters
+    description: This unit test tests the startup validation of component default parameter values, including the assertion failure on an invalid result.

--- a/src/components/parameters/test/parameters_tests-implementation.adb
+++ b/src/components/parameters/test/parameters_tests-implementation.adb
@@ -32,8 +32,18 @@ with Parameter_Table_Header;
 with Crc_16;
 with Packed_Table_Operation_Status.Assertion; use Packed_Table_Operation_Status.Assertion;
 with System.Storage_Elements; use System.Storage_Elements;
+with Ada.Assertions;
+with Component.Test_Component_2.Implementation;
+with Tick;
 
 package body Parameters_Tests.Implementation is
+
+   -- A test component whose validation rejects every parameter set, including its defaults:
+   type Invalid_Defaults_Instance is new Component.Test_Component_2.Implementation.Instance with null record;
+   overriding function Validate_Parameters (
+      Self : in out Invalid_Defaults_Instance;
+      The_Tick : in Tick.U
+   ) return Parameter_Enums.Parameter_Validation_Status.E is (Parameter_Enums.Parameter_Validation_Status.Invalid);
 
    -------------------------------------------------------------------------
    -- Fixtures:
@@ -1168,5 +1178,25 @@ package body Parameters_Tests.Implementation is
       Natural_Assert.Eq (T.Invalid_Command_Received_History.Get_Count, 1);
       Invalid_Command_Info_Assert.Eq (T.Invalid_Command_Received_History.Get (1), (Id => T.Commands.Get_Dump_Parameters_Id, Errant_Field_Number => Interfaces.Unsigned_32'Last, Errant_Field => [0, 0, 0, 0, 0, 0, 0, 22]));
    end Test_Invalid_Command;
+
+   overriding procedure Test_Assert_Valid_Parameters (Self : in out Instance) is
+      T : Component.Parameters.Implementation.Tester.Instance_Access renames Self.Tester;
+      Bad_Component : Invalid_Defaults_Instance;
+      Assertion_Raised : Boolean := False;
+   begin
+      -- Components whose defaults pass validation return without raising:
+      T.Component_A.Assert_Valid_Parameters;
+      T.Component_B.Assert_Valid_Parameters;
+      T.Component_C.Assert_Valid_Parameters;
+
+      -- A component whose validation rejects its defaults fails an assertion:
+      begin
+         Bad_Component.Assert_Valid_Parameters;
+      exception
+         when Ada.Assertions.Assertion_Error =>
+            Assertion_Raised := True;
+      end;
+      Boolean_Assert.Eq (Assertion_Raised, True);
+   end Test_Assert_Valid_Parameters;
 
 end Parameters_Tests.Implementation;

--- a/src/components/parameters/test/parameters_tests-implementation.ads
+++ b/src/components/parameters/test/parameters_tests-implementation.ads
@@ -41,6 +41,8 @@ private
    overriding procedure Test_Full_Queue (Self : in out Instance);
    -- This unit test exercises that an invalid command throws the appropriate event.
    overriding procedure Test_Invalid_Command (Self : in out Instance);
+   -- This unit test tests the startup validation of component default parameter values, including the assertion failure on an invalid result.
+   overriding procedure Test_Assert_Valid_Parameters (Self : in out Instance);
 
    -- Test data and state:
    type Instance is new Parameters_Tests.Base_Instance with record

--- a/src/components/parameters/test/test_component_1/component-test_component_1-implementation.ads
+++ b/src/components/parameters/test/test_component_1/component-test_component_1-implementation.ads
@@ -59,12 +59,13 @@ private
    -- hardware registers, or performing other special functionality that only needs to be performed after parameters have
    -- been updated.
    overriding procedure Update_Parameters_Action (Self : in out Instance) is null;
-   -- This function is called when the parameter operation type is "Validate". The default implementation of this
+   -- This function is called when the parameter operation type is "Validate", and once at startup by
+   -- Assert_Valid_Parameters to check the compiled-in default parameter values. The default implementation of this
    -- subprogram in the implementation package is a function that returns "Valid". However, this function can, and should be
-   -- overridden if something special needs to happen to further validate a parameter. Examples of this might be validation of
-   -- certain parameters beyond individual type ranges, or performing other special functionality that only needs to be
-   -- performed after parameters have been validated. Note that range checking is performed during staging, and does not need
-   -- to be implemented here.
+   -- overridden if a parameter requires validation beyond its individual type range, such as enforcing a relationship
+   -- between parameters. Note that range checking is performed during staging, and does not need to be implemented here.
+   -- The startup call runs before components are connected or initialized, so an override must be a pure function of its
+   -- parameter arguments - it must not invoke connectors or rely on state established during component initialization.
    overriding function Validate_Parameters (
       Self : in out Instance;
       Parameter_U16 : in Packed_U16.U;

--- a/src/components/parameters/test/test_component_2/component-test_component_2-implementation.ads
+++ b/src/components/parameters/test/test_component_2/component-test_component_2-implementation.ads
@@ -50,12 +50,13 @@ private
    -- hardware registers, or performing other special functionality that only needs to be performed after parameters have
    -- been updated.
    overriding procedure Update_Parameters_Action (Self : in out Instance) is null;
-   -- This function is called when the parameter operation type is "Validate". The default implementation of this
+   -- This function is called when the parameter operation type is "Validate", and once at startup by
+   -- Assert_Valid_Parameters to check the compiled-in default parameter values. The default implementation of this
    -- subprogram in the implementation package is a function that returns "Valid". However, this function can, and should be
-   -- overridden if something special needs to happen to further validate a parameter. Examples of this might be validation of
-   -- certain parameters beyond individual type ranges, or performing other special functionality that only needs to be
-   -- performed after parameters have been validated. Note that range checking is performed during staging, and does not need
-   -- to be implemented here.
+   -- overridden if a parameter requires validation beyond its individual type range, such as enforcing a relationship
+   -- between parameters. Note that range checking is performed during staging, and does not need to be implemented here.
+   -- The startup call runs before components are connected or initialized, so an override must be a pure function of its
+   -- parameter arguments - it must not invoke connectors or rely on state established during component initialization.
    overriding function Validate_Parameters (
       Self : in out Instance;
       The_Tick : in Tick.U

--- a/src/components/parameters/test_grouped/test_component_1/component-test_component_1-implementation.ads
+++ b/src/components/parameters/test_grouped/test_component_1/component-test_component_1-implementation.ads
@@ -61,12 +61,13 @@ private
    -- hardware registers, or performing other special functionality that only needs to be performed after parameters have
    -- been updated.
    overriding procedure Update_Parameters_Action (Self : in out Instance) is null;
-   -- This function is called when the parameter operation type is "Validate". The default implementation of this
+   -- This function is called when the parameter operation type is "Validate", and once at startup by
+   -- Assert_Valid_Parameters to check the compiled-in default parameter values. The default implementation of this
    -- subprogram in the implementation package is a function that returns "Valid". However, this function can, and should be
-   -- overridden if something special needs to happen to further validate a parameter. Examples of this might be validation of
-   -- certain parameters beyond individual type ranges, or performing other special functionality that only needs to be
-   -- performed after parameters have been validated. Note that range checking is performed during staging, and does not need
-   -- to be implemented here.
+   -- overridden if a parameter requires validation beyond its individual type range, such as enforcing a relationship
+   -- between parameters. Note that range checking is performed during staging, and does not need to be implemented here.
+   -- The startup call runs before components are connected or initialized, so an override must be a pure function of its
+   -- parameter arguments - it must not invoke connectors or rely on state established during component initialization.
    overriding function Validate_Parameters (
       Self : in out Instance;
       Parameter_U16 : in Packed_U16.U;

--- a/src/components/parameters/test_grouped/test_component_2/component-test_component_2-implementation.ads
+++ b/src/components/parameters/test_grouped/test_component_2/component-test_component_2-implementation.ads
@@ -50,12 +50,13 @@ private
    -- hardware registers, or performing other special functionality that only needs to be performed after parameters have
    -- been updated.
    overriding procedure Update_Parameters_Action (Self : in out Instance) is null;
-   -- This function is called when the parameter operation type is "Validate". The default implementation of this
+   -- This function is called when the parameter operation type is "Validate", and once at startup by
+   -- Assert_Valid_Parameters to check the compiled-in default parameter values. The default implementation of this
    -- subprogram in the implementation package is a function that returns "Valid". However, this function can, and should be
-   -- overridden if something special needs to happen to further validate a parameter. Examples of this might be validation of
-   -- certain parameters beyond individual type ranges, or performing other special functionality that only needs to be
-   -- performed after parameters have been validated. Note that range checking is performed during staging, and does not need
-   -- to be implemented here.
+   -- overridden if a parameter requires validation beyond its individual type range, such as enforcing a relationship
+   -- between parameters. Note that range checking is performed during staging, and does not need to be implemented here.
+   -- The startup call runs before components are connected or initialized, so an override must be a pure function of its
+   -- parameter arguments - it must not invoke connectors or rely on state established during component initialization.
    overriding function Validate_Parameters (
       Self : in out Instance;
       The_Tick : in Tick.U

--- a/src/components/pid_controller/component-pid_controller-implementation.ads
+++ b/src/components/pid_controller/component-pid_controller-implementation.ads
@@ -133,12 +133,13 @@ private
    -- hardware registers, or performing other special functionality that only needs to be performed after parameters have
    -- been updated.
    overriding procedure Update_Parameters_Action (Self : in out Instance) is null;
-   -- This function is called when the parameter operation type is "Validate". The default implementation of this
+   -- This function is called when the parameter operation type is "Validate", and once at startup by
+   -- Assert_Valid_Parameters to check the compiled-in default parameter values. The default implementation of this
    -- subprogram in the implementation package is a function that returns "Valid". However, this function can, and should be
-   -- overridden if something special needs to happen to further validate a parameter. Examples of this might be validation of
-   -- certain parameters beyond individual type ranges, or performing other special functionality that only needs to be
-   -- performed after parameters have been validated. Note that range checking is performed during staging, and does not need
-   -- to be implemented here.
+   -- overridden if a parameter requires validation beyond its individual type range, such as enforcing a relationship
+   -- between parameters. Note that range checking is performed during staging, and does not need to be implemented here.
+   -- The startup call runs before components are connected or initialized, so an override must be a pure function of its
+   -- parameter arguments - it must not invoke connectors or rely on state established during component initialization.
    overriding function Validate_Parameters (
       Self : in out Instance;
       P_Gain : in Packed_F32.U;


### PR DESCRIPTION
A component's default parameter values are compiled in as record initializers and never pass through the component's own Validate_Parameters function, which runs only on ground-commanded table operations, so a default violating the component's cross-parameter checks flies silently until a table upload exposes it. The component autocoder now generates a public Validate_Parameter_Defaults subprogram that dispatches to Validate_Parameters with the working-copy values and fails an assertion on an invalid result, and the assembly autocoder calls it for every parameterized instance during the Set_Id_Bases phase. Running before components are connected or initialized is deliberate: it makes init-order independence part of the Validate_Parameters contract, so an override that strays into invoking a connector trips the unconnected-connector assertion at first startup rather than misbehaving later; the generated comment above Validate_Parameters now states that contract. Dying on an invalid default is likewise intentional - a default the component itself rejects is a defective build, and the assertion surfaces it on the first unit-test or simulation run instead of letting it reach flight.