### PR TITLE
Convert the CRC, checksum and parity packages to SPARK silver

### DIFF
--- a/src/util/crc/all.prove.yaml
+++ b/src/util/crc/all.prove.yaml
@@ -1,0 +1,4 @@
+---
+description: GNATprove configuration for the CRC, checksum and parity packages. The target is silver, absence of runtime errors.
+level: 2
+mode: "silver"

--- a/src/util/crc/checksum_16.adb
+++ b/src/util/crc/checksum_16.adb
@@ -1,6 +1,6 @@
 with Interfaces; use Interfaces;
 
-package body Checksum_16 is
+package body Checksum_16 with SPARK_Mode => On is
 
    -- This function computes the 16-bit checksum in terms of an unsigned 16 which is easier. It uses
    -- multiplies in order to be endian agnostic.

--- a/src/util/crc/checksum_16.ads
+++ b/src/util/crc/checksum_16.ads
@@ -1,6 +1,6 @@
 with Basic_Types;
 
-package Checksum_16 is
+package Checksum_16 with SPARK_Mode => On is
 
    -- 16-bit Checksum type. This type is just a 2 element 8-bit array. This
    -- is used instead of a 16-bit type to prevent endianness issues. We never

--- a/src/util/crc/crc_16.adb
+++ b/src/util/crc/crc_16.adb
@@ -1,6 +1,6 @@
 with Interfaces; use Interfaces;
 
-package body Crc_16 is
+package body Crc_16 with SPARK_Mode => On is
 
    -- Function to compute CRC on a variable array of bytes. A CRC of the whole
    -- array is computed.
@@ -71,7 +71,10 @@ package body Crc_16 is
       return [Crc_16_Type'First => High_Parity, Crc_16_Type'First + 1 => Low_Parity];
    end Compute_Crc_16;
 
-   function Compute_Crc_16 (Byte_Ptr : in Byte_Array_Pointer.Instance; Seed : in Crc_16_Type := [0 => 16#FF#, 1 => 16#FF#]) return Crc_16_Type is
+   -- The body is not analyzed by SPARK since it overlays the memory behind
+   -- the pointer with a byte array by address, which is outside the SPARK
+   -- memory model. It delegates the computation to the proved function above.
+   function Compute_Crc_16 (Byte_Ptr : in Byte_Array_Pointer.Instance; Seed : in Crc_16_Type := [0 => 16#FF#, 1 => 16#FF#]) return Crc_16_Type with SPARK_Mode => Off is
       use Byte_Array_Pointer;
       subtype Safe_Byte_Array_Type is Basic_Types.Byte_Array (0 .. Length (Byte_Ptr) - 1);
       -- Perform overlay manually instead of using Byte_Array_Pointer.Pointer to avoid Byte_Array_Access range checking.

--- a/src/util/crc/crc_16.ads
+++ b/src/util/crc/crc_16.ads
@@ -1,7 +1,7 @@
 with Basic_Types;
 with Byte_Array_Pointer;
 
-package Crc_16 is
+package Crc_16 with SPARK_Mode => On is
 
    -- 16-bit CRC type. This type is just a 2 element 8-bit array. This
    -- is used instead of a 16-bit type to prevent endianness issues. We never

--- a/src/util/crc/xor_8.adb
+++ b/src/util/crc/xor_8.adb
@@ -1,6 +1,6 @@
 with Interfaces; use Interfaces;
 
-package body Xor_8 is
+package body Xor_8 with SPARK_Mode => On is
 
    function Compute_Xor_8 (Bytes : in Basic_Types.Byte_Array; Seed : in Xor_8_Type := 16#FF#) return Xor_8_Type is
       To_Return : Xor_8_Type := Seed;

--- a/src/util/crc/xor_8.ads
+++ b/src/util/crc/xor_8.ads
@@ -1,6 +1,6 @@
 with Basic_Types;
 
-package Xor_8 is
+package Xor_8 with SPARK_Mode => On is
 
    -- 8-bit XOR type. This type is just an 8-bit unsigned value which contains an 8-bit longitudinal parity
    -- byte computed over a byte array.


### PR DESCRIPTION
## Summary

Converts `src/util/crc/` (`Crc_16`, `Checksum_16`, `Xor_8`) to SPARK and proves them at the **silver** level (absence of runtime errors) with GNATprove 15.1.0 at `--level=2`. Single commit.

```
Run-time Checks       12   proved
Total                 16   0 unproved, 0 justified, 0 pragma Assume
```

## What changed

- **`SPARK_Mode => On` on all three packages.** They prove as written: loops over a byte array with table lookups and modular arithmetic, so no contracts, loop invariants or assertion policy are needed.
- **`Compute_Crc_16 (Byte_Array_Pointer.Instance)` body is `SPARK_Mode => Off`.** It overlays the pointed-to memory by address so a CRC can be taken at address zero, which is outside the SPARK memory model. It delegates to the proved array version.
- `all.prove.yaml` (silver, level 2).