### PR TITLE
Convert the binary tree package to SPARK silver

### DIFF
--- a/src/data_structures/binary_tree/all.prove.yaml
+++ b/src/data_structures/binary_tree/all.prove.yaml
@@ -1,0 +1,4 @@
+---
+description: GNATprove configuration for the binary tree package. The target is silver, absence of runtime errors, including proof of the defensive assertions.
+level: 2
+mode: "silver"

--- a/src/data_structures/binary_tree/binary_tree.adb
+++ b/src/data_structures/binary_tree/binary_tree.adb
@@ -1,16 +1,23 @@
 with Safe_Deallocator;
 
-package body Binary_Tree is
+package body Binary_Tree with SPARK_Mode => On is
    ----------------------------------
    -- Public sub programs:
    ----------------------------------
 
-   procedure Init (Self : in out Instance; Maximum_Size : in Positive) is
+   -- The body is not analyzed by SPARK since it performs the heap allocation
+   -- that owns the element storage for the rest of the tree's life. The
+   -- postcondition holds because the precondition provides an empty tree and
+   -- the allocation below is indexed from 1 with the requested positive size.
+   procedure Init (Self : in out Instance; Maximum_Size : in Positive) with SPARK_Mode => Off is
    begin
       Self.Tree := new Element_Array (Positive'First .. Positive'First + Maximum_Size - 1);
    end Init;
 
-   procedure Destroy (Self : in out Instance) is
+   -- The body is not analyzed by SPARK since conditional deallocation is
+   -- outside the SPARK ownership model. The postcondition holds because
+   -- Clear sets the size to zero below.
+   procedure Destroy (Self : in out Instance) with SPARK_Mode => Off is
       procedure Free_If_Testing is new Safe_Deallocator.Deallocate_If_Testing (Object => Element_Array, Name => Element_Array_Access);
    begin
       Free_If_Testing (Self.Tree);
@@ -89,6 +96,11 @@ package body Binary_Tree is
 
       -- Perform binary search on sorted list:
       while Low_Index <= High_Index loop
+         -- The search range stays within the elements held, so every probed index is in range.
+         pragma Loop_Invariant (Low_Index >= Self.Tree'First);
+         pragma Loop_Invariant (High_Index <= Self.Size);
+         -- The search range shrinks every iteration, so the loop terminates.
+         pragma Loop_Variant (Decreases => High_Index - Low_Index);
          declare
             Mid_Index : constant Positive := Low_Index + ((High_Index - Low_Index) / 2);
             Current_Element : Element_Type renames Self.Tree (Mid_Index);
@@ -126,16 +138,6 @@ package body Binary_Tree is
    begin
       Self.Size := 0;
    end Clear;
-
-   function Get_Size (Self : in Instance) return Natural is
-   begin
-      return Self.Size;
-   end Get_Size;
-
-   function Get_Capacity (Self : in Instance) return Positive is
-   begin
-      return Self.Tree'Length;
-   end Get_Capacity;
 
    function Get_First_Index (Self : in Instance) return Positive is
    begin

--- a/src/data_structures/binary_tree/binary_tree.ads
+++ b/src/data_structures/binary_tree/binary_tree.ads
@@ -29,34 +29,136 @@ generic
    type Element_Type is private;
    with function "<" (Left, Right : Element_Type) return Boolean is <>;
    with function ">" (Left, Right : Element_Type) return Boolean is <>;
-package Binary_Tree is
+package Binary_Tree with SPARK_Mode => On is
+
+   -- The contracts and ghost code in this package exist for proof with
+   -- GNATprove only. The assertion policy below disables them at runtime, so
+   -- the generated code and the runtime behavior of this package is
+   -- identical to what it was before the SPARK conversion. The defensive
+   -- pragma Assert statements in the package body are not affected by this
+   -- policy. They remain compiled in and enabled under the project wide
+   -- assertion policy, and they are also proved.
+   pragma Assertion_Policy
+      (Pre => Ignore,
+       Pre'Class => Ignore,
+       Post => Ignore,
+       Post'Class => Ignore,
+       Contract_Cases => Ignore,
+       Ghost => Ignore,
+       Loop_Invariant => Ignore,
+       Loop_Variant => Ignore,
+       Assert_And_Cut => Ignore,
+       Subprogram_Variant => Ignore);
+   pragma Unevaluated_Use_Of_Old (Allow);
+
    type Instance is tagged limited private;
    type Instance_Access is access all Instance;
 
-   procedure Init (Self : in out Instance; Maximum_Size : in Positive);
-   procedure Destroy (Self : in out Instance);
+   -- Maximum tree capacity supported by the proof. The binary search steps
+   -- its bounds one past the probed index, so this bound keeps that
+   -- arithmetic within Integer. All realistic trees are far below this bound.
+   -- Trees larger than this are outside the verified domain and behave as
+   -- they did before the SPARK conversion.
+   Max_Tree_Size : constant := Positive'Last - 1;
+
+   -- Ghost predicate stating that the tree is in a valid, initialized state:
+   -- storage has been allocated by Init and the number of elements held
+   -- fits within that storage. This is the precondition of every operation
+   -- that touches the element storage. It takes a class-wide parameter so
+   -- that it is not a dispatching operation, which would force every derived
+   -- type to override each operation mentioning it (SPARK RM 6.1.1).
+   function Is_Valid (Self : in Instance'Class) return Boolean
+      with Ghost;
+
+   -- Allocate storage for the tree. The tree must be empty, as it is when
+   -- default initialized or after Clear or Destroy.
+   procedure Init (Self : in out Instance; Maximum_Size : in Positive)
+      with
+         -- The tree holds no elements and the requested capacity is within the verified maximum.
+         Pre'Class => Get_Size (Self) = 0 and then Maximum_Size <= Max_Tree_Size,
+         -- The tree is valid, still holds no elements, and its capacity is the requested size.
+         Post => Is_Valid (Self) and then Get_Size (Self) = 0 and then Get_Capacity (Self) = Maximum_Size;
+   -- Release the tree storage when testing and empty the tree.
+   procedure Destroy (Self : in out Instance)
+      with
+         -- The tree holds no elements.
+         Post => Get_Size (Self) = 0;
 
    -- Add element to tree. This is done in O(n) time where n is the current size of the tree.
    -- Return: True means add was successful. False means there is no more room in the tree.
-   function Add (Self : in out Instance; Element : in Element_Type) return Boolean;
+   function Add (Self : in out Instance; Element : in Element_Type) return Boolean
+      with
+         Side_Effects,
+         -- The tree is valid.
+         Pre'Class => Is_Valid (Self),
+         -- The tree is still valid with the same capacity, the add succeeds exactly when there was
+         -- room, and on success the size grew by one, otherwise it is unchanged.
+         Post => Is_Valid (Self)
+            and then Get_Capacity (Self) = Get_Capacity (Self)'Old
+            and then Add'Result = (Get_Size (Self)'Old < Get_Capacity (Self))
+            and then (if Add'Result then Get_Size (Self) = Get_Size (Self)'Old + 1 else Get_Size (Self) = Get_Size (Self)'Old);
    -- Remove element from tree. This is done in O(n) time where n is the current size of the tree.
    -- Return: True means remove was successful. False means the provided index is not found in the tree.
-   function Remove (Self : in out Instance; Element_Index : in Positive) return Boolean;
+   function Remove (Self : in out Instance; Element_Index : in Positive) return Boolean
+      with
+         Side_Effects,
+         -- The tree is valid.
+         Pre'Class => Is_Valid (Self),
+         -- The tree is still valid with the same capacity, the remove succeeds exactly when the index
+         -- was within the size, and on success the size shrank by one, otherwise it is unchanged.
+         Post => Is_Valid (Self)
+            and then Get_Capacity (Self) = Get_Capacity (Self)'Old
+            and then Remove'Result = (Element_Index <= Get_Size (Self)'Old)
+            and then (if Remove'Result then Get_Size (Self) = Get_Size (Self)'Old - 1 else Get_Size (Self) = Get_Size (Self)'Old);
    -- Search for element in tree. This is done in O(log n) where n is the current size of the tree.
    -- Return: True means element was found. False means it was not. The element and index in the array where it was found are also returned.
-   function Search (Self : in Instance; Element : in Element_Type; Element_Found : out Element_Type; Element_Index : out Positive) return Boolean;
+   function Search (Self : in Instance; Element : in Element_Type; Element_Found : out Element_Type; Element_Index : out Positive) return Boolean
+      with
+         Side_Effects,
+         -- The tree is valid.
+         Pre'Class => Is_Valid (Self),
+         -- On success the returned index is within the size, otherwise it is the sentinel value 1.
+         Post => (if Search'Result then Element_Index <= Get_Size (Self) else Element_Index = 1);
    -- Get an element via its index. This can be helpful to quickly retrieve an element in O(1) time if you have already obtained its index via "search".
-   function Get (Self : in Instance; Element_Index : in Positive) return Element_Type;
+   function Get (Self : in Instance; Element_Index : in Positive) return Element_Type
+      with
+         -- The tree is valid and the index is within the size.
+         Pre'Class => Is_Valid (Self) and then Element_Index <= Get_Size (Self);
    -- Set an element via its index. This can be helpful to quickly set an element in O(1) time if you have already obtained its index via "search".
-   procedure Set (Self : in out Instance; Element_Index : in Positive; Element : in Element_Type);
+   procedure Set (Self : in out Instance; Element_Index : in Positive; Element : in Element_Type)
+      with
+         -- The tree is valid and the index is within the size.
+         Pre'Class => Is_Valid (Self) and then Element_Index <= Get_Size (Self),
+         -- The tree is still valid with the same size and capacity.
+         Post => Is_Valid (Self)
+            and then Get_Size (Self) = Get_Size (Self)'Old
+            and then Get_Capacity (Self) = Get_Capacity (Self)'Old;
    -- Clear the tree. This is done in O(1) time.
-   procedure Clear (Self : in out Instance);
+   procedure Clear (Self : in out Instance)
+      with
+         -- The tree is valid.
+         Pre'Class => Is_Valid (Self),
+         -- The tree is still valid with the same capacity and holds no elements.
+         Post => Is_Valid (Self)
+            and then Get_Size (Self) = 0
+            and then Get_Capacity (Self) = Get_Capacity (Self)'Old;
    -- Get functions:
    function Get_Size (Self : in Instance) return Natural;
-   function Get_Capacity (Self : in Instance) return Positive;
+   function Get_Capacity (Self : in Instance) return Positive
+      with
+         -- The tree is valid.
+         Pre'Class => Is_Valid (Self);
    -- Functions to get the first and last index in the tree. If the tree is empty, then first returns 1 and last returns 0.
-   function Get_First_Index (Self : in Instance) return Positive;
-   function Get_Last_Index (Self : in Instance) return Natural;
+   function Get_First_Index (Self : in Instance) return Positive
+      with
+         -- The tree is valid.
+         Pre'Class => Is_Valid (Self),
+         -- The first index is always 1.
+         Post => Get_First_Index'Result = 1;
+   function Get_Last_Index (Self : in Instance) return Natural
+      with
+         -- The last index is the number of elements held.
+         Post => Get_Last_Index'Result = Get_Size (Self);
 
 private
    type Element_Array is array (Positive range <>) of Element_Type;
@@ -68,4 +170,20 @@ private
       -- an O(log n) search.
       Tree : Element_Array_Access := null;
    end record;
+
+   -- Ghost model completion. Storage is allocated, starts at index 1, holds
+   -- at least one element and no more than the verified maximum, and the
+   -- number of elements in the tree never exceeds the storage:
+   function Is_Valid (Self : in Instance'Class) return Boolean is
+      (Self.Tree /= null
+         and then Self.Tree'First = 1
+         and then Self.Tree'Last >= 1
+         and then Self.Tree'Last <= Max_Tree_Size
+         and then Self.Size <= Self.Tree'Last);
+
+   -- Expression function completions, so that the proof can see through
+   -- these accessors when they appear in the contracts above:
+   function Get_Size (Self : in Instance) return Natural is (Self.Size);
+   function Get_Capacity (Self : in Instance) return Positive is (Self.Tree'Length);
+
 end Binary_Tree;

--- a/src/data_structures/binary_tree/binary_tree_prover.ads
+++ b/src/data_structures/binary_tree/binary_tree_prover.ads
@@ -1,0 +1,23 @@
+with Binary_Tree;
+
+-- This package exists solely so that GNATprove analyzes an instance of the
+-- generic Binary_Tree package, since GNATprove analyzes generics only at
+-- their instantiation points. Real instantiations elsewhere in a project are
+-- verified at their own instantiation points when they occur in SPARK
+-- analyzed code. Nothing references this package, so it contributes no code
+-- to any build.
+package Binary_Tree_Prover with SPARK_Mode => On is
+
+   -- A representative element, similar in shape to the identifier keyed
+   -- records that binary trees typically hold:
+   type Example_Element is record
+      Id : Natural := 0;
+      Value : Natural := 0;
+   end record;
+
+   function "<" (Left, Right : Example_Element) return Boolean is (Left.Id < Right.Id);
+   function ">" (Left, Right : Example_Element) return Boolean is (Left.Id > Right.Id);
+
+   package Example_Tree is new Binary_Tree (Example_Element);
+
+end Binary_Tree_Prover;


### PR DESCRIPTION
## Summary

Converts `src/data_structures/binary_tree/` to SPARK and proves it at the **silver** level (absence of runtime errors) with GNATprove 15.1.0 at `--level=2`.

## What changed

- **API unchanged.** Every subprogram keeps its name, profile and behavior. All contracts are proof only: an `Assertion_Policy` at the top of the package ignores them at runtime, so the generated code is identical to the unconverted package for every instantiation. The defensive `pragma Assert` statements in `Add` and `Search` stay live and are now proved.
- **Every contract and loop invariant carries a one sentence plain English comment** directly above it saying what it checks.
- **One ghost predicate, `Is_Valid`**: storage allocated, indexed from 1, within `Max_Tree_Size`, and `Size <= Tree'Last`. `Init` establishes it, everything else preserves it. With it, the size assertion at the top of `Search` and every index inside the binary search are proved.
- **`Init` and `Destroy`** are the only `SPARK_Mode => Off` bodies (heap allocation and conditional deallocation are outside the ownership model). Their postconditions are documented in the body.
- **`Get` and `Set`** gain the explicit precondition `Element_Index <= Get_Size (Self)`, which is the obligation callers already meet by taking indices from `Search` or `Get_First_Index .. Get_Last_Index`.
- **`Max_Tree_Size = Positive'Last - 1`**: the binary search steps `Mid_Index + 1`, which genuinely overflows when the capacity is `Positive'Last`. Trees above the bound are outside the verified domain and behave exactly as before.
- `Get_Size` and `Get_Capacity` become expression functions in the private part so the proof can see through them. Functions with `in out`/`out` parameters carry the `Side_Effects` aspect SPARK requires.
- `all.prove.yaml` selects silver, level 2. `binary_tree_prover.ads` instantiates the generic so GNATprove has an instance to analyze (generics are only analyzed at instantiation points). Nothing references it and it adds no code to any build.

## Proof results

```
Run-time Checks       55   proved
Assertions             9   proved
Functional Contracts  16   proved
Initialization         3   flow
Termination            9   8 flow, 1 proved
Total                 92   0 unproved, 0 justified, 0 pragma Assume
```
