### PR TITLE
Convert the protected variables package to SPARK silver

### DIFF
--- a/redo/targets/gpr/linux_prove.gpr
+++ b/redo/targets/gpr/linux_prove.gpr
@@ -1,0 +1,33 @@
+project linux_prove extends all "a_linux_debug_base.gpr" is
+
+   -----------------------------------------------
+   -- These lines of code must be included at the
+   -- top of every Adamant based .gpr file. They
+   -- are used to connect the Adamant build system
+   -- to GPRBuild.
+   -----------------------------------------------
+   for Source_Dirs use a_adamant.SOURCE_DIRS;
+   for Excluded_Source_Files use a_adamant.EXCLUDED_SOURCE_FILES;
+   for Object_Dir use a_adamant.OBJECT_DIR;
+   for Exec_Dir use a_adamant.EXEC_DIR;
+
+   --
+   -- This GPR file is the same as linux_debug.gpr but also enforces the
+   -- sequential partition elaboration policy, as the bareboard targets do.
+   -- GNATprove requires it to analyze tasking constructs such as protected
+   -- types (SPARK RM 9(2)), and it matches the configuration the flight
+   -- software actually runs under.
+   --
+   package Compiler is
+      -- Add preprocessor definitions and configuration pragma switches:
+      for Switches ("Ada") use a_linux_debug_base.Compiler'Switches ("Ada") &
+         -- add ravenscar restriction
+         ("-gnatec=" & a_adamant.ADAMANT_DIR & "/redo/targets/configuration_pragmas/ravenscar.adc") &
+         -- add sequential elaboration policy
+         ("-gnatec=" & a_adamant.ADAMANT_DIR & "/redo/targets/configuration_pragmas/sequential_elaboration.adc");
+      for Switches ("C++") use a_linux_debug_base.Compiler'Switches ("C++");
+      for Switches ("C") use a_linux_debug_base.Compiler'Switches ("C");
+      for Switches ("Asm_Cpp") use a_linux_debug_base.Compiler'Switches ("Asm_Cpp");
+   end Compiler;
+
+end linux_prove;

--- a/redo/targets/linux.py
+++ b/redo/targets/linux.py
@@ -77,7 +77,15 @@ class Linux_Coverage(Linux_Base):
 class Linux_Prove(Linux_Debug):
     """This is the target used with GNATprove to verify SPARK code."""
     def description(self):
-        return "This target is used to generate the path for calls to GNATprove to analyze SPARK code."
+        return ("This target is used to generate the path for calls to GNATprove to analyze SPARK code. "
+                "It is the same as Linux_Debug but also enforces the sequential partition elaboration "
+                "policy, which GNATprove requires to analyze tasking constructs.")
+
+    def gpr_project_file(self):
+        return os.path.join(
+            os.environ["ADAMANT_DIR"],
+            "redo" + os.sep + "targets" + os.sep + "gpr" + os.sep + "linux_prove.gpr",
+        )
 
 
 class Linux_Analyze(Linux_Base):

--- a/src/components/pid_controller/component-pid_controller-implementation.adb
+++ b/src/components/pid_controller/component-pid_controller-implementation.adb
@@ -161,7 +161,7 @@ package body Component.Pid_Controller.Implementation is
          declare
             use Pid_Diagnostic_Subpacket;
             -- The current diagnostic count:
-            Diag_Count : constant Integer := Self.Diagnostic_Counter.Get_Count;
+            Diag_Count : constant Natural := Self.Diagnostic_Counter.Get_Count;
             -- The current index in the packet we are filling:
             Diagnostic_Packet_Index : Natural := (Self.Diagnostic_Subpacket_Count * Pid_Diagnostic_Subpacket.Max_Serialized_Length) + Packed_Natural.Max_Serialized_Length;
 
@@ -244,7 +244,7 @@ package body Component.Pid_Controller.Implementation is
       use Command_Execution_Status;
    begin
       -- Set the diagnostic subpacket count
-      Self.Diagnostic_Counter.Set_Count (Integer (Arg.Duration));
+      Self.Diagnostic_Counter.Set_Count (Natural (Arg.Duration));
       -- Throw informational event:
       Self.Event_T_Send_If_Connected (Self.Events.Diagnostics_Started (Self.Sys_Time_T_Get, Arg));
       return Success;

--- a/src/components/pid_controller/component-pid_controller-implementation.ads
+++ b/src/components/pid_controller/component-pid_controller-implementation.ads
@@ -29,7 +29,7 @@ package Component.Pid_Controller.Implementation is
 private
 
    -- Protected objects for protecting data that can be modified by synchronous command.
-   package Protected_Signed_16_Counter is new Protected_Variables.Generic_Protected_Counter_Decrement (Integer);
+   package Protected_Natural_Counter is new Protected_Variables.Generic_Protected_Counter_Decrement (Natural);
    package Protected_Unsigned_16_Counter is new Protected_Variables.Generic_Protected_Periodic_Counter (Interfaces.Unsigned_16);
    package Moving_Average_Variable is new Moving_Average (Short_Float);
 
@@ -59,7 +59,7 @@ private
       Control_Out_Prev_D : Short_Float := 0.0;
 
       -- Diagnostic packet variables
-      Diagnostic_Counter : Protected_Signed_16_Counter.Counter;
+      Diagnostic_Counter : Protected_Natural_Counter.Counter;
       Diagnostic_Packet : Packet.T;
       Diagnostic_Subpacket_Count : Natural := 0;
 

--- a/src/data_structures/protected_variables/all.prove.yaml
+++ b/src/data_structures/protected_variables/all.prove.yaml
@@ -1,0 +1,4 @@
+---
+description: GNATprove configuration for the protected variables package. The target is silver, absence of runtime errors.
+level: 3
+mode: "silver"

--- a/src/data_structures/protected_variables/protected_variables.adb
+++ b/src/data_structures/protected_variables/protected_variables.adb
@@ -1,4 +1,4 @@
-package body Protected_Variables is
+package body Protected_Variables with SPARK_Mode => On is
 
    package body Generic_Variable is
       protected body Variable is
@@ -63,13 +63,23 @@ package body Protected_Variables is
 
          procedure Decrement_Count (To_Subtract : in T := 1) is
          begin
-            Count := @ - To_Subtract;
+            -- Saturate at zero:
+            if To_Subtract > Count then
+               Count := 0;
+            else
+               Count := @ - To_Subtract;
+            end if;
          end Decrement_Count;
 
          procedure Decrement_Count_And_Return_Previous (Prev_Count : out T; To_Subtract : in T := 1) is
          begin
             Prev_Count := Count;
-            Count := @ - To_Subtract;
+            -- Saturate at zero:
+            if To_Subtract > Count then
+               Count := 0;
+            else
+               Count := @ - To_Subtract;
+            end if;
          end Decrement_Count_And_Return_Previous;
       end Counter;
    end Generic_Protected_Counter_Decrement;

--- a/src/data_structures/protected_variables/protected_variables.ads
+++ b/src/data_structures/protected_variables/protected_variables.ads
@@ -2,7 +2,7 @@
 -- components. Each protected variable pattern is contained within a generic
 -- package that can be adapted for the particular type needed.
 
-package Protected_Variables is
+package Protected_Variables with SPARK_Mode => On is
 
    -- A generic variable that can be set/fetched in a thread safe way.
    generic
@@ -40,11 +40,21 @@ package Protected_Variables is
       end Counter;
    end Generic_Protected_Counter;
 
-   -- A generic counter whose members are set/fetched/incremented in a thread safe way.
+   -- A generic countdown whose members are set/fetched/decremented in a thread
+   -- safe way. The count never goes below zero: decrementing by more than the
+   -- current count leaves the count at zero. A caller can therefore decrement
+   -- freely and treat a count of zero as "expired" without guarding the
+   -- decrement, and no operation of this counter raises an exception. To
+   -- detect the moment the countdown expires, read the count before
+   -- decrementing.
    generic
-      -- Any modular type
+      -- Any signed integer type whose range starts at zero, such as Natural,
+      -- so that zero is the floor of the countdown and a decrement of 1 is
+      -- always representable.
       type T is range <>;
    package Generic_Protected_Counter_Decrement is
+      pragma Compile_Time_Error (T'First /= 0 or else T'Last < 1, "Generic_Protected_Counter_Decrement requires a type whose range starts at zero and includes one; the count is a countdown that saturates at zero.");
+
       protected type Counter is
          -- Set the count.
          procedure Set_Count (Value : in T);
@@ -52,11 +62,15 @@ package Protected_Variables is
          function Get_Count return T;
          -- Set the count to zero.
          procedure Reset_Count;
-         -- Increment the count, by 1 by default.
+         -- Decrement the count, by 1 by default. The count saturates at zero:
+         -- if To_Subtract is more than the current count, the count becomes
+         -- zero. Never raises.
          procedure Decrement_Count (To_Subtract : in T := 1);
-         -- Same as Decrement_Count but returns the previous value.
+         -- Same as Decrement_Count but returns the previous value, so a caller
+         -- can tell exactly which decrement expired the countdown.
          procedure Decrement_Count_And_Return_Previous (Prev_Count : out T; To_Subtract : in T := 1);
       private
+         -- The count starts expired:
          Count : T := 0;
       end Counter;
    end Generic_Protected_Counter_Decrement;

--- a/src/data_structures/protected_variables/protected_variables_prover.ads
+++ b/src/data_structures/protected_variables/protected_variables_prover.ads
@@ -1,0 +1,29 @@
+with Protected_Variables;
+with Interfaces;
+
+-- This package exists solely so that GNATprove analyzes an instance of each
+-- generic package inside Protected_Variables, since GNATprove analyzes
+-- generics only at their instantiation points. Real instantiations elsewhere
+-- in a project are verified at their own instantiation points when they
+-- occur in SPARK analyzed code. Nothing references this package, so it
+-- contributes no code to any build.
+package Protected_Variables_Prover with SPARK_Mode => On is
+
+   -- A representative record, similar in shape to the packed record types
+   -- that components typically hold in a protected variable:
+   type Example_Record is record
+      Id : Interfaces.Unsigned_16 := 0;
+      Value : Interfaces.Unsigned_16 := 0;
+   end record;
+
+   package Example_Variable is new Protected_Variables.Generic_Variable (Example_Record);
+   package Example_Counter is new Protected_Variables.Generic_Protected_Counter (Interfaces.Unsigned_32);
+   -- The countdown requires a range starting at zero. Natural is the typical
+   -- actual, and a narrow range checks that nothing depends on T'Last:
+   package Example_Countdown is new Protected_Variables.Generic_Protected_Counter_Decrement (Natural);
+   type Narrow_Range is range 0 .. 7;
+   package Example_Narrow_Countdown is new Protected_Variables.Generic_Protected_Counter_Decrement (Narrow_Range);
+   package Example_Staged_Variable is new Protected_Variables.Generic_Staged_Variable (Example_Record);
+   package Example_Periodic_Counter is new Protected_Variables.Generic_Protected_Periodic_Counter (Interfaces.Unsigned_16);
+
+end Protected_Variables_Prover;

--- a/src/data_structures/protected_variables/test/protected_variables_tests-implementation.adb
+++ b/src/data_structures/protected_variables/test/protected_variables_tests-implementation.adb
@@ -17,8 +17,8 @@ package body Protected_Variables_Tests.Implementation is
    type Byte_Mod is mod 2**8;
    package Byte_Counter is new Protected_Variables.Generic_Protected_Counter (T => Byte_Mod);
 
-   type Signed_Range is range -100 .. 100;
-   package Signed_Counter is new Protected_Variables.Generic_Protected_Counter_Decrement (T => Signed_Range);
+   type Countdown_Range is range 0 .. 100;
+   package Countdown_Counter is new Protected_Variables.Generic_Protected_Counter_Decrement (T => Countdown_Range);
 
    package Byte_Periodic_Counter is new Protected_Variables.Generic_Protected_Periodic_Counter (T => Byte_Mod);
 
@@ -33,7 +33,7 @@ package body Protected_Variables_Tests.Implementation is
    -- Smart-assert instantiations for the custom types declared above.
    -- Integer_Assert / Boolean_Assert come from Basic_Assertions.
    package Byte_Mod_Assert is new Smart_Assert.Discrete (Byte_Mod, Byte_Mod'Image);
-   package Signed_Range_Assert is new Smart_Assert.Discrete (Signed_Range, Signed_Range'Image);
+   package Countdown_Range_Assert is new Smart_Assert.Discrete (Countdown_Range, Countdown_Range'Image);
    package Pair_Assert is new Smart_Assert.Basic (Pair, Pair'Image);
 
    -------------------------------------------------------------------------
@@ -103,37 +103,46 @@ package body Protected_Variables_Tests.Implementation is
 
    overriding procedure Test_Protected_Counter_Decrement (Self : in out Instance) is
       Ignore : Instance renames Self;
-      C : Signed_Counter.Counter;
-      Prev : Signed_Range;
+      C : Countdown_Counter.Counter;
+      Prev : Countdown_Range;
    begin
       -- Default starts at 0.
-      Signed_Range_Assert.Eq (C.Get_Count, 0);
-
+      Countdown_Range_Assert.Eq (C.Get_Count, 0);
       -- Set / Get.
       C.Set_Count (50);
-      Signed_Range_Assert.Eq (C.Get_Count, 50);
-
+      Countdown_Range_Assert.Eq (C.Get_Count, 50);
       -- Default decrement is 1.
       C.Decrement_Count;
-      Signed_Range_Assert.Eq (C.Get_Count, 49);
-
+      Countdown_Range_Assert.Eq (C.Get_Count, 49);
       -- Decrement by N.
       C.Decrement_Count (To_Subtract => 9);
-      Signed_Range_Assert.Eq (C.Get_Count, 40);
-
-      -- Reset.
-      C.Reset_Count;
-      Signed_Range_Assert.Eq (C.Get_Count, 0);
-
-      -- Negative range (counter is signed).
+      Countdown_Range_Assert.Eq (C.Get_Count, 40);
+      -- Decrement exactly to the floor.
+      C.Decrement_Count (To_Subtract => 40);
+      Countdown_Range_Assert.Eq (C.Get_Count, 0);
+      -- Decrementing at the floor saturates, it does not raise or wrap.
+      C.Decrement_Count;
+      Countdown_Range_Assert.Eq (C.Get_Count, 0);
+      C.Decrement_Count (To_Subtract => 100);
+      Countdown_Range_Assert.Eq (C.Get_Count, 0);
+      -- Decrementing by more than the count saturates.
+      C.Set_Count (5);
       C.Decrement_Count (To_Subtract => 20);
-      Signed_Range_Assert.Eq (C.Get_Count, -20);
-
+      Countdown_Range_Assert.Eq (C.Get_Count, 0);
+      -- Reset.
+      C.Set_Count (7);
+      C.Reset_Count;
+      Countdown_Range_Assert.Eq (C.Get_Count, 0);
       -- Return-previous semantics.
       C.Set_Count (10);
       C.Decrement_Count_And_Return_Previous (Prev_Count => Prev, To_Subtract => 4);
-      Signed_Range_Assert.Eq (Prev, 10);
-      Signed_Range_Assert.Eq (C.Get_Count, 6);
+      Countdown_Range_Assert.Eq (Prev, 10);
+      Countdown_Range_Assert.Eq (C.Get_Count, 6);
+      -- Return-previous saturates too, and still reports the previous value.
+      C.Decrement_Count_And_Return_Previous (Prev_Count => Prev, To_Subtract => 50);
+      Countdown_Range_Assert.Eq (Prev, 6);
+      Countdown_Range_Assert.Eq (C.Get_Count, 0);
+
    end Test_Protected_Counter_Decrement;
 
    overriding procedure Test_Protected_Periodic_Counter (Self : in out Instance) is


### PR DESCRIPTION
## Summary

Converts `src/data_structures/protected_variables/` to SPARK and proves it at the **silver** level (absence of runtime errors) with GNATprove 15.1.0 at `--level=3`. First SPARK proof of protected types in the framework. Single commit.

```
Run-time Checks       10   proved
Initialization         3   flow
Termination            9   flow
Total                 22   0 unproved, 0 justified, 0 pragma Assume
```

## What changed

- **Four of five generics prove with no contracts at all**, just `SPARK_Mode => On`: `Generic_Variable`, `Generic_Protected_Counter` (modular, wraps by definition), `Generic_Staged_Variable`, `Generic_Protected_Periodic_Counter` (modular; its `mod Period` was already guarded by `Period > 0`). No assertion policy pragma is needed since there are no contracts.
- **`Generic_Protected_Counter_Decrement` becomes a countdown that saturates at zero.** This is the one real finding: `Count := @ - To_Subtract` on a signed `T` could leave the range and raise `Constraint_Error` inside the protected action. A precondition is not an option here: Ada evaluates a protected operation's `Pre` *outside* the lock, so it may not depend on the object's state (GNAT: `internal call cannot appear in precondition of protected operation`), which is also the reason a caller-side check would be a time-of-check/time-of-use race. The counter's only user treats it as a countdown of remaining samples with zero meaning "expired", so the type now says so:
  - decrementing by more than the current count leaves it at zero; no operation raises;
  - `pragma Compile_Time_Error` requires `T'First = 0` and `T'Last >= 1`, so zero is the floor and the default decrement of 1 is representable (verified to reject an `Integer` instantiation with the message);
  - the spec comments describe the saturation for callers, and the unit test exercises saturation from zero, from a small count, and via `Decrement_Count_And_Return_Previous`;
  - two comments that wrongly said "Any modular type" / "Increment the count" on this signed decrementing generic are corrected.
- **pid_controller** (the sole instantiator in this repo and in the downstream projects I can see) moves its diagnostic countdown from `Integer` to `Natural`. Behavior unchanged: it already guards with `if Diag_Count > 0`. Its 9 unit tests pass.
- **`Linux_Prove` gets its own `linux_prove.gpr`**: `linux_debug.gpr` plus the existing `sequential_elaboration.adc`. GNATprove refuses tasking constructs without `pragma Partition_Elaboration_Policy (Sequential)` (SPARK RM 9(2)); the bareboard flight targets already compile with exactly this pair (`ravenscar.adc` + `sequential_elaboration.adc`), so the prove configuration now matches the flight one more closely. `Linux_Debug`/`Linux_Test` are untouched. `stopwatch` and the doc example still prove under the new project.
- `all.prove.yaml` (silver, level 3) and `protected_variables_prover.ads`, which instantiates every generic (the countdown twice, with `Natural` and a narrow `0 .. 7` range) so GNATprove has instances to analyze. Referenced by nothing, adds no code.

## Note for downstream projects

A project that ships its own `Linux_Prove` target (overriding the framework's) needs the same two-line GPR addition to prove protected types locally; `prove_all` in this repository's CI uses the framework target and needs nothing.

## Verification

- `redo prove` in `src/data_structures/protected_variables`: clean at silver level 3.
- `redo test` in `src/data_structures/protected_variables/test`: 5/5 pass (decrement test extended with saturation cases).
- `redo test` in `src/components/pid_controller/test`: 9/9 pass.
- `redo style` on both directories: clean.
- `redo all` for command_router, cpu_monitor, queue_monitor, connector_queuer (instantiators of the other generics): builds.
- `Compile_Time_Error` confirmed to reject `Generic_Protected_Counter_Decrement (Integer)`.
