### PR TITLE
Renode cross unit testing: restore tester to elaborated state between tests

### DIFF
--- a/gen/templates/tests/name-implementation.adb
+++ b/gen/templates/tests/name-implementation.adb
@@ -4,10 +4,20 @@
 
 with AUnit.Assertions; use AUnit.Assertions;
 {% if component and component.generic %}
-with Safe_Deallocator;
+with Tester_Allocator;
 {% endif %}
 
 package body {{ name }}.Implementation is
+{% if component and component.generic %}
+
+   -- Target-aware tester allocator: heap on Linux, a static instance on
+   -- bareboard, where Free also restores the Tester's fresh state.
+   -- Generic components must instantiate this themselves; the generated
+   -- unit test base cannot (it does not know the concrete types).
+   package Tester_Alloc is new Tester_Allocator
+     (Tester_Inst   => Component_Tester_Package.Instance,
+      Tester_Access => Component_Tester_Package.Instance_Access);
+{% endif %}
 
    -------------------------------------------------------------------------
    -- Fixtures:
@@ -17,8 +27,8 @@ package body {{ name }}.Implementation is
    begin
 {% if component %}
 {% if component.generic %}
-      -- Dynamically allocate the generic component tester:
-      Self.Tester := new Component_Tester_Package.Instance;
+      -- Acquire a Tester from the target-aware allocator:
+      Self.Tester := Tester_Alloc.Allocate;
 
       -- Set the logger in the component
       Self.Tester.Set_Logger (Self.Logger'Unchecked_Access);
@@ -48,13 +58,6 @@ package body {{ name }}.Implementation is
    end Set_Up_Test;
 
    overriding procedure Tear_Down_Test (Self : in out Instance) is
-{% if component and component.generic %}
-      -- Free the tester component:
-      procedure Free_Tester is new Safe_Deallocator.Deallocate_If_Testing (
-         Object => Component_Tester_Package.Instance,
-         Name => Component_Tester_Package.Instance_Access
-      );
-{% endif %}
    begin
       -- TODO Insert custom cleanup code here.
       null;
@@ -65,8 +68,8 @@ package body {{ name }}.Implementation is
 {% endif %}
 {% if component.generic %}
 
-      -- Delete tester:
-      Free_Tester (Self.Tester);
+      -- Release the tester (restores its fresh state on bareboard):
+      Tester_Alloc.Free (Self.Tester);
 {% endif %}
 {% endif %}
    end Tear_Down_Test;

--- a/gen/templates/tests/name.adb
+++ b/gen/templates/tests/name.adb
@@ -15,8 +15,8 @@ with Tester_Allocator;
 package body {{ name }} is
 {% if component and not component.generic %}
 
-   -- Instantiate tester allocator, uses heap for Linux but not for
-   -- bareboard runtimes.
+   -- Target-aware tester allocator: heap on Linux, a static instance on
+   -- bareboard, where Free also restores the Tester's fresh state.
    package Tester_Alloc is new Tester_Allocator
      (Tester_Inst   => Component.{{ component.name }}.Implementation.Tester.Instance,
       Tester_Access => Component.{{ component.name }}.Implementation.Tester.Instance_Access);
@@ -69,8 +69,8 @@ package body {{ name }} is
       -- Log that we are starting to setup
       Self.Log ("    Starting Set_Up for test " & Test_String);
 {% if component and not component.generic %}
-      -- Acquire a Tester via the target-aware allocator (heap on Linux,
-      -- static on bareboard) and wire its logger to ours.
+      -- Acquire a Tester from the target-aware allocator and wire its
+      -- logger to ours:
       Self.Tester := Tester_Alloc.Allocate;
       -- Link the log access type to the logger in the reciprocal
       Self.Tester.Set_Logger (Self.Logger'Unchecked_Access);
@@ -93,7 +93,7 @@ package body {{ name }} is
       -- Increment counter for the next test name in the list and pass the log to close back up to the tear down (or component unit test)
       Self.Test_Name_Index := @ + 1;
 {% if component and not component.generic %}
-      -- Release the tester (heap free on Linux, no-op on bareboard).
+      -- Release the tester (restores its fresh state on bareboard):
       Tester_Alloc.Free (Self.Tester);
 {% endif %}
    end Tear_Down;

--- a/src/components/limiter/test/limiter_tests-implementation.adb
+++ b/src/components/limiter/test/limiter_tests-implementation.adb
@@ -16,9 +16,17 @@ with Invalid_Parameter_Info.Assertion; use Invalid_Parameter_Info.Assertion;
 with Interfaces; use Interfaces;
 with Parameter.Assertion; use Parameter.Assertion;
 with Packed_U16.Assertion; use Packed_U16.Assertion;
-with Safe_Deallocator;
+with Tester_Allocator;
 
 package body Limiter_Tests.Implementation is
+
+   -- Target-aware tester allocator: heap on Linux, a static instance on
+   -- bareboard, where Free also restores the Tester's fresh state.
+   -- Generic components must instantiate this themselves; the generated
+   -- unit test base cannot (it does not know the concrete types).
+   package Tester_Alloc is new Tester_Allocator
+     (Tester_Inst   => Component_Tester_Package.Instance,
+      Tester_Access => Component_Tester_Package.Instance_Access);
 
    -------------------------------------------------------------------------
    -- Fixtures:
@@ -26,8 +34,8 @@ package body Limiter_Tests.Implementation is
 
    overriding procedure Set_Up_Test (Self : in out Instance) is
    begin
-      -- Dynamically allocate the generic component tester:
-      Self.Tester := new Component_Tester_Package.Instance;
+      -- Acquire a Tester from the target-aware allocator:
+      Self.Tester := Tester_Alloc.Allocate;
 
       -- Set the logger in the component
       Self.Tester.Set_Logger (Self.Logger'Unchecked_Access);
@@ -46,12 +54,12 @@ package body Limiter_Tests.Implementation is
    end Set_Up_Test;
 
    overriding procedure Tear_Down_Test (Self : in out Instance) is
-      -- Free the tester component:
-      procedure Free_If_Testing is new Safe_Deallocator.Deallocate_If_Testing (Object => Component_Tester_Package.Instance, Name => Component_Tester_Package.Instance_Access);
    begin
       -- Free component heap:
       Self.Tester.Final_Base;
-      Free_If_Testing (Self.Tester);
+
+      -- Release the tester (restores its fresh state on bareboard):
+      Tester_Alloc.Free (Self.Tester);
    end Tear_Down_Test;
 
    -------------------------------------------------------------------------

--- a/src/components/limiter/test_variable/variable_tests-implementation.adb
+++ b/src/components/limiter/test_variable/variable_tests-implementation.adb
@@ -5,9 +5,17 @@
 with Basic_Assertions; use Basic_Assertions;
 with Simple_Variable.Assertion; use Simple_Variable.Assertion;
 with Tick;
-with Safe_Deallocator;
+with Tester_Allocator;
 
 package body Variable_Tests.Implementation is
+
+   -- Target-aware tester allocator: heap on Linux, a static instance on
+   -- bareboard, where Free also restores the Tester's fresh state.
+   -- Generic components must instantiate this themselves; the generated
+   -- unit test base cannot (it does not know the concrete types).
+   package Tester_Alloc is new Tester_Allocator
+     (Tester_Inst   => Component_Tester_Package.Instance,
+      Tester_Access => Component_Tester_Package.Instance_Access);
 
    -------------------------------------------------------------------------
    -- Fixtures:
@@ -15,8 +23,8 @@ package body Variable_Tests.Implementation is
 
    overriding procedure Set_Up_Test (Self : in out Instance) is
    begin
-      -- Dynamically allocate the generic component tester:
-      Self.Tester := new Component_Tester_Package.Instance;
+      -- Acquire a Tester from the target-aware allocator:
+      Self.Tester := Tester_Alloc.Allocate;
 
       -- Set the logger in the component
       Self.Tester.Set_Logger (Self.Logger'Unchecked_Access);
@@ -35,14 +43,12 @@ package body Variable_Tests.Implementation is
    end Set_Up_Test;
 
    overriding procedure Tear_Down_Test (Self : in out Instance) is
-      -- Free the tester component:
-      procedure Free_If_Testing is new Safe_Deallocator.Deallocate_If_Testing (Object => Component_Tester_Package.Instance, Name => Component_Tester_Package.Instance_Access);
    begin
       -- Free component heap:
       Self.Tester.Final_Base;
 
-      -- Delete tester:
-      Free_If_Testing (Self.Tester);
+      -- Release the tester (restores its fresh state on bareboard):
+      Tester_Alloc.Free (Self.Tester);
    end Tear_Down_Test;
 
    -------------------------------------------------------------------------

--- a/src/unit_test/tester_allocator/Linux/state_snapshot.adb
+++ b/src/unit_test/tester_allocator/Linux/state_snapshot.adb
@@ -1,0 +1,17 @@
+-- Host body: no-ops. Each scenario gets a fresh heap Tester, so
+-- there is nothing to restore (see the spec).
+package body State_Snapshot is
+
+   procedure Save (Object : in Object_Type) is
+      pragma Unreferenced (Object);
+   begin
+      null;
+   end Save;
+
+   procedure Restore (Object : in out Object_Type) is
+      pragma Unreferenced (Object);
+   begin
+      null;
+   end Restore;
+
+end State_Snapshot;

--- a/src/unit_test/tester_allocator/Linux/tester_allocator.adb
+++ b/src/unit_test/tester_allocator/Linux/tester_allocator.adb
@@ -1,4 +1,5 @@
 with Safe_Deallocator;
+with State_Snapshot;
 
 package body Tester_Allocator is
 
@@ -12,14 +13,20 @@ package body Tester_Allocator is
      (Object => Tester_Inst,
       Name   => Tester_Access);
 
+   -- Fixture state snapshot (no-op body on this target; see the spec):
+   package Snap is new State_Snapshot (Object_Type => Tester_Inst);
+
    function Allocate return Tester_Access is
+      T : constant Tester_Access := new Tester_Inst;
    begin
-      return new Tester_Inst;
+      Snap.Save (T.all);
+      return T;
    end Allocate;
 
    procedure Free (T : in out Tester_Access) is
    begin
       if T /= null then
+         Snap.Restore (T.all);
          Inner_Free (T);
       end if;
    end Free;

--- a/src/unit_test/tester_allocator/bb/state_snapshot.adb
+++ b/src/unit_test/tester_allocator/bb/state_snapshot.adb
@@ -1,0 +1,30 @@
+-- Bareboard body: save the object's bytes into a static buffer once,
+-- and copy them back on Restore. See the spec for why this is sound.
+with Basic_Types;
+
+package body State_Snapshot is
+
+   -- Static snapshot storage, sized to the object:
+   Size_In_Bytes : constant Natural := Object_Type'Object_Size / Basic_Types.Byte'Object_Size;
+   Snapshot : Basic_Types.Byte_Array (0 .. Size_In_Bytes - 1);
+   Saved : Boolean := False;
+
+   procedure Save (Object : in Object_Type) is
+      Object_Bytes : Basic_Types.Byte_Array (Snapshot'Range)
+         with Import, Convention => Ada, Address => Object'Address;
+   begin
+      if not Saved then
+         Snapshot := Object_Bytes;
+         Saved := True;
+      end if;
+   end Save;
+
+   procedure Restore (Object : in out Object_Type) is
+      Object_Bytes : Basic_Types.Byte_Array (Snapshot'Range)
+         with Import, Convention => Ada, Address => Object'Address;
+   begin
+      pragma Assert (Saved, "State_Snapshot.Restore called before Save.");
+      Object_Bytes := Snapshot;
+   end Restore;
+
+end State_Snapshot;

--- a/src/unit_test/tester_allocator/bb/tester_allocator.adb
+++ b/src/unit_test/tester_allocator/bb/tester_allocator.adb
@@ -1,3 +1,5 @@
+with State_Snapshot;
+
 package body Tester_Allocator is
 
    -- Single shared static storage. AUnit serializes test execution,
@@ -15,15 +17,20 @@ package body Tester_Allocator is
    -- error you get from `Tester_Access (Storage'Unchecked_Access)`.
    Storage_Ref : constant Tester_Access := Storage'Unchecked_Access;
 
+   -- Fixture state snapshot: Allocate saves, Free restores (see spec).
+   package Snap is new State_Snapshot (Object_Type => Tester_Inst);
+
    function Allocate return Tester_Access is
    begin
+      Snap.Save (Storage);
       return Storage_Ref;
    end Allocate;
 
    procedure Free (T : in out Tester_Access) is
    begin
-      -- Static storage -- nothing to free. Null the user's handle
-      -- so dangling-reference behavior matches the host body.
+      -- Restore the Tester's freshly-elaborated state for the next
+      -- scenario. Static storage, so nothing to free.
+      Snap.Restore (Storage);
       T := null;
    end Free;
 

--- a/src/unit_test/tester_allocator/state_snapshot.ads
+++ b/src/unit_test/tester_allocator/state_snapshot.ads
@@ -1,0 +1,26 @@
+-- Test-only capture and restore of an object's freshly-elaborated
+-- state, by byte image. Save stores the object's bytes the first time
+-- it is called; Restore copies them back, returning the object to its
+-- just-elaborated state.
+--
+-- Target-split bodies: no-ops on Linux, where test fixtures get a
+-- fresh heap Tester every scenario anyway. Real on bareboard, where
+-- the fixture reuses one static Tester across scenarios and state
+-- would otherwise leak between them. The image is only ever restored
+-- onto the same object it was captured from, at the same address and
+-- with no tasks queued, so identity-encoding state (access
+-- discriminants, protected object bookkeeping) restores to identical
+-- bytes. Requires a by-reference (tagged or limited) Object_Type.
+generic
+   type Object_Type is limited private;
+package State_Snapshot is
+
+   -- Capture Object's byte image. Only the first call captures; later
+   -- calls are no-ops.
+   procedure Save (Object : in Object_Type);
+
+   -- Overwrite Object with the captured image. Must not be called
+   -- before Save.
+   procedure Restore (Object : in out Object_Type);
+
+end State_Snapshot;

--- a/src/unit_test/tester_allocator/tester_allocator.ads
+++ b/src/unit_test/tester_allocator/tester_allocator.ads
@@ -16,6 +16,11 @@
 -- protected components (No_Protected_Type_Allocators) and
 -- function-local protected objects (No_Local_Protected_Objects).
 --
+-- Both bodies snapshot the Tester (see State_Snapshot): the first
+-- Allocate captures its freshly-elaborated byte image, and every Free
+-- restores it. On bareboard this resets all Tester and component
+-- state between scenarios; no hand-written reset code is needed.
+--
 -- Generic instantiation must occur at library level in the generated
 -- test scaffold so the bb body's static storage lives at library level
 -- too -- declaring it inside a subprogram would still be a "local


### PR DESCRIPTION
Enables adamant's unit test suites to run cross-compiled for RV32 bareboard targets under renode.

Bareboard cross targets cannot deallocate heap memory like Linux targets, so the tester and component state persists between tests, which breaks current test logic. This change adds a "snapshot" capability which copies the memory of a component and tester when it is pristine (before any tests have run). This clean snapshot is then applied between tests on bareboard targets to simulate a heap deallocation and free. Linux unit test behavior remains unchanged.
