### PR TITLE
Convert the byte array utilities to SPARK silver

### DIFF
--- a/src/util/byte_array_util/all.prove.yaml
+++ b/src/util/byte_array_util/all.prove.yaml
@@ -1,0 +1,4 @@
+---
+description: GNATprove configuration for the byte array utilities. The target is silver, absence of runtime errors.
+level: 2
+mode: "silver"

--- a/src/util/byte_array_util/byte_array_util.adb
+++ b/src/util/byte_array_util/byte_array_util.adb
@@ -1,6 +1,18 @@
 with Interfaces; use Interfaces;
 
-package body Byte_Array_Util is
+package body Byte_Array_Util with SPARK_Mode => On is
+
+   -- See the note in the package specification. All contracts are for proof
+   -- only and are disabled at runtime:
+   pragma Assertion_Policy
+      (Pre => Ignore,
+       Post => Ignore,
+       Contract_Cases => Ignore,
+       Ghost => Ignore,
+       Loop_Invariant => Ignore,
+       Loop_Variant => Ignore,
+       Assert_And_Cut => Ignore,
+       Assume => Ignore);
 
    function Safe_Right_Copy (Dest : in out Byte_Array; Src : in Byte_Array) return Natural is
    begin
@@ -15,8 +27,8 @@ package body Byte_Array_Util is
             -- must be less than or equal to both the destination and src array
             -- lengths at this point. We know that both dest and src cannot be
             -- a null array.
-            pragma Assert (Num_Bytes_To_Copy <= Signed_Length (Dest));
-            pragma Assert (Num_Bytes_To_Copy <= Signed_Length (Src));
+            pragma Assert (Num_Bytes_To_Copy <= Dest'Length);
+            pragma Assert (Num_Bytes_To_Copy <= Src'Length);
 
             -- Perform the copy:
             Dest (Dest'Last - Num_Bytes_To_Copy + 1 .. Dest'Last) := Src (Src'Last - Num_Bytes_To_Copy + 1 .. Src'Last);
@@ -46,8 +58,8 @@ package body Byte_Array_Util is
             -- must be less than or equal to both the destination and src array
             -- lengths at this point. We know that both dest and src cannot be
             -- a null array.
-            pragma Assert (Num_Bytes_To_Copy <= Signed_Length (Dest));
-            pragma Assert (Num_Bytes_To_Copy <= Signed_Length (Src));
+            pragma Assert (Num_Bytes_To_Copy <= Dest'Length);
+            pragma Assert (Num_Bytes_To_Copy <= Src'Length);
 
             -- Perform the copy:
             Dest (Dest'First .. Dest'First + Num_Bytes_To_Copy - 1) := Src (Src'First .. Src'First + Num_Bytes_To_Copy - 1);
@@ -78,9 +90,10 @@ package body Byte_Array_Util is
       Value := [0, 0, 0, 0];
 
       -- Validate offset and size. Size must be <= 32 bits. The size + offset must not overflow
-      -- the size of the byte array. Size must be greater than zero.
+      -- the size of the byte array. Size must be greater than zero. The comparison is done in
+      -- 64 bits so that it cannot itself overflow for any offset or array length.
       if Size > Poly_32_Type'Object_Size or else
-          Offset + Size > Src'Length * Byte'Object_Size
+          Long_Long_Integer (Offset) + Long_Long_Integer (Size) > Long_Long_Integer (Src'Length) * Long_Long_Integer (Byte'Object_Size)
       then
          return Error;
       end if;
@@ -91,16 +104,20 @@ package body Byte_Array_Util is
          Num_Dest_Bytes : constant Natural := (Size + Byte'Object_Size - 1) / Byte'Object_Size;
          First_Dest_Idx : constant Natural := Value'Last - Num_Dest_Bytes + 1;
          Last_Dest_Idx : constant Natural := Value'Last;
+         -- Split the offset into whole bytes and remaining bits. All the index arithmetic below
+         -- works from these two parts, so it stays small and cannot overflow for any offset.
+         Offset_Bytes : constant Natural := Offset / Byte'Object_Size;
+         Offset_Bits : constant Natural := Offset mod Byte'Object_Size;
          -- Calculate the first byte we need to copy from the source, the offset rounded down to nearest byte:
-         First_Src_Idx : constant Natural := Src'First + (Offset / Byte'Object_Size);
+         First_Src_Idx : constant Natural := Src'First + Offset_Bytes;
          -- Calculate the last byte we need to extract from the source to completely encapsulate the data we seek.
-         Last_Src_Idx : constant Natural := Src'First + ((Offset + Size - 1) / Byte'Object_Size);
+         Last_Src_Idx : constant Natural := First_Src_Idx + ((Offset_Bits + Size - 1) / Byte'Object_Size);
          -- Index for grabbing bytes out of source array.
          Src_Idx : Natural := Last_Src_Idx;
          -- Calculate the number of bits we need to shift everything right, this 8 minus the offset mod 8,
          -- i.e. the number of padding bits between the last bit we care about and the last whole byte we need
          -- data from.
-         Left_Shift : constant Natural := (Offset + Size) mod Byte'Object_Size;
+         Left_Shift : constant Natural := (Offset_Bits + Size) mod Byte'Object_Size;
          Right_Shift : constant Natural := (Byte'Object_Size - Left_Shift) mod Byte'Object_Size;
          -- Create a mask for the shifts.
          Right_Mask : constant Unsigned_8 := Bit_Mask (Mod_1_8 (Left_Shift));
@@ -158,9 +175,10 @@ package body Byte_Array_Util is
       Value_To_Set : Poly_32_Type := Value;
    begin
       -- Validate offset and size. Size must be <= 32 bits. The size + offset must not overflow
-      -- the size of the byte array. Size must be greater than zero.
+      -- the size of the byte array. Size must be greater than zero. The comparison is done in
+      -- 64 bits so that it cannot itself overflow for any offset or array length.
       if Size > Poly_32_Type'Object_Size or else
-          Offset + Size > (Dest'Last - Dest'First + 1) * Byte'Object_Size
+          Long_Long_Integer (Offset) + Long_Long_Integer (Size) > Long_Long_Integer (Dest'Length) * Long_Long_Integer (Byte'Object_Size)
       then
          return Error;
       end if;
@@ -205,18 +223,23 @@ package body Byte_Array_Util is
          First_Src_Idx : constant Natural := Value_To_Set'Last - Num_Src_Bytes + 1;
          Last_Src_Idx : constant Natural := Value_To_Set'Last;
 
+         -- Split the offset into whole bytes and remaining bits. All the index arithmetic below
+         -- works from these two parts, so it stays small and cannot overflow for any offset.
+         Offset_Bytes : constant Natural := Offset / Byte'Object_Size;
+         Offset_Bits : constant Natural := Offset mod Byte'Object_Size;
+
          -- Calculate indexes in the destination we need to copy to.
-         First_Dest_Idx : constant Natural := Dest'First + (Offset / Byte'Object_Size);
-         Last_Dest_Idx : constant Natural := Dest'First + (Size + Offset - 1) / Byte'Object_Size;
+         First_Dest_Idx : constant Natural := Dest'First + Offset_Bytes;
+         Last_Dest_Idx : constant Natural := First_Dest_Idx + (Offset_Bits + Size - 1) / Byte'Object_Size;
 
          -- Calculate the number of bits we need to shift everything left from the source as we copy to
          -- the destination.
-         Right_Shift : constant Natural := (Offset + Size) mod Byte'Object_Size;
+         Right_Shift : constant Natural := (Offset_Bits + Size) mod Byte'Object_Size;
          Left_Shift : constant Natural := (Byte'Object_Size - Right_Shift) mod Byte'Object_Size;
          -- Create masks for the shifts.
          Left_Mask : constant Unsigned_8 := Shift_Left (16#FF#, Left_Shift);
          Right_Mask : constant Unsigned_8 := 16#FF# xor Left_Mask;
-         Last_Mask : constant Unsigned_8 := Shift_Left (16#FF#, Byte'Object_Size - (Offset mod Byte'Object_Size)) and 16#FF#;
+         Last_Mask : constant Unsigned_8 := Shift_Left (16#FF#, Byte'Object_Size - Offset_Bits) and 16#FF#;
 
          -- Save off the first destination data, since there may be bits in here we don't want to overwrite, but
          -- the algorithm corrupts.

--- a/src/util/byte_array_util/byte_array_util.ads
+++ b/src/util/byte_array_util/byte_array_util.ads
@@ -1,18 +1,29 @@
 with Basic_Types; use Basic_Types;
 
 -- A collection of utility functions for managing byte arrays:
-package Byte_Array_Util is
+package Byte_Array_Util with SPARK_Mode => On is
+
+   -- The contracts in this package exist for proof with GNATprove only. The
+   -- assertion policy below disables them at runtime, so the generated code
+   -- and the runtime behavior of this package is identical to what it was
+   -- before the SPARK conversion. The defensive pragma Assert statements in
+   -- the package body are not affected by this policy. They remain compiled
+   -- in and enabled under the project wide assertion policy, and they are
+   -- also proved.
+   pragma Assertion_Policy
+      (Pre => Ignore,
+       Post => Ignore,
+       Contract_Cases => Ignore,
+       Ghost => Ignore,
+       Loop_Invariant => Ignore,
+       Loop_Variant => Ignore,
+       Assert_And_Cut => Ignore,
+       Assume => Ignore);
 
    -- Helper functions to determine if array is empty or not.
    function Is_Empty (A : in Byte_Array) return Boolean is (A'First > A'Last)
       with Inline => True;
    function Is_Not_Empty (A : in Byte_Array) return Boolean is (A'Last >= A'First)
-      with Inline => True;
-
-   -- Helper function which returns a signed length. This can be negative if
-   -- 'First > 'Last, whereas 'Length will be zero. This can be helpful in
-   -- helping static analysis tools understand certain things.
-   function Signed_Length (A : in Byte_Array) return Integer is (A'Last - A'First + 1)
       with Inline => True;
 
    -- Given a source array of bytes copy the right-most bytes in that array to the destination
@@ -23,7 +34,9 @@ package Byte_Array_Util is
       with Inline => True;
    -- Same as above, but the number of bytes copied is returned:
    function Safe_Right_Copy (Dest : in out Byte_Array; Src : in Byte_Array) return Natural
-      with Post => (Safe_Right_Copy'Result <= Signed_Length (Dest) and then Safe_Right_Copy'Result <= Signed_Length (Src));
+      with Side_Effects,
+           -- No more bytes are copied than either array holds.
+           Post => Safe_Right_Copy'Result <= Dest'Length and then Safe_Right_Copy'Result <= Src'Length;
 
    -- Given a source array of bytes copy the left-most bytes in that array to the destination
    -- aligned to the left in the destination array. If src is bigger than dest, only
@@ -33,7 +46,9 @@ package Byte_Array_Util is
       with Inline => True;
    -- Same as above, but the number of bytes copied is returned:
    function Safe_Left_Copy (Dest : in out Byte_Array; Src : in Byte_Array) return Natural
-      with Post => (Safe_Left_Copy'Result <= Signed_Length (Dest) and then Safe_Left_Copy'Result <= Signed_Length (Src));
+      with Side_Effects,
+           -- No more bytes are copied than either array holds.
+           Post => Safe_Left_Copy'Result <= Dest'Length and then Safe_Left_Copy'Result <= Src'Length;
 
    -- Given a source byte array, extract data into a poly type (32-bits) starting at offset (in bits)
    -- and of size (in bits). If the offset and size are too large to extract from the given byte array,
@@ -42,7 +57,8 @@ package Byte_Array_Util is
    --
    -- Note: This function assumes Value represents the type in big endian, i.e. MSB first, LSB last (right)
    type Extract_Poly_Type_Status is (Success, Error);
-   function Extract_Poly_Type (Src : in Byte_Array; Offset : in Natural; Size : in Positive; Is_Signed : in Boolean; Value : out Poly_32_Type) return Extract_Poly_Type_Status;
+   function Extract_Poly_Type (Src : in Byte_Array; Offset : in Natural; Size : in Positive; Is_Signed : in Boolean; Value : out Poly_32_Type) return Extract_Poly_Type_Status
+      with Side_Effects;
 
    -- Given a source poly type (32-bits) set bits in the destination byte array starting at offset
    -- (in bits) and size (in bits). The right-most (least significant) bytes in the poly type (Value)
@@ -61,6 +77,7 @@ package Byte_Array_Util is
    --
    -- Note: This function assumes Value represents the type in big endian, i.e. MSB first, LSB last (right)
    type Set_Poly_Type_Status is (Success, Error, Truncation_Error);
-   function Set_Poly_Type (Dest : in out Byte_Array; Offset : in Natural; Size : in Positive; Value : in Poly_32_Type; Truncation_Allowed : Boolean := False) return Set_Poly_Type_Status;
+   function Set_Poly_Type (Dest : in out Byte_Array; Offset : in Natural; Size : in Positive; Value : in Poly_32_Type; Truncation_Allowed : Boolean := False) return Set_Poly_Type_Status
+      with Side_Effects;
 
 end Byte_Array_Util;


### PR DESCRIPTION
## Summary

Converts `src/util/byte_array_util/` to SPARK and proves it at the **silver** level (absence of runtime errors) with GNATprove 15.1.0 at `--level=2`. Single commit.

```
Run-time Checks      109   proved
Assertions             4   proved
Functional Contracts   2   proved
Total                120   0 unproved, 0 justified, 0 pragma Assume
```

## What changed

- **`SPARK_Mode => On` and `Side_Effects`** on the four functions with `out`/`in out` parameters. The bit extraction and insertion loops prove as written; no loop invariants were needed. Contracts are proof-only (`Assertion_Policy` as in binary_tree): the two postconditions on the copy functions, previously live, are now guaranteed by the proof rather than a runtime check. The defensive `pragma Assert`s stay live and are proved.
- **Overflow in the size checks fixed.** `Offset + Size > Src'Length * 8` overflows `Integer` for an offset near `Integer'Last` or an array over 256 MB, raising `Constraint_Error` where `Error` should be returned. The comparison is now done in 64 bits, and the index arithmetic splits the offset into whole bytes and remaining bits so it cannot overflow either. Results are identical for every input the old code handled.
- **`Signed_Length` removed.** It could overflow for an empty array with far apart bounds, and the copy postconditions written with it were false for such arrays (copy returns 0, `Signed_Length` is negative). Nothing outside the package used it. The postconditions and internal assertions now say what they meant: no more bytes are copied than either array holds (`'Length`).
- `all.prove.yaml` (silver, level 2).