### PR TITLE
Cache computed type ranges by Ada type name within a redo session

### DIFF
--- a/gen/models/packed_type.py
+++ b/gen/models/packed_type.py
@@ -3,8 +3,64 @@ from util import ada
 from util import redo_arg
 from util import model_loader
 from util import redo
+from collections import OrderedDict
 import os
 import abc
+
+
+class _type_ranges_cache_miss(Exception):
+    """
+    Raised internally when a type range cannot be served from the
+    session cache. It tells load_type_ranges() to fall back to building
+    and running this model's own type ranges program.
+    """
+    pass
+
+
+class _cached_type_ranges(object):
+    """
+    A stand-in for a type_ranges model that resolves lookups from the
+    session type ranges cache instead of from a *.type_ranges.yaml file.
+
+    This is what lets the cache work without any packed type subclass
+    knowing it exists. Every set_type_ranges() implementation already
+    asks a type ranges model for exactly the types it needs, one name at
+    a time, so serving those same calls from the cache requires no
+    duplicate knowledge of which fields need ranges. A name that cannot
+    be served raises _type_ranges_cache_miss.
+    """
+    def __init__(self, db, model_has_preamble):
+        self.db = db
+        self.model_has_preamble = model_has_preamble
+        # The *.type_ranges.yaml files whose programs computed the
+        # entries served here, in first seen order:
+        self.source_yamls = OrderedDict()
+
+    def get_type_by_name(self, name):
+        from database.type_ranges_cache_database import is_cacheable_type_name
+
+        # An undotted name that is not an Ada predefined scalar may be
+        # declared in this model's preamble, which makes it local to
+        # this model and unsafe to share by name. Note that a single
+        # such type puts the whole model on the slow path: its range can
+        # only come from this model's own type ranges program, and once
+        # that program has to be built there is nothing left to save.
+        if not is_cacheable_type_name(name, self.model_has_preamble):
+            raise _type_ranges_cache_miss(name)
+
+        try:
+            entry = self.db.try_get_type_range(name)
+        except Exception:
+            # Treat an unreadable cache as a miss. A cache failure must
+            # never fail a build, it just costs us the slow path.
+            raise _type_ranges_cache_miss(name)
+
+        if entry is None:
+            raise _type_ranges_cache_miss(name)
+
+        type_range, source_yaml = entry
+        self.source_yamls[source_yaml] = None
+        return type_range
 
 
 class packed_type(base):
@@ -81,22 +137,96 @@ class packed_type(base):
         """Get model dependencies."""
         return super().get_dependencies() + self.deps_list
 
+    def _load_type_ranges_from_cache(self):
+        """
+        Try to satisfy set_type_ranges() from the session type ranges
+        cache instead of building and running this model's type ranges
+        program. Returns True if every type the model asked for was
+        served from the cache, False otherwise.
+        """
+        from database.type_ranges_cache_database import type_ranges_cache_database
+
+        try:
+            db = type_ranges_cache_database()
+        except Exception:
+            # No readable cache database for this session. Fall back to
+            # the slow path, which needs no cache at all.
+            return False
+
+        with db:
+            resolver = _cached_type_ranges(db, bool(self.preamble))
+            try:
+                self.set_type_ranges(resolver)
+            except _type_ranges_cache_miss:
+                # This model needs at least one type the cache cannot
+                # serve, so its type ranges program has to be built
+                # anyway. Any field already set from the cache holds the
+                # value that program reports for it, since a type name
+                # resolves to one declaration for the whole session, and
+                # set_type_ranges() on the slow path leaves fields that
+                # are already loaded alone.
+                return False
+
+        # Depend on the type ranges yaml files whose programs computed
+        # the entries used here. This preserves the redo dependency chain
+        # from whatever target is being built, through those programs,
+        # down to the Ada source files that define these types, so that a
+        # later change to those sources still rebuilds the consumer.
+        if resolver.source_yamls:
+            redo.redo_ifchange(list(resolver.source_yamls.keys()))
+        return True
+
+    def _save_type_ranges_to_cache(self, type_ranges_model, type_ranges_yaml):
+        """
+        Store every cacheable type from a freshly built type ranges model
+        into the session cache, recording this model's type ranges yaml
+        as the source that computed them.
+        """
+        from database.type_ranges_cache_database import (
+            type_ranges_cache_database,
+            is_cacheable_type_name,
+        )
+        from database.database import DATABASE_MODE
+
+        try:
+            entries = [
+                (type_name, type_range)
+                for type_name, type_range in type_ranges_model.types.items()
+                if is_cacheable_type_name(type_name, bool(self.preamble))
+            ]
+            if entries:
+                with type_ranges_cache_database(
+                    mode=DATABASE_MODE.READ_WRITE
+                ) as db:
+                    for type_name, type_range in entries:
+                        db.store_type_range(type_name, type_range, type_ranges_yaml)
+        except Exception:
+            # Failing to populate the cache must never break the build.
+            # The next model needing these types just recomputes them.
+            pass
+
     def load_type_ranges(self):
         if not self.type_ranges_loaded:
-            # Build and load the type ranges model for this packed record.
-            type_ranges_yaml = (
-                redo_arg.get_src_dir(self.full_filename)
-                + os.sep
-                + "build"
-                + os.sep
-                + "yaml"
-                + os.sep
-                + self.model_name
-                + ".type_ranges.yaml"
-            )
-            redo.redo_ifchange(type_ranges_yaml)
-            type_ranges_model = model_loader.load_model(type_ranges_yaml)
+            cache_enabled = "DISABLE_TYPE_RANGES_CACHE" not in os.environ
+            if not (cache_enabled and self._load_type_ranges_from_cache()):
+                # Build and load the type ranges model for this packed record.
+                type_ranges_yaml = (
+                    redo_arg.get_src_dir(self.full_filename)
+                    + os.sep
+                    + "build"
+                    + os.sep
+                    + "yaml"
+                    + os.sep
+                    + self.model_name
+                    + ".type_ranges.yaml"
+                )
+                redo.redo_ifchange(type_ranges_yaml)
+                type_ranges_model = model_loader.load_model(type_ranges_yaml)
+                if cache_enabled:
+                    self._save_type_ranges_to_cache(
+                        type_ranges_model, type_ranges_yaml
+                    )
 
-            # Call the inherited abstract method.
-            self.set_type_ranges(type_ranges_model)
+                # Call the inherited abstract method.
+                self.set_type_ranges(type_ranges_model)
         self.type_ranges_loaded = True

--- a/redo/database/create.py
+++ b/redo/database/create.py
@@ -18,6 +18,7 @@ from database.utility_database import utility_database
 from database.redo_target_database import redo_target_database
 from database.build_target_database import build_target_database
 import database.model_cache_database
+import database.type_ranges_cache_database
 from database.model_database import model_database
 
 # Base class imports:
@@ -331,6 +332,8 @@ def create_pre_build_path():
     #######################################
     # Create an empty model cache database if it doesn't already exist:
     database.model_cache_database.touch_model_cache_database()
+    # Create an empty type ranges cache database if it doesn't already exist:
+    database.type_ranges_cache_database.touch_type_ranges_cache_database()
 
     #######################################
     # Create build target database:

--- a/redo/database/type_ranges_cache_database.py
+++ b/redo/database/type_ranges_cache_database.py
@@ -1,0 +1,116 @@
+from database.database import database
+from database.database import DATABASE_MODE
+from database.util import get_database_file
+
+# The purpose of the type ranges cache is to save off the computed type
+# range (min/max bounds or enumeration literals) of each underlying Ada
+# type encountered while producing *.type_ranges.yaml files. Computing
+# these ranges requires generating, compiling, linking, and running an
+# Ada program, which is expensive. Many packed types share the same
+# underlying Ada types (ie. Natural or Interfaces.Unsigned_16), so
+# caching computed ranges by type name allows most of these programs to
+# never be built at all.
+#
+# The cache database lives in the session temporary directory, so
+# entries only live for a single redo session. This is what makes the
+# cache safe to key by type name alone: redo builds each target at most
+# once per session, so the Ada source that defines a type cannot change
+# underneath the cache while it is alive.
+
+# Ada predefined scalar types (declared in package Standard) that are
+# directly visible to generated code without any "with" clause. These
+# are the only undotted type names that can be safely cached, since any
+# other undotted name must come from a model's preamble, whose contents
+# are local to that model. This list intentionally errs on the side of
+# omission. A name missing from this list simply results in a cache
+# miss, which is always safe.
+ADA_PREDEFINED_SCALAR_TYPES = frozenset(
+    [
+        "Boolean",
+        "Character",
+        "Duration",
+        "Float",
+        "Integer",
+        "Long_Float",
+        "Long_Integer",
+        "Long_Long_Float",
+        "Long_Long_Integer",
+        "Natural",
+        "Positive",
+        "Short_Float",
+        "Short_Integer",
+        "Short_Short_Integer",
+        "Wide_Character",
+        "Wide_Wide_Character",
+    ]
+)
+
+
+def is_cacheable_type_name(type_name, model_has_preamble):
+    """
+    Return True if a type name may be shared through the cache across
+    different packed type models.
+
+    Dotted names (ie. Interfaces.Unsigned_16) are package-qualified and
+    resolve to the same declaration everywhere in the build, so they are
+    always cacheable. Undotted names are only cacheable when they are
+    Ada predefined scalars AND the model has no preamble, since a
+    preamble may declare a local type that shadows a predefined name.
+    """
+    if "." in type_name:
+        return True
+    return not model_has_preamble and type_name in ADA_PREDEFINED_SCALAR_TYPES
+
+
+def get_type_key(type_name):
+    """
+    Form the cache key for a type name. The key includes the build
+    directory the type ranges programs are compiled for, so that ranges
+    computed under different native targets never mix. This is the same
+    helper the *.type_ranges.yaml build rule uses to locate those
+    programs.
+    """
+    from util import target
+
+    return target.get_native_build_for() + "//" + type_name
+
+
+class type_ranges_cache_database(database):
+    def __init__(self, mode=DATABASE_MODE.READ_ONLY):
+        """Initialize the database."""
+        super(type_ranges_cache_database, self).__init__(
+            get_database_file("type_ranges_cache"), mode
+        )
+
+    def store_type_range(self, type_name, type_range, source_yaml):
+        """
+        Store the computed range object (a type_number or type_enum from
+        models.type_ranges) for a type name, along with the path of the
+        *.type_ranges.yaml file whose program computed it. The source
+        yaml is kept so that cache readers can depend on it via redo,
+        preserving the dependency chain from any target consuming the
+        cached range, through the program that computed it, to the Ada
+        source files that define the type.
+        """
+        self.store(get_type_key(type_name), (type_range, source_yaml))
+
+    def try_get_type_range(self, type_name):
+        """
+        Fetch the cache entry for a type name. Returns a tuple of
+        (type_range, source_yaml) or None if no entry exists.
+        """
+        return self.try_fetch(get_type_key(type_name))
+
+
+def touch_type_ranges_cache_database():
+    """
+    Create an empty type ranges cache database file, if one does
+    not already exist:
+    """
+    import os.path
+
+    filename = get_database_file("type_ranges_cache")
+    if not os.path.isfile(filename):
+        with type_ranges_cache_database(mode=DATABASE_MODE.CREATE) as db:
+            # Get a dummy element to make sure database is created
+            db.try_get_type_range("dummy")

--- a/redo/rules/build_type_ranges_yaml.py
+++ b/redo/rules/build_type_ranges_yaml.py
@@ -7,7 +7,6 @@ from util import redo_arg
 from util import target
 from base_classes.build_rule_base import build_rule_base
 import database.model_database
-import platform
 
 
 class build_type_ranges_yaml(build_rule_base):
@@ -24,13 +23,7 @@ class build_type_ranges_yaml(build_rule_base):
             model_type,
             specific_name,
         ) = database.model_database.split_model_file_name(redo_1)
-        the_target = target.try_get_target()
-        build_for = platform.system()
-        if the_target:
-            if the_target.endswith("_Test"):
-                build_for += "_Test"
-            if the_target.endswith("_Deprecated"):
-                build_for += "_Deprecated"
+        build_for = target.get_native_build_for()
         elf = (
             directory
             + os.sep

--- a/redo/util/target.py
+++ b/redo/util/target.py
@@ -52,6 +52,29 @@ def get_default_target():
         return platform.system()
 
 
+def get_native_build_for():
+    """
+    Get the name of the build directory used for executables that are
+    compiled for, and run on, the build machine itself, ie. something
+    like "Linux" or "Linux_Test".
+
+    This is NOT the current target. Some executables (ie. the type
+    ranges programs) must run on the build machine even when cross
+    compiling, so they are always built for the native platform. The
+    "_Test" and "_Deprecated" variants of the current target are still
+    honored, since those select different source, and therefore
+    different results, on the native platform.
+    """
+    the_target = try_get_target()
+    build_for = platform.system()
+    if the_target:
+        if the_target.endswith("_Test"):
+            build_for += "_Test"
+        if the_target.endswith("_Deprecated"):
+            build_for += "_Deprecated"
+    return build_for
+
+
 def set_default_target():
     """
     Set the current target to the default target which

--- a/src/components/command_sequencer/seq/types/packed_seq_opcode.record.yaml
+++ b/src/components/command_sequencer/seq/types/packed_seq_opcode.record.yaml
@@ -4,4 +4,4 @@ fields:
   - name: Opcode
     description: Instruction code
     type: Seq_Enums.Seq_Opcode.E
-    format: U8
+    format: E8


### PR DESCRIPTION
## Problem

Producing a `*.type_ranges.yaml` file requires generating, compiling, linking, and running a dedicated Ada program, once per packed type model. These programs exist to extract ground truth from the compiler (`'First`/`'Last` bounds and enumeration literals via `'Image`/`'Enum_Rep`), but most packed type models draw their fields from the same small set of underlying Ada types (`Natural`, `Interfaces.Unsigned_16`, `Basic_Types.Byte`, and so on). On a clean build, nearly every one of these programs relinks an executable to recompute answers that another model's program already produced. Models whose fields are all packed types or modeled enums pay the full compile and link cost just to print an empty list.

## Approach

A session-scoped cache database (`type_ranges_cache_database`, following the `model_cache_database` pattern) maps Ada type names to their computed ranges. It is consulted in `packed_type.load_type_ranges()`:

- The stand-in type ranges model handed to `set_type_ranges()` resolves each `get_type_by_name()` call against the cache as it is made. If every name is served, the model's type ranges program is never built or run. Models that ask for nothing (all fields packed types or modeled enums) skip the program without a single cache lookup.
- A name the cache cannot serve raises an internal miss exception, and `load_type_ranges()` falls back to the existing path: build the yaml via the program, load it, then store every cacheable type from the result for the rest of the session.

Resolving lazily rather than predicting which fields need ranges is what keeps the feature contained. The questions the cache answers are precisely the questions `set_type_ranges()` asks, so no filter has to be duplicated and no packed type subclass needs to know the cache exists: `record.py`, `array.py` and `type.py` are untouched. The `build_type_ranges_yaml` rule is untouched too, so explicitly redoing a `*.type_ranges.yaml` target behaves exactly as before. The one piece of shared knowledge, the native platform directory the programs are built for, is now a single `target.get_native_build_for()` helper used by both the rule that locates a program and the cache that keys its entries.

## Performance

Measured on a cleaned `src/types` subtree (103 packed type models), both arms run back to back from identical clean states:

| | Wall time | Type ranges programs built |
|---|---|---|
| `DISABLE_TYPE_RANGES_CACHE=1` | 9m37s | 103 of 103 |
| cache enabled | 3m22s | 35 of 103 |

2.9x faster here, with 66% of the programs never built, and identical range output from both arms.
