### PR TITLE
Nightly documentation regeneration

### DIFF
--- a/.github/scripts/github_pr_sync.py
+++ b/.github/scripts/github_pr_sync.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Open or refresh the pull request for a regenerated-documentation branch.
+
+Usage: github_pr_sync.py <branch> <base_commit> <document>...
+
+Reads GITHUB_TOKEN and GITHUB_REPOSITORY (owner/name) from the environment.
+With an open pull request from the branch, rewrites its description. Without
+one, opens the pull request against the default branch.
+"""
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+API = os.environ.get("GITHUB_API_URL", "https://api.github.com")
+REPOSITORY = os.environ.get("GITHUB_REPOSITORY", "")
+TARGET = os.environ.get("TARGET_BRANCH", "main")
+TITLE = "Regenerate documentation"
+
+
+def request(method, path, body=None):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(API + path, data=data, method=method)
+    req.add_header("Authorization", "Bearer " + os.environ["GITHUB_TOKEN"])
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            text = resp.read().decode()
+    except urllib.error.HTTPError as e:
+        text = e.read().decode(errors="replace")
+        try:
+            return e.code, json.loads(text)
+        except ValueError:
+            return e.code, {"message": text}
+    return resp.status, (json.loads(text) if text else None)
+
+
+def fail(what, status, payload):
+    message = (payload or {}).get("message", payload)
+    sys.exit(f"{what} failed with HTTP {status}: {message}")
+
+
+def description(base, documents):
+    lines = [f"Documentation rebuilt on {TARGET} at {base}.", "",
+             "Documents whose text changed:"]
+    lines += [f"- {document}" for document in documents]
+    lines += ["", f"Each scheduled run replaces this branch with a fresh commit on the current {TARGET}. "
+              "Do not push to this branch."]
+    return "\n".join(lines)
+
+
+def open_pull_requests(branch):
+    owner = REPOSITORY.split("/")[0]
+    status, payload = request(
+        "GET", f"/repos/{REPOSITORY}/pulls?state=open&base={TARGET}&head={owner}:{branch}")
+    if status != 200:
+        fail("Listing pull requests", status, payload)
+    return payload
+
+
+def update(pr, text):
+    status, payload = request("PATCH", f"/repos/{REPOSITORY}/pulls/{pr['number']}", {"body": text})
+    if status != 200:
+        fail(f"Updating pull request #{pr['number']}", status, payload)
+    print(f"Updated the description of pull request #{pr['number']}.")
+
+
+def create(branch, text):
+    body = {"title": TITLE, "head": branch, "base": TARGET, "body": text}
+    status, payload = request("POST", f"/repos/{REPOSITORY}/pulls", body)
+    if status == 201:
+        print(f"Opened pull request #{payload['number']} {payload.get('html_url', '')}".rstrip())
+        return True
+    if status == 422:
+        return False  # opened by someone else since the listing
+    if status == 403:
+        fail("Opening the pull request (the repository must allow GitHub Actions to create pull requests)",
+             status, payload)
+    fail("Opening the pull request", status, payload)
+
+
+def main(argv):
+    if len(argv) < 3:
+        sys.exit(__doc__)
+    for name in ("GITHUB_TOKEN", "GITHUB_REPOSITORY"):
+        if not os.environ.get(name):
+            sys.exit(f"{name} is not set.")
+    branch, base, documents = argv[1], argv[2], argv[3:]
+    text = description(base, documents)
+    prs = open_pull_requests(branch)
+    if not prs:
+        if create(branch, text):
+            return
+        prs = open_pull_requests(branch)
+        if not prs:
+            sys.exit(f"Opening the pull request from {branch} reported a duplicate, but none is open.")
+    for pr in prs:
+        update(pr, text)
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/.github/scripts/regen_docs.sh
+++ b/.github/scripts/regen_docs.sh
@@ -7,6 +7,7 @@
 
 repo_dir=$(cd "$(dirname "$0")/../.." && pwd)
 branch="nightly/documentation"
+TARGET_BRANCH_NAME="main"
 
 if [ -z "${GITHUB_TOKEN:-}" ] && [ "${DRY_RUN:-0}" != "1" ]; then
   echo "GITHUB_TOKEN is not set." >&2
@@ -38,20 +39,45 @@ text() {
     -e 's#/[[:alnum:]_./-]*/adamant/#<root>/#g'
 }
 
+# The text diff of every changed document goes under build/ for the run to
+# attach, and into the job summary when GitHub provides one.
+diff_file="$repo_dir/build/doc_regen/regen.diff"
+mkdir -p "$(dirname "$diff_file")"
+: > "$diff_file"
+summary=${GITHUB_STEP_SUMMARY:-/dev/null}
+work=$(mktemp -d)
 changed=()
+details=""
 for pdf in $(git ls-files '*.pdf'); do
-  if [ "$(git show "HEAD:$pdf" | text -)" = "$(text "$pdf")" ]; then
+  git show "HEAD:$pdf" | text - > "$work/old.txt"
+  text "$pdf" > "$work/new.txt"
+  if cmp -s "$work/old.txt" "$work/new.txt"; then
     git checkout -- "$pdf"
   else
-    changed+=("$(basename "$pdf" .pdf)")
+    name=$(basename "$pdf" .pdf)
+    changed+=("$name")
+    diff -u --label "a/$pdf" --label "b/$pdf" "$work/old.txt" "$work/new.txt" > "$work/one.diff" || true
+    count=$(($(grep -c '^[-+]' "$work/one.diff") - 2))
+    echo "  $name: $count differing text lines"
+    cat "$work/one.diff" >> "$diff_file"
+    details+="<details><summary>$name ($count lines)</summary>"$'\n\n'"\`\`\`diff"$'\n'"$(head -n 120 "$work/one.diff")"$'\n'"\`\`\`"$'\n\n'"</details>"$'\n'
   fi
 done
+rm -rf "$work"
 
 if [ ${#changed[@]} -eq 0 ]; then
   echo "Documentation is current at $base."
+  echo "Documentation is current at $base." >> "$summary"
   exit 0
 fi
 echo "Regenerated: ${changed[*]}"
+{
+  echo "## Regenerated documents"
+  echo
+  echo "${#changed[@]} of $(git ls-files '*.pdf' | wc -l) tracked PDFs differ in text from the copies on $TARGET_BRANCH_NAME. The full diff is the regenerated-documentation-diff artifact of this run; each block below shows up to 120 lines."
+  echo
+  echo "$details"
+} >> "$summary"
 
 git checkout -B "$branch" "$base"
 git add -u -- '*.pdf'

--- a/.github/scripts/regen_docs.sh
+++ b/.github/scripts/regen_docs.sh
@@ -25,10 +25,22 @@ export SOURCE_DATE_EPOCH
 # and the architecture description document publish through their own rules.
 redo publish doc/user_guide/publish doc/architecture_description_document/publish
 
-# The PDF metadata differs on every build, so compare the document text.
+# The PDF metadata differs on every build, so compare the document text. The
+# user guide embeds its own build: test logs with the time of the run, generated
+# code with its generation stamp, and tool output with the build path. Those
+# fields are masked so that only document content decides.
+text() {
+  pdftotext -layout "$1" - | sed -E \
+    -e 's/^[[:space:]]*[0-9]{10}\.[0-9]+ //' \
+    -e 's/ at [0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}/ at <time>/' \
+    -e 's/(Generated from .*) on [0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}/\1 on <time>/' \
+    -e 's/(Report generation time: ).*/\1<time>/' \
+    -e 's#/[[:alnum:]_./-]*/adamant/#<root>/#g'
+}
+
 changed=()
 for pdf in $(git ls-files '*.pdf'); do
-  if [ "$(git show "HEAD:$pdf" | pdftotext -layout - -)" = "$(pdftotext -layout "$pdf" -)" ]; then
+  if [ "$(git show "HEAD:$pdf" | text -)" = "$(text "$pdf")" ]; then
     git checkout -- "$pdf"
   else
     changed+=("$(basename "$pdf" .pdf)")

--- a/.github/scripts/regen_docs.sh
+++ b/.github/scripts/regen_docs.sh
@@ -1,0 +1,58 @@
+#!/bin/bash -e
+
+# Rebuild every document, keep the PDFs whose text changed, and put them up
+# for review on a fixed branch. Runs in the Adamant environment inside a
+# checkout that can push to its origin. GITHUB_TOKEN and GITHUB_REPOSITORY
+# come from the workflow. DRY_RUN=1 stops after the local commit.
+
+repo_dir=$(cd "$(dirname "$0")/../.." && pwd)
+branch="nightly/documentation"
+
+if [ -z "${GITHUB_TOKEN:-}" ] && [ "${DRY_RUN:-0}" != "1" ]; then
+  echo "GITHUB_TOKEN is not set." >&2
+  exit 1
+fi
+
+cd "$repo_dir"
+base=$(git rev-parse HEAD)
+
+# pdfTeX stamps the build time into the PDF. Pinning it to the commit time
+# makes a rebuild of the same commit byte-identical.
+SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)
+export SOURCE_DATE_EPOCH
+
+# The publish rule reaches every doc directory below the root. The user guide
+# and the architecture description document publish through their own rules.
+redo publish doc/user_guide/publish doc/architecture_description_document/publish
+
+# The PDF metadata differs on every build, so compare the document text.
+changed=()
+for pdf in $(git ls-files '*.pdf'); do
+  if [ "$(git show "HEAD:$pdf" | pdftotext -layout - -)" = "$(pdftotext -layout "$pdf" -)" ]; then
+    git checkout -- "$pdf"
+  else
+    changed+=("$(basename "$pdf" .pdf)")
+  fi
+done
+
+if [ ${#changed[@]} -eq 0 ]; then
+  echo "Documentation is current at $base."
+  exit 0
+fi
+echo "Regenerated: ${changed[*]}"
+
+git checkout -B "$branch" "$base"
+git add -u -- '*.pdf'
+git -c user.name="github-actions[bot]" \
+    -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+  commit -q -m "Regenerate documentation"
+git log -1 --stat --format='%h %s'
+
+if [ "${DRY_RUN:-0}" = "1" ]; then
+  echo "DRY_RUN=1: not pushing $branch."
+  exit 0
+fi
+
+git push --force origin "HEAD:refs/heads/$branch"
+
+python3 "$repo_dir/.github/scripts/github_pr_sync.py" "$branch" "$base" "${changed[@]}"

--- a/.github/workflows/regen_docs.yml
+++ b/.github/workflows/regen_docs.yml
@@ -30,5 +30,11 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           DRY_RUN: ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run == true) && '1' || '0' }}
         run: bash env/github_run.sh ".github/scripts/regen_docs.sh"
+      - name: Attach the text diff of the regenerated documents
+        if: ${{ hashFiles('build/doc_regen/regen.diff') != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: regenerated-documentation-diff
+          path: build/doc_regen/regen.diff
       - run: echo "Finished with status - ${{ job.status }}."
         if: always()

--- a/.github/workflows/regen_docs.yml
+++ b/.github/workflows/regen_docs.yml
@@ -1,0 +1,34 @@
+name: Regenerate Documentation
+on:
+  schedule:
+    - cron: "0 7 1 1,4,7,10 *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Stop after the local commit and push nothing"
+        type: boolean
+        default: true
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  regenerate_job:
+    name: regenerate_docs
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/lasp/adamant:0.2
+      options: --user root
+    steps:
+      - run: echo "Starting job triggered by a ${{ github.event_name }} event on a ${{ runner.os }} server hosted by GitHub."
+      - run: echo "Checking out ${{ github.repository }} on branch ${{ github.ref }}."
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Trust the checkout owned by the runner user
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Regenerate documentation
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          DRY_RUN: ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run == true) && '1' || '0' }}
+        run: bash env/github_run.sh ".github/scripts/regen_docs.sh"
+      - run: echo "Finished with status - ${{ job.status }}."
+        if: always()

--- a/doc/architecture_description_document/publish.do
+++ b/doc/architecture_description_document/publish.do
@@ -1,0 +1,2 @@
+redo-ifchange build/pdf/architecture_description_document.pdf
+cp -f build/pdf/architecture_description_document.pdf architecture_description_document.pdf


### PR DESCRIPTION
This PR adds a quarterly CI action which regenerates all PDF documentation, extracts text content, and compares against the tracked PDF (excluding generation timestamps). If any differences are found, the regenerated PDF(s) are committed to a new PR authored by github-actions. If left open, the PR will be updated in-place by any consecutive workflow runs.

Opening the pull request with the workflow token requires the repository setting that allows GitHub Actions to create pull requests.