### PR TITLE
Convert the variable database package to SPARK silver

### DIFF
--- a/src/data_structures/database/all.prove.yaml
+++ b/src/data_structures/database/all.prove.yaml
@@ -1,0 +1,4 @@
+---
+description: GNATprove configuration for the database packages. The target is silver, absence of runtime errors, including proof of the defensive assertions.
+level: 2
+mode: "silver"

--- a/src/data_structures/database/variable_database.adb
+++ b/src/data_structures/database/variable_database.adb
@@ -1,13 +1,49 @@
 with Safe_Deallocator;
 
-package body Variable_Database is
+package body Variable_Database with SPARK_Mode => On is
 
-   procedure Init (Self : in out Instance; Minimum_Id : in Id_Type; Maximum_Id : in Id_Type) is
+   -- See the note in the package specification. All contracts and ghost code
+   -- are for proof only and are disabled at runtime:
+   pragma Assertion_Policy
+      (Pre => Ignore,
+       Pre'Class => Ignore,
+       Post => Ignore,
+       Post'Class => Ignore,
+       Contract_Cases => Ignore,
+       Ghost => Ignore,
+       Loop_Invariant => Ignore,
+       Loop_Variant => Ignore,
+       Assert_And_Cut => Ignore,
+       Assume => Ignore,
+       Subprogram_Variant => Ignore);
+   pragma Unevaluated_Use_Of_Old (Allow);
+
+   function Store (Data : out Entry_Bytes; Value : in T) return Serializer_Types.Serialization_Status is
+      Status : Serializer_Types.Serialization_Status;
+   begin
+      Status := T_Serializer.To_Byte_Array (Data, Value);
+      return Status;
+   end Store;
+
+   function Load (Value : out T; Data : in Entry_Bytes) return Serializer_Types.Serialization_Status is
+      Status : Serializer_Types.Serialization_Status;
+   begin
+      Status := T_Serializer.From_Byte_Array (Value, Data);
+      return Status;
+   end Load;
+
+   -- The body is not analyzed by SPARK since it performs the heap allocation
+   -- that owns the table for the rest of the database's life. The
+   -- postcondition holds because the allocation below has exactly the
+   -- requested bounds.
+   procedure Init (Self : in out Instance; Minimum_Id : in Id_Type; Maximum_Id : in Id_Type) with SPARK_Mode => Off is
    begin
       Self.Db_Table := new Database_Table (Minimum_Id .. Maximum_Id);
    end Init;
 
-   procedure Destroy (Self : in out Instance) is
+   -- The body is not analyzed by SPARK since conditional deallocation is
+   -- outside the SPARK ownership model.
+   procedure Destroy (Self : in out Instance) with SPARK_Mode => Off is
       procedure Free_If_Testing is new Safe_Deallocator.Deallocate_If_Testing (Object => Database_Table, Name => Database_Table_Access);
    begin
       Free_If_Testing (Self.Db_Table);
@@ -27,7 +63,7 @@ package body Variable_Database is
          -- If not in override mode then allow the entry to be updated:
          when Empty | Filled =>
             -- Try to serialize the value into the database:
-            Stat := T_Serializer.To_Byte_Array (Self.Db_Table (Id).Data, Value);
+            Stat := Store (Self.Db_Table (Id).Data, Value);
             if Stat /= Success then
                return Serialization_Failure;
             end if;
@@ -55,12 +91,13 @@ package body Variable_Database is
       end case;
 
       -- OK, we are good, grab the data:
-      Stat := T_Serializer.From_Byte_Array (Value, Self.Db_Table (Id).Data);
+      Stat := Load (Value, Self.Db_Table (Id).Data);
 
       -- The status should always be successful here. Since the data was serialized
       -- into the database, there is no way it can deserialize with error unless a
       -- bit was flipped or there is a software bug in this package.
       pragma Assert (Stat = Success, "Deserialization of database item failed!");
+      pragma Annotate (GNATprove, Intentional, "assertion might fail", "The bytes were written by Store, so Load can only fail if the storage has since been corrupted. That is a fault to report, not a case to handle, and no proof can rule it out.");
 
       return Success;
    end Fetch;
@@ -75,7 +112,7 @@ package body Variable_Database is
       end if;
 
       -- Try to serialize the value into the database:
-      Stat := T_Serializer.To_Byte_Array (Self.Db_Table (Id).Data, Value);
+      Stat := Store (Self.Db_Table (Id).Data, Value);
       if Stat /= Success then
          return Serialization_Failure;
       end if;
@@ -107,6 +144,9 @@ package body Variable_Database is
       Stat : Clear_Override_Status;
    begin
       for Id in Self.Db_Table'Range loop
+         -- The database stays valid and keeps its range, so every Id of the range is still held.
+         pragma Loop_Invariant (Is_Valid (Self));
+         pragma Loop_Invariant (First_Id (Self) = First_Id (Self)'Loop_Entry and then Last_Id (Self) = Last_Id (Self)'Loop_Entry);
          Stat := Self.Clear_Override (Id);
          pragma Assert (Stat = Success);
       end loop;

--- a/src/data_structures/database/variable_database.ads
+++ b/src/data_structures/database/variable_database.ads
@@ -24,10 +24,53 @@ generic
    type T is private;
    with function Serialized_Length (Src : in T; Num_Bytes_Serialized : out Natural) return Serializer_Types.Serialization_Status;
    with function Serialized_Length (Src : in Basic_Types.Byte_Array; Num_Bytes_Serialized : out Natural) return Serializer_Types.Serialization_Status;
-package Variable_Database is
+package Variable_Database with SPARK_Mode => On is
+
+   -- The contracts and ghost code in this package exist for proof with
+   -- GNATprove only. The assertion policy below disables them at runtime, so
+   -- the generated code and the runtime behavior of this package is
+   -- identical to what it was before the SPARK conversion. The defensive
+   -- pragma Assert statements in the package body are not affected by this
+   -- policy. They remain compiled in and enabled under the project wide
+   -- assertion policy, and they are also proved.
+   pragma Assertion_Policy
+      (Pre => Ignore,
+       Pre'Class => Ignore,
+       Post => Ignore,
+       Post'Class => Ignore,
+       Contract_Cases => Ignore,
+       Ghost => Ignore,
+       Loop_Invariant => Ignore,
+       Loop_Variant => Ignore,
+       Assert_And_Cut => Ignore,
+       Assume => Ignore,
+       Subprogram_Variant => Ignore);
+   pragma Unevaluated_Use_Of_Old (Allow);
 
    -- Object type:
    type Instance is tagged private;
+
+   -- Ghost predicate stating that the database is in a valid, initialized
+   -- state: its table has been allocated by Init. This is the precondition
+   -- of every operation that touches the table. It takes a class-wide
+   -- parameter so that it is not a dispatching operation, which would force
+   -- every derived type to override each operation mentioning it
+   -- (SPARK RM 6.1.1).
+   function Is_Valid (Self : in Instance'Class) return Boolean
+      with Ghost;
+
+   -- Ghost functions giving the range of Ids the database was initialized to
+   -- hold, and whether an Id is within it:
+   function First_Id (Self : in Instance'Class) return Id_Type
+      with Ghost,
+           Pre => Is_Valid (Self);
+   function Last_Id (Self : in Instance'Class) return Id_Type
+      with Ghost,
+           Pre => Is_Valid (Self);
+   function Contains (Self : in Instance'Class; Id : in Id_Type) return Boolean is
+      (Id in First_Id (Self) .. Last_Id (Self))
+      with Ghost,
+           Pre => Is_Valid (Self);
 
    -- Return types:
    type Update_Status is (Success, Id_Out_Of_Range, Serialization_Failure);
@@ -35,26 +78,79 @@ package Variable_Database is
    type Clear_Override_Status is (Success, Id_Out_Of_Range);
 
    -- Object primitives:
-   procedure Init (Self : in out Instance; Minimum_Id : in Id_Type; Maximum_Id : in Id_Type);
+   procedure Init (Self : in out Instance; Minimum_Id : in Id_Type; Maximum_Id : in Id_Type)
+      with
+         -- The database is valid and holds exactly the Ids from Minimum_Id to Maximum_Id.
+         Post => Is_Valid (Self) and then (for all Id in Id_Type => Contains (Self, Id) = (Id in Minimum_Id .. Maximum_Id));
    procedure Destroy (Self : in out Instance);
-   function Update (Self : in out Instance; Id : in Id_Type; Value : in T) return Update_Status;
-   function Fetch (Self : in Instance; Id : in Id_Type; Value : out T) return Fetch_Status;
+   function Update (Self : in out Instance; Id : in Id_Type; Value : in T) return Update_Status
+      with
+         Side_Effects,
+         -- The database is valid.
+         Pre'Class => Is_Valid (Self),
+         -- The database is still valid, holds the same Ids, and the update fails with Id_Out_Of_Range exactly when the Id is not held.
+         Post => Is_Valid (Self)
+            and then First_Id (Self) = First_Id (Self)'Old and then Last_Id (Self) = Last_Id (Self)'Old
+            and then (Update'Result = Id_Out_Of_Range) = (not Contains (Self, Id));
+   function Fetch (Self : in Instance; Id : in Id_Type; Value : out T) return Fetch_Status
+      with
+         Side_Effects,
+         -- The database is valid.
+         Pre'Class => Is_Valid (Self),
+         -- The fetch fails with Id_Out_Of_Range exactly when the Id is not held.
+         Post => (Fetch'Result = Id_Out_Of_Range) = (not Contains (Self, Id));
+   pragma Annotate (GNATprove, Intentional, "might not be set", "Value is only meaningful when Fetch returns Success, and callers check the status before using it. There is no value of the private type T to write on the failure paths.");
 
    -- Backdoor features:
    -- Same as update, but prevents any future updates from changing the underlying value. This
    -- state can be reversed using Clear_Override.
-   function Override (Self : in out Instance; Id : in Id_Type; Value : in T) return Update_Status;
+   function Override (Self : in out Instance; Id : in Id_Type; Value : in T) return Update_Status
+      with
+         Side_Effects,
+         -- The database is valid.
+         Pre'Class => Is_Valid (Self),
+         -- The database is still valid, holds the same Ids, and the override fails with Id_Out_Of_Range exactly when the Id is not held.
+         Post => Is_Valid (Self)
+            and then First_Id (Self) = First_Id (Self)'Old and then Last_Id (Self) = Last_Id (Self)'Old
+            and then (Override'Result = Id_Out_Of_Range) = (not Contains (Self, Id));
    -- Allow future updates to take effect again.
-   function Clear_Override (Self : in out Instance; Id : in Id_Type) return Clear_Override_Status;
+   function Clear_Override (Self : in out Instance; Id : in Id_Type) return Clear_Override_Status
+      with
+         Side_Effects,
+         -- The database is valid.
+         Pre'Class => Is_Valid (Self),
+         -- The database is still valid, holds the same Ids, and the clear succeeds exactly when the Id is held.
+         Post => Is_Valid (Self)
+            and then First_Id (Self) = First_Id (Self)'Old and then Last_Id (Self) = Last_Id (Self)'Old
+            and then (Clear_Override'Result = Success) = Contains (Self, Id);
    -- Clear_Override for all entries in the database.
-   procedure Clear_Override_All (Self : in out Instance);
+   procedure Clear_Override_All (Self : in out Instance)
+      with
+         -- The database is valid.
+         Pre'Class => Is_Valid (Self),
+         -- The database is still valid and holds the same Ids.
+         Post => Is_Valid (Self) and then First_Id (Self) = First_Id (Self)'Old and then Last_Id (Self) = Last_Id (Self)'Old;
    -- Returns True if any entries are currently being overridden.
-   function Any_Overridden (Self : in Instance) return Boolean;
+   function Any_Overridden (Self : in Instance) return Boolean
+      with
+         -- The database is valid.
+         Pre'Class => Is_Valid (Self);
 
 private
 
-   -- Instantiate the variable serializer for our type:
+   -- Instantiate the variable serializer for our type. Its declarations are in
+   -- SPARK and its body, which overlays byte arrays by address, is not
+   -- analyzed, so SPARK treats its operations as trusted boundary operations.
    package T_Serializer is new Variable_Serializer (T, Serialized_Length, Serialized_Length);
+   -- The storage for one serialized value, sized to hold the largest T:
+   subtype Entry_Bytes is T_Serializer.Byte_Array;
+
+   -- Serialize a value into an entry's storage:
+   function Store (Data : out Entry_Bytes; Value : in T) return Serializer_Types.Serialization_Status
+      with Side_Effects;
+   -- Deserialize a value from an entry's storage:
+   function Load (Value : out T; Data : in Entry_Bytes) return Serializer_Types.Serialization_Status
+      with Side_Effects;
 
    -- State of a data base entry:
    -- Empty - The database entry has not been stored to yet.
@@ -67,7 +163,7 @@ private
    -- stored.
    type Database_Entry is record
       State : Entry_State := Empty;
-      Data : T_Serializer.Byte_Array := [others => 0];
+      Data : Entry_Bytes := [others => 0];
    end record;
 
    -- Database table type which maps the index type (unconstrained)
@@ -79,5 +175,11 @@ private
    type Instance is tagged record
       Db_Table : Database_Table_Access := null;
    end record;
+
+   -- Ghost model completions:
+   function Is_Valid (Self : in Instance'Class) return Boolean is
+      (Self.Db_Table /= null and then Self.Db_Table'First in Id_Type and then Self.Db_Table'Last in Id_Type);
+   function First_Id (Self : in Instance'Class) return Id_Type is (Self.Db_Table'First);
+   function Last_Id (Self : in Instance'Class) return Id_Type is (Self.Db_Table'Last);
 
 end Variable_Database;

--- a/src/data_structures/database/variable_database_prover.adb
+++ b/src/data_structures/database/variable_database_prover.adb
@@ -1,0 +1,21 @@
+package body Variable_Database_Prover with SPARK_Mode => On is
+
+   Element_Length : constant Natural := Example_Element'Object_Size / Basic_Types.Byte'Object_Size;
+
+   function Serialized_Length (Src : in Example_Element; Num_Bytes_Serialized : out Natural) return Serializer_Types.Serialization_Status is
+      pragma Unreferenced (Src);
+   begin
+      Num_Bytes_Serialized := Element_Length;
+      return Serializer_Types.Success;
+   end Serialized_Length;
+
+   function Serialized_Length (Src : in Basic_Types.Byte_Array; Num_Bytes_Serialized : out Natural) return Serializer_Types.Serialization_Status is
+   begin
+      Num_Bytes_Serialized := Element_Length;
+      if Src'Length < Element_Length then
+         return Serializer_Types.Failure;
+      end if;
+      return Serializer_Types.Success;
+   end Serialized_Length;
+
+end Variable_Database_Prover;

--- a/src/data_structures/database/variable_database_prover.ads
+++ b/src/data_structures/database/variable_database_prover.ads
@@ -1,0 +1,30 @@
+with Variable_Database;
+with Basic_Types;
+with Serializer_Types;
+with Interfaces;
+
+-- This package exists solely so that GNATprove analyzes an instance of the
+-- generic Variable_Database package, since GNATprove analyzes generics only
+-- at their instantiation points. Real instantiations elsewhere in a project
+-- are verified at their own instantiation points when they occur in SPARK
+-- analyzed code. Nothing references this package, so it contributes no code
+-- to any build.
+package Variable_Database_Prover with SPARK_Mode => On is
+
+   -- A representative fixed size element and Id, similar in shape to the
+   -- data product records and Ids that variable databases typically hold:
+   type Example_Id is range 0 .. 99;
+   type Example_Element is record
+      Id : Interfaces.Unsigned_16 := 0;
+      Value : Interfaces.Unsigned_32 := 0;
+   end record;
+
+   -- The serialized length functions a fixed size element provides:
+   function Serialized_Length (Src : in Example_Element; Num_Bytes_Serialized : out Natural) return Serializer_Types.Serialization_Status
+      with Side_Effects;
+   function Serialized_Length (Src : in Basic_Types.Byte_Array; Num_Bytes_Serialized : out Natural) return Serializer_Types.Serialization_Status
+      with Side_Effects;
+
+   package Example_Database is new Variable_Database (Example_Id, Example_Element, Serialized_Length, Serialized_Length);
+
+end Variable_Database_Prover;


### PR DESCRIPTION
Convert the variable database package to SPARK silver

Prove the generic Variable_Database package free of runtime errors with
GNATprove at the silver level. This is the store beneath the product
database component.

The public API is unchanged and the contracts are proof only: an
Assertion_Policy at the top of the package ignores them at runtime, so
the generated code is identical to the unconverted package. The proof
rests on the ghost predicate Is_Valid, stating that the table has been
allocated with bounds within Id_Type, and on ghost accessors for the
range of Ids held, which every operation is proved to preserve. The
status contracts state that an operation fails with Id_Out_Of_Range
exactly when the Id is outside that range, which is what the defensive
assertion in Clear_Override_All relies on.

The variable serializer is instantiated directly, as before. Its
declarations are in SPARK and its body is not analyzed, so the store and
load of a value are proved against its declarations and treated as
trusted boundary operations. Init and Destroy are excluded from
analysis, for the heap allocation and conditional deallocation.

Two checks are justified rather than proved. Fetch does not write its
out parameter on the failure paths, since there is no value of the
private type T to write, and the API documents that callers check the
status first. The defensive assertion in Fetch that a stored value
deserializes successfully guards against corruption of the storage after
it was written, which no proof can rule out.

A prover package instantiates the generic so that GNATprove has an
instance to analyze, since generics are only analyzed at instantiation
points. It is referenced by nothing and adds no code to any build.
EOF
## Summary

Converts `src/data_structures/database/variable_database.ads/.adb` (the store beneath the product database component) to SPARK and proves it at the **silver** level with GNATprove at `--level=2`. Single commit, stacked on #217, which puts the serializer declarations in SPARK so this package can instantiate `Variable_Serializer` directly.

```
Total   103   0 unproved, 3 justified, 0 pragma Assume
```

## What changed

- **Ghost model.** `Is_Valid` (table allocated, bounds within `Id_Type`), `First_Id`/`Last_Id`/`Contains` as ghost accessors. Every operation preserves `Is_Valid`; the status contracts say an operation fails with `Id_Out_Of_Range` exactly when the Id is outside the held range, which the defensive assertion in `Clear_Override_All` relies on.
- **Proof-only contracts.** The usual `Assertion_Policy` block; generated code is unchanged. Functions with `out` parameters carry `Side_Effects`.
- **Serializer.** `T_Serializer` is instantiated directly in the private part as before and `Entry_Bytes` is its `Byte_Array`. `Store`/`Load` are ordinary SPARK code calling the instance. (Thanks to #217 no nested Off package or mirror subtype is needed.)
- **Excluded bodies.** `Init` and `Destroy` (heap allocation and conditional deallocation), with their postconditions documented.
- **Three justified checks.** `Fetch` leaves its `out` parameter unset on the two failure paths (no value of the private type `T` to write; callers check the status first), and the defensive assertion in `Fetch` that a stored value deserializes guards against storage corruption after writing, which no proof can rule out.
- `variable_database_prover.ads` instantiates the generic for analysis; referenced by nothing.

## Verification

- `redo prove`: 103 checks, 0 unproved. Package unit tests pass, style clean.
- Product database component test suite passes on the fork PR (dinkelk/adamant#183, which this supersedes).
