### PR TITLE
Mark generated functions with out parameters as having side effects

### DIFF
--- a/gen/templates/array/name-validation.ads
+++ b/gen/templates/array/name-validation.ads
@@ -32,7 +32,8 @@ package {{ name }}.Validation is
       Errant_Field : out Unsigned_32;
       First_Index : in Unconstrained_Index_Type := T'First;
       Last_Index : in Unconstrained_Index_Type := T'Last
-   ) return Boolean;
+   ) return Boolean
+      with Side_Effects;
 {% endif %}
 {% if endianness in ["either", "little"] %}
    -- Valid_Le function accepting a byte array. Optionally, a first or last index can be passed in to only check
@@ -42,7 +43,8 @@ package {{ name }}.Validation is
       Errant_Field : out Unsigned_32;
       First_Index : in Unconstrained_Index_Type := T_Le'First;
       Last_Index : in Unconstrained_Index_Type := T_Le'Last
-   ) return Boolean;
+   ) return Boolean
+      with Side_Effects;
 {% endif %}
 
    -- Return a field (provided by a field number) as a polymorphic type.

--- a/gen/templates/record/name-validation.ads
+++ b/gen/templates/record/name-validation.ads
@@ -22,10 +22,12 @@ package {{ name }}.Validation is
    -- False is returned and the Errant_Field parameter is filled in with a
    -- Natural specifying which field was out of range.
 {% if endianness in ["either", "big"] %}
-   function Valid (Bytes : in Serialization.Byte_Array; Errant_Field : out Interfaces.Unsigned_32) return Boolean;
+   function Valid (Bytes : in Serialization.Byte_Array; Errant_Field : out Interfaces.Unsigned_32) return Boolean
+      with Side_Effects;
 {% endif %}
 {% if endianness in ["either", "little"] %}
-   function Valid_Le (Bytes : in Serialization_Le.Byte_Array; Errant_Field : out Interfaces.Unsigned_32) return Boolean;
+   function Valid_Le (Bytes : in Serialization_Le.Byte_Array; Errant_Field : out Interfaces.Unsigned_32) return Boolean
+      with Side_Effects;
 {% endif %}
 
    -- Return a field (provided by a field number) as a polymorphic type.

--- a/gen/templates/record/name.ads
+++ b/gen/templates/record/name.ads
@@ -491,19 +491,23 @@ package {{ name }} is
    -- Max_Serialized_Length, then the number symbolizes the actual calculated length, which is
    -- too large.
 {% if endianness in ["either", "big"] %}
-   function Serialized_Length (Src : in T; Num_Bytes_Serialized : out Natural) return Serialization_Status;
+   function Serialized_Length (Src : in T; Num_Bytes_Serialized : out Natural) return Serialization_Status
+      with Side_Effects;
 {% endif %}
 {% if endianness in ["either", "little"] %}
-   function Serialized_Length_Le (Src : in T_Le; Num_Bytes_Serialized : out Natural) return Serialization_Status;
+   function Serialized_Length_Le (Src : in T_Le; Num_Bytes_Serialized : out Natural) return Serialization_Status
+      with Side_Effects;
 {% endif %}
 
    -- Get the size of the already serialized type inside of the byte array. If the byte array is too small then
    -- a serialization error is returned.
 {% if endianness in ["either", "big"] %}
-   function Serialized_Length (Src : in Basic_Types.Byte_Array; Num_Bytes_Serialized : out Natural) return Serialization_Status;
+   function Serialized_Length (Src : in Basic_Types.Byte_Array; Num_Bytes_Serialized : out Natural) return Serialization_Status
+      with Side_Effects;
 {% endif %}
 {% if endianness in ["either", "little"] %}
-   function Serialized_Length_Le (Src : in Basic_Types.Byte_Array; Num_Bytes_Serialized : out Natural) return Serialization_Status;
+   function Serialized_Length_Le (Src : in Basic_Types.Byte_Array; Num_Bytes_Serialized : out Natural) return Serialization_Status
+      with Side_Effects;
 {% endif %}
 
    -- Serializing functions for entire record:
@@ -539,22 +543,22 @@ package {{ name }} is
    -- definition below, but its for a statically sized type.
 {% if endianness in ["either", "big"] %}
    function Serialized_Length (Src : in T; Num_Bytes_Serialized : out Natural) return Serialization_Status
-      with Inline => True;
+      with Side_Effects, Inline => True;
 {% endif %}
 {% if endianness in ["either", "little"] %}
    function Serialized_Length_Le (Src : in T_Le; Num_Bytes_Serialized : out Natural) return Serialization_Status
-      with Inline => True;
+      with Side_Effects, Inline => True;
 {% endif %}
 
    -- Get the size of the already serialized type inside of the byte array. If the byte array is too small then
    -- a serialization error is returned.
 {% if endianness in ["either", "big"] %}
    function Serialized_Length (Src : in Basic_Types.Byte_Array; Num_Bytes_Serialized : out Natural) return Serialization_Status
-      with Inline => True;
+      with Side_Effects, Inline => True;
 {% endif %}
 {% if endianness in ["either", "little"] %}
    function Serialized_Length_Le (Src : in Basic_Types.Byte_Array; Num_Bytes_Serialized : out Natural) return Serialization_Status
-      with Inline => True;
+      with Side_Effects, Inline => True;
 {% endif %}
 {% endif %}
 

--- a/src/core/serializer/serializer.ads
+++ b/src/core/serializer/serializer.ads
@@ -52,7 +52,8 @@ package Serializer is
    -- the first bytes of the array will be filled with the type. If the array is smaller,
    -- a Constraint_Error will likely be called, or a segmentation fault may occur.
    -- Use the To_Byte_Array function above whenever possible.
-   function To_Byte_Array_Unchecked (Dest : out Basic_Types.Byte_Array; Src : in T) return Natural;
+   function To_Byte_Array_Unchecked (Dest : out Basic_Types.Byte_Array; Src : in T) return Natural
+      with Side_Effects;
    procedure To_Byte_Array_Unchecked (Dest : out Basic_Types.Byte_Array; Src : in T);
    function To_Byte_Array_Unchecked (Src : in T) return Basic_Types.Byte_Array;
 
@@ -65,7 +66,8 @@ package Serializer is
    -- the type will not receive updated serialized data from the array. If this is not
    -- your intended behavior, then you might be in trouble. Use the From_Byte_Array
    -- function above whenever possible.
-   function From_Byte_Array_Unchecked (Dest : out T; Src : in Basic_Types.Byte_Array) return Natural;
+   function From_Byte_Array_Unchecked (Dest : out T; Src : in Basic_Types.Byte_Array) return Natural
+      with Side_Effects;
    procedure From_Byte_Array_Unchecked (Dest : out T; Src : in Basic_Types.Byte_Array);
    function From_Byte_Array_Unchecked (Src : in Basic_Types.Byte_Array) return T;
 end Serializer;

--- a/src/core/serializer/variable_serializer.ads
+++ b/src/core/serializer/variable_serializer.ads
@@ -49,12 +49,16 @@ package Variable_Serializer is
    -- Convert type to byte array, return number of bytes serialized:
    -- These functions may produce an error if the length of a variable field
    -- is invalid.
-   function To_Byte_Array (Dest : out Basic_Types.Byte_Array; Src : in T; Num_Bytes_Serialized : out Natural) return Serialization_Status;
-   function To_Byte_Array (Dest : out Basic_Types.Byte_Array; Src : in T) return Serialization_Status;
+   function To_Byte_Array (Dest : out Basic_Types.Byte_Array; Src : in T; Num_Bytes_Serialized : out Natural) return Serialization_Status
+      with Side_Effects;
+   function To_Byte_Array (Dest : out Basic_Types.Byte_Array; Src : in T) return Serialization_Status
+      with Side_Effects;
 
    -- Convert byte array to type, return number of bytes deserialized:
    -- These functions may produce an error if the length of a variable field
    -- is invalid.
-   function From_Byte_Array (Dest : out T; Src : in Basic_Types.Byte_Array; Num_Bytes_Deserialized : out Natural) return Serialization_Status;
-   function From_Byte_Array (Dest : out T; Src : in Basic_Types.Byte_Array) return Serialization_Status;
+   function From_Byte_Array (Dest : out T; Src : in Basic_Types.Byte_Array; Num_Bytes_Deserialized : out Natural) return Serialization_Status
+      with Side_Effects;
+   function From_Byte_Array (Dest : out T; Src : in Basic_Types.Byte_Array) return Serialization_Status
+      with Side_Effects;
 end Variable_Serializer;


### PR DESCRIPTION
## Summary

Makes the generated packed record and packed array code callable from SPARK. SPARK rejects a call to a function with an `out` parameter unless the function carries the `Side_Effects` aspect, and that was the only thing standing between SPARK code and the generated types: their declarations are otherwise legal SPARK, and their bodies (memory overlays) are treated by GNATprove as trusted boundary operations that it does not analyze. Single commit, template and serializer specs only.

## What changed

`Side_Effects` added to every generated or serializer function that has an `out` parameter:

- `gen/templates/record/name-validation.ads`, `gen/templates/array/name-validation.ads`: `Valid`, `Valid_Le`
- `gen/templates/record/name.ads`: the four `Serialized_Length` / `Serialized_Length_Le` variants (fixed and variable length)
- `src/core/serializer/serializer.ads`: `To_Byte_Array_Unchecked`, `From_Byte_Array_Unchecked` (function forms)
- `src/core/serializer/variable_serializer.ads`: the four `To_Byte_Array` / `From_Byte_Array` functions

The two serializer specs are included because the generated code instantiates them, so without those lines the generated `Serialization` packages would still be uncallable.

The aspect changes nothing for Ada callers or generated code. SPARK callers call these functions as the whole right hand side of an assignment statement. Passing the now `Side_Effects` `Serialized_Length` actuals to `Variable_Serializer`'s plain generic formals compiles fine.


