### PR TITLE
Single-source the CI dependency refs

### DIFF
--- a/.github/workflows/_refs.yml
+++ b/.github/workflows/_refs.yml
@@ -1,0 +1,36 @@
+# Single source of truth for the toolchain image (and any future
+# cross-repo refs) that this repo's CI builds against.
+#
+# Edit the "outputs:" block at the bottom. Every workflow in
+# .github/workflows reads these values, so a value changes in exactly
+# one place.
+#
+name: CI dependency refs
+
+on:
+  workflow_call:
+    outputs:
+      image:
+        description: "Adamant toolchain container image, including tag"
+        value: ${{ jobs.refs.outputs.image }}
+
+# This workflow reads nothing and writes nothing.
+permissions: {}
+
+jobs:
+  refs:
+    runs-on: ubuntu-latest
+    # ===== EDIT HERE ==================================================
+    # These are literal strings rather than values written to $GITHUB_OUTPUT
+    # by a step: a workflow_call output must reference a *job* output, and
+    # routing an empty value through $GITHUB_OUTPUT has been observed to go
+    # stale across job re-runs. Literals avoid both hazards.
+    outputs:
+      # Used by the amd64 jobs (job-level container:) and by the arm64 jobs
+      # (docker run under QEMU).
+      image: 'ghcr.io/lasp/adamant:0.2'
+    steps:
+      # A job must declare at least one step. Everything this workflow
+      # provides lives in outputs: above.
+      - name: Emit shared refs
+        run: 'true'

--- a/.github/workflows/build_user_guide.yml
+++ b/.github/workflows/build_user_guide.yml
@@ -8,11 +8,14 @@ on:
       - main
   workflow_dispatch:
 jobs:
+  refs:
+    uses: ./.github/workflows/_refs.yml
   compile_job:
+    needs: refs
     name: build_user_guide
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/lasp/adamant:0.2
+      image: ${{ needs.refs.outputs.image }}
       options: --user root
     steps:
       - run: echo "Starting job triggered by a ${{ github.event_name }} event on a ${{ runner.os }} server hosted by GitHub."

--- a/.github/workflows/build_user_guide_arm64.yml
+++ b/.github/workflows/build_user_guide_arm64.yml
@@ -4,7 +4,10 @@ on:
     types: [published]
   workflow_dispatch:
 jobs:
+  refs:
+    uses: ./.github/workflows/_refs.yml
   compile_job:
+    needs: refs
     name: build_user_guide (arm64)
     runs-on: ubuntu-latest
     steps:
@@ -22,7 +25,7 @@ jobs:
           docker run --rm --platform linux/arm64 \
             -v ${{ github.workspace }}:/workspace \
             -w /workspace \
-            ghcr.io/lasp/adamant:0.2 \
+            ${{ needs.refs.outputs.image }} \
             bash env/github_run.sh "redo doc/user_guide/build_user_guide"
 
       - name: Archive user guide PDF
@@ -37,7 +40,7 @@ jobs:
           docker run --rm --platform linux/arm64 \
             -v ${{ github.workspace }}:/workspace \
             -w /workspace \
-            ghcr.io/lasp/adamant:0.2 \
+            ${{ needs.refs.outputs.image }} \
             bash env/github_run.sh "redo doc/architecture_description_document/build/pdf/architecture_description_document.pdf"
 
       - name: Archive architecture description document PDF

--- a/.github/workflows/prove_all.yml
+++ b/.github/workflows/prove_all.yml
@@ -8,11 +8,14 @@ on:
       - main
   workflow_dispatch:
 jobs:
+  refs:
+    uses: ./.github/workflows/_refs.yml
   compile_job:
+    needs: refs
     name: prove_all
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/lasp/adamant:0.2
+      image: ${{ needs.refs.outputs.image }}
       options: --user root
     steps:
       - run: echo "Starting job triggered by a ${{ github.event_name }} event on a ${{ runner.os }} server hosted by GitHub."

--- a/.github/workflows/prove_all_arm64.yml
+++ b/.github/workflows/prove_all_arm64.yml
@@ -4,7 +4,10 @@ on:
     types: [published]
   workflow_dispatch:
 jobs:
+  refs:
+    uses: ./.github/workflows/_refs.yml
   compile_job:
+    needs: refs
     name: prove_all (arm64)
     runs-on: ubuntu-latest
     steps:
@@ -22,7 +25,7 @@ jobs:
           docker run --rm --platform linux/arm64 \
             -v ${{ github.workspace }}:/workspace \
             -w /workspace \
-            ghcr.io/lasp/adamant:0.2 \
+            ${{ needs.refs.outputs.image }} \
             bash env/github_run.sh "redo prove_all"
 
       - name: Archive prove logs

--- a/.github/workflows/publish_all.yml
+++ b/.github/workflows/publish_all.yml
@@ -8,11 +8,14 @@ on:
       - main
   workflow_dispatch:
 jobs:
+  refs:
+    uses: ./.github/workflows/_refs.yml
   compile_job:
+    needs: refs
     name: publish_all
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/lasp/adamant:0.2
+      image: ${{ needs.refs.outputs.image }}
       options: --user root
     steps:
       - run: echo "Starting job triggered by a ${{ github.event_name }} event on a ${{ runner.os }} server hosted by GitHub."

--- a/.github/workflows/publish_all_arm64.yml
+++ b/.github/workflows/publish_all_arm64.yml
@@ -4,7 +4,10 @@ on:
     types: [published]
   workflow_dispatch:
 jobs:
+  refs:
+    uses: ./.github/workflows/_refs.yml
   compile_job:
+    needs: refs
     name: publish_all (arm64)
     runs-on: ubuntu-latest
     steps:
@@ -22,7 +25,7 @@ jobs:
           docker run --rm --platform linux/arm64 \
             -v ${{ github.workspace }}:/workspace \
             -w /workspace \
-            ghcr.io/lasp/adamant:0.2 \
+            ${{ needs.refs.outputs.image }} \
             bash env/github_run.sh "redo publish"
 
       - run: echo "Finished with status - ${{ job.status }}."

--- a/.github/workflows/style_all.yml
+++ b/.github/workflows/style_all.yml
@@ -8,11 +8,14 @@ on:
       - main
   workflow_dispatch:
 jobs:
+  refs:
+    uses: ./.github/workflows/_refs.yml
   compile_job:
+    needs: refs
     name: style_all
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/lasp/adamant:0.2
+      image: ${{ needs.refs.outputs.image }}
       options: --user root
     steps:
       - run: echo "Starting job triggered by a ${{ github.event_name }} event on a ${{ runner.os }} server hosted by GitHub."

--- a/.github/workflows/style_all_arm64.yml
+++ b/.github/workflows/style_all_arm64.yml
@@ -4,7 +4,10 @@ on:
     types: [published]
   workflow_dispatch:
 jobs:
+  refs:
+    uses: ./.github/workflows/_refs.yml
   compile_job:
+    needs: refs
     name: style_all (arm64)
     runs-on: ubuntu-latest
     steps:
@@ -22,7 +25,7 @@ jobs:
           docker run --rm --platform linux/arm64 \
             -v ${{ github.workspace }}:/workspace \
             -w /workspace \
-            ghcr.io/lasp/adamant:0.2 \
+            ${{ needs.refs.outputs.image }} \
             bash env/github_run.sh "redo src/components/command_router/style_all"
 
       - name: Archive logs for failed style checks

--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -8,11 +8,14 @@ on:
       - main
   workflow_dispatch:
 jobs:
+  refs:
+    uses: ./.github/workflows/_refs.yml
   compile_job:
+    needs: refs
     name: test_all
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/lasp/adamant:0.2
+      image: ${{ needs.refs.outputs.image }}
       options: --user root
     steps:
       - run: echo "Starting job triggered by a ${{ github.event_name }} event on a ${{ runner.os }} server hosted by GitHub."

--- a/.github/workflows/test_all_arm64.yml
+++ b/.github/workflows/test_all_arm64.yml
@@ -4,7 +4,10 @@ on:
     types: [published]
   workflow_dispatch:
 jobs:
+  refs:
+    uses: ./.github/workflows/_refs.yml
   compile_job:
+    needs: refs
     name: test_all (arm64)
     runs-on: ubuntu-latest
     steps:
@@ -22,7 +25,7 @@ jobs:
           docker run --rm --platform linux/arm64 \
             -v ${{ github.workspace }}:/workspace \
             -w /workspace \
-            ghcr.io/lasp/adamant:0.2 \
+            ${{ needs.refs.outputs.image }} \
             bash env/github_run.sh "redo src/components/command_router/coverage_all"
 
       - name: Archive logs for failed unit tests


### PR DESCRIPTION
## Summary

Collects the CI dependency values duplicated across workflows into a single reusable workflow, `.github/workflows/_refs.yml`, consumed by every other workflow via `workflow_call` outputs. Today the only shared value is the toolchain container image tag (`ghcr.io/lasp/adamant:0.2`), which was repeated in all ten workflow files; a bump now edits exactly one line. Future cross-repo refs (for example a pinned sibling ref for one-off integration testing) land in the same file, where a temporary pin is an obvious one-line diff instead of hiding in a workflow env block.

The outputs are literal strings on the job rather than values written to `$GITHUB_OUTPUT` by a step: a `workflow_call` output must reference a job output, and routing an empty value through `$GITHUB_OUTPUT` has been observed to go stale across job re-runs.